### PR TITLE
Fix app layout on desktop and add Toronto clock

### DIFF
--- a/src/apps/DaySwitcherApp/DaySwitcherApp.css
+++ b/src/apps/DaySwitcherApp/DaySwitcherApp.css
@@ -6,7 +6,7 @@
   padding: 40px;
 }
 
-.app-container {
+.day-switcher-card {
   background: rgba(255, 255, 255, 0.95);
   border-radius: 20px;
   padding: 50px 60px;
@@ -16,6 +16,7 @@
   width: 100%;
   backdrop-filter: blur(10px);
   min-width: 600px;
+  margin: 0 auto;
 }
 
 .day-display {
@@ -130,7 +131,7 @@
 
 /* Desktop-first responsive design */
 @media (max-width: 900px) {
-  .app-container {
+  .day-switcher-card {
     min-width: 500px;
     padding: 40px 50px;
   }
@@ -145,7 +146,7 @@
     padding: 20px;
   }
   
-  .app-container {
+  .day-switcher-card {
     min-width: 0;
     max-width: 90vw;
     padding: 30px 25px;

--- a/src/apps/DaySwitcherApp/DaySwitcherApp.js
+++ b/src/apps/DaySwitcherApp/DaySwitcherApp.js
@@ -28,7 +28,7 @@ const DaySwitcherApp = ({ onBack }) => {
 
   return (
     <div className="day-switcher-app">
-      <div className="app-container">
+      <div className="day-switcher-card">
         <div className="day-display">
           <h2 className="current-day">{daysOfWeek[currentDayIndex]}</h2>
           <p className="day-number">Day {currentDayIndex + 1} of 7</p>

--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -16,11 +16,20 @@
   backdrop-filter: blur(10px);
 }
 
+.launcher-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: var(--spacing-medium);
+  flex-wrap: wrap;
+}
+
 .launcher-title {
   display: flex;
   align-items: center;
   gap: 15px;
-  margin-bottom: var(--spacing-medium);
+  margin: 0;
   font-size: var(--font-size-large);
   font-weight: 700;
   color: #333;
@@ -34,6 +43,36 @@
   font-size: 1.2rem;
   color: #666;
   font-weight: 400;
+}
+
+.toronto-clock {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 14px 24px;
+  border-radius: 16px;
+  border: 2px solid #00ff9f;
+  background: rgba(0, 255, 159, 0.12);
+  box-shadow: 0 0 20px rgba(0, 255, 159, 0.35);
+  min-width: 170px;
+}
+
+.clock-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(0, 255, 159, 0.85);
+  margin-bottom: 6px;
+}
+
+.clock-time {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  color: #39ff14;
+  text-shadow: 0 0 12px rgba(57, 255, 20, 0.9), 0 0 24px rgba(57, 255, 20, 0.6);
+  font-family: 'Orbitron', 'Courier New', monospace;
 }
 
 .launcher-controls {
@@ -299,11 +338,21 @@
   .launcher-header {
     padding: 20px;
   }
-  
+
   .launcher-title {
     font-size: 2rem;
   }
-  
+
+  .launcher-header-top {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .toronto-clock {
+    align-items: center;
+  }
+
   .launcher-controls {
     flex-direction: column;
     align-items: stretch;

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -6,6 +6,25 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState('grid'); // 'grid' or 'list'
+  const [torontoTime, setTorontoTime] = useState('--:--:--');
+
+  useEffect(() => {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Toronto',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+
+    const updateTime = () => {
+      setTorontoTime(formatter.format(new Date()));
+    };
+
+    updateTime();
+    const intervalId = setInterval(updateTime, 1000);
+    return () => clearInterval(intervalId);
+  }, []);
 
   const categories = ['All', ...Object.keys(APP_CATEGORIES)];
   
@@ -50,12 +69,19 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
   return (
     <div className="app-launcher">
       <header className="launcher-header">
-        <h1 className="launcher-title">
-          <span className="title-icon">📱</span>
-          App Container
-          <span className="app-count">({getAllApps().length} apps)</span>
-        </h1>
-        
+        <div className="launcher-header-top">
+          <h1 className="launcher-title">
+            <span className="title-icon">📱</span>
+            App Container
+            <span className="app-count">({getAllApps().length} apps)</span>
+          </h1>
+
+          <div className="toronto-clock" aria-label="Current time in Toronto">
+            <span className="clock-label">Toronto</span>
+            <span className="clock-time">{torontoTime}</span>
+          </div>
+        </div>
+
         <div className="launcher-controls">
           <div className="search-container">
             <input


### PR DESCRIPTION
## Summary
- prevent the DaySwitcher styles from leaking to the shared app container so desktop layouts stay centered
- update the DaySwitcher markup and styles to use the new class name
- add a neon Toronto time clock to the launcher header for quick reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca429603b8832ba002a5f44c54ada5