### PR TITLE
Add neon Pong sub-app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/preset-env": "^7.22.0",
         "@babel/preset-react": "^7.22.0",
         "babel-loader": "^9.1.0",
+        "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.8.0",
         "gh-pages": "^6.0.0",
         "html-webpack-plugin": "^5.5.0",
@@ -2886,6 +2887,43 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.1.tgz",
+      "integrity": "sha512-J+YV3WfhY6W/Xf9h+J1znYuqTye2xkBUIGyTPWuBAT27qajBa5mR4f8WBmfDY3YjRftT2kqZZiLi1qf0H+UOFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-parent": "^6.0.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2",
+        "tinyglobby": "^0.2.12"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.45.1",
@@ -6567,6 +6605,54 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "^7.22.0",
     "@babel/preset-react": "^7.22.0",
     "babel-loader": "^9.1.0",
+    "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^6.8.0",
     "gh-pages": "^6.0.0",
     "html-webpack-plugin": "^5.5.0",
@@ -26,7 +27,11 @@
     "webpack-cli": "^5.1.0",
     "webpack-dev-server": "^4.15.0"
   },
-  "keywords": ["react", "day-of-week", "github-pages"],
+  "keywords": [
+    "react",
+    "day-of-week",
+    "github-pages"
+  ],
   "author": "Your Name",
   "license": "MIT"
 }

--- a/public/css/pong.css
+++ b/public/css/pong.css
@@ -1,0 +1,280 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700&display=swap');
+
+:root {
+  --bg-color: #020111;
+  --neon-cyan: #00eaff;
+  --neon-magenta: #ff00ff;
+  --neon-yellow: #fcee09;
+  --neon-green: #39ff14;
+  --text-color: #e0e0ff;
+  --card-bg: rgba(10, 10, 25, 0.75);
+  --border-glow: rgba(0, 234, 255, 0.35);
+  font-family: 'Orbitron', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 24px;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(0, 234, 255, 0.2), transparent 55%),
+              radial-gradient(circle at bottom, rgba(255, 0, 255, 0.2), transparent 50%),
+              var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+}
+
+.pong-app {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.info-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--card-bg);
+  border: 1px solid var(--border-glow);
+  border-radius: 16px;
+  padding: 12px 18px;
+  box-shadow: 0 0 25px rgba(0, 234, 255, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.mode-indicator {
+  font-size: 1.1rem;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.ghost-btn,
+.primary-btn {
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-weight: 600;
+}
+
+.ghost-btn {
+  background: transparent;
+  border: 1px solid var(--neon-cyan);
+  color: var(--neon-cyan);
+  box-shadow: 0 0 12px rgba(0, 234, 255, 0.25);
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, var(--neon-magenta), var(--neon-cyan));
+  border: none;
+  color: #0b0623;
+  box-shadow: 0 0 25px rgba(255, 0, 255, 0.45), 0 0 35px rgba(0, 234, 255, 0.35);
+}
+
+.ghost-btn:hover,
+.primary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 30px rgba(0, 234, 255, 0.5);
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.score-box {
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+  text-align: center;
+  box-shadow: 0 0 20px rgba(255, 0, 255, 0.25);
+}
+
+.score-label {
+  display: block;
+  font-size: 0.95rem;
+  color: rgba(224, 224, 255, 0.7);
+  margin-bottom: 8px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.score-value {
+  font-size: 2.6rem;
+  font-weight: 700;
+  color: var(--neon-yellow);
+  text-shadow: 0 0 20px rgba(252, 238, 9, 0.8), 0 0 35px rgba(252, 238, 9, 0.6);
+}
+
+.canvas-wrapper {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 234, 255, 0.3);
+  box-shadow: 0 0 45px rgba(0, 234, 255, 0.35), inset 0 0 35px rgba(255, 0, 255, 0.2);
+}
+
+#pongCanvas {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: radial-gradient(circle at center, rgba(0, 234, 255, 0.07), transparent 60%),
+              rgba(2, 1, 17, 0.92);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(6px);
+  background: rgba(2, 1, 17, 0.75);
+  transition: opacity 0.3s ease;
+}
+
+.overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.overlay-content {
+  text-align: center;
+  padding: 32px 36px;
+  border-radius: 24px;
+  background: rgba(8, 4, 32, 0.9);
+  border: 1px solid rgba(255, 0, 255, 0.4);
+  box-shadow: 0 0 45px rgba(255, 0, 255, 0.55), 0 0 65px rgba(0, 234, 255, 0.45);
+}
+
+.overlay-content h2 {
+  margin: 0 0 12px;
+  font-size: 2rem;
+  color: var(--neon-green);
+  text-shadow: 0 0 25px rgba(57, 255, 20, 0.8);
+}
+
+.overlay-content p {
+  margin: 0 0 20px;
+  font-size: 1rem;
+  color: rgba(224, 224, 255, 0.8);
+}
+
+.instructions,
+.history-panel {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 20px 24px;
+  border: 1px solid rgba(0, 234, 255, 0.18);
+  box-shadow: 0 0 25px rgba(0, 234, 255, 0.2);
+}
+
+.instructions h3,
+.history-panel h3 {
+  margin-top: 0;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--neon-cyan);
+  text-shadow: 0 0 20px rgba(0, 234, 255, 0.7);
+}
+
+.instructions ul {
+  padding-left: 18px;
+  margin: 0 0 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.instructions li {
+  list-style: none;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  background: rgba(0, 234, 255, 0.08);
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 234, 255, 0.12);
+}
+
+.instructions li span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  padding: 4px 8px;
+  background: linear-gradient(135deg, rgba(0, 234, 255, 0.4), rgba(255, 0, 255, 0.4));
+  border-radius: 999px;
+  font-weight: 700;
+  color: #07031a;
+}
+
+.tip {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(224, 224, 255, 0.75);
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.history-list li {
+  background: rgba(255, 0, 255, 0.08);
+  border: 1px solid rgba(255, 0, 255, 0.2);
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.history-list li.empty {
+  justify-content: center;
+  color: rgba(224, 224, 255, 0.6);
+  font-style: italic;
+}
+
+.history-list li span {
+  color: rgba(224, 224, 255, 0.85);
+}
+
+.history-list li strong {
+  color: var(--neon-magenta);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 16px;
+  }
+
+  .pong-app {
+    gap: 18px;
+  }
+
+  .scoreboard {
+    grid-template-columns: 1fr;
+  }
+
+  .instructions ul {
+    gap: 6px;
+  }
+
+  .instructions li {
+    font-size: 0.9rem;
+  }
+}

--- a/public/html/pong.html
+++ b/public/html/pong.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Pong</title>
+  <link rel="stylesheet" href="../css/pong.css" />
+</head>
+<body>
+  <div class="pong-app">
+    <div class="info-bar">
+      <div class="mode-indicator">Mode: <span id="modeLabel">1 Player</span></div>
+      <button id="resetHistoryBtn" class="ghost-btn" type="button">Reset History</button>
+    </div>
+
+    <div class="scoreboard">
+      <div class="score-box">
+        <span class="score-label">Player 1</span>
+        <span id="scoreLeft" class="score-value">0</span>
+      </div>
+      <div class="score-box">
+        <span id="rightLabel" class="score-label">Computer</span>
+        <span id="scoreRight" class="score-value">0</span>
+      </div>
+    </div>
+
+    <div class="canvas-wrapper">
+      <canvas id="pongCanvas" width="900" height="540"></canvas>
+      <div id="overlay" class="overlay hidden">
+        <div class="overlay-content">
+          <h2 id="overlayTitle">Player 1 Wins!</h2>
+          <p id="overlaySubtitle">First to 3 points wins the match.</p>
+          <button id="playAgainBtn" class="primary-btn" type="button">Play Again</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="instructions">
+      <h3>Controls</h3>
+      <ul>
+        <li><span>W / S</span> — Move Player 1 paddle up / down</li>
+        <li><span>O / L</span> — Move Player 2 paddle (two-player mode only)</li>
+        <li><span>1</span> — Switch to 1-player mode</li>
+        <li><span>2</span> — Switch to 2-player mode</li>
+        <li><span>P</span> — Toggle between 1-player and 2-player modes</li>
+      </ul>
+      <p class="tip">First to 3 points wins. Scores persist during the session — reset history anytime.</p>
+    </div>
+
+    <div class="history-panel">
+      <h3>Session History</h3>
+      <ul id="historyList" class="history-list"></ul>
+    </div>
+  </div>
+
+  <script type="module" src="../js/pong.js"></script>
+</body>
+</html>

--- a/public/js/pong.js
+++ b/public/js/pong.js
@@ -1,0 +1,459 @@
+const COOKIE_NAME = 'neonPongHistory';
+const WINNING_SCORE = 3;
+const BASE_BALL_SPEED = 6.2;
+const BALL_ACCELERATION = 0.45;
+const MAX_BALL_SPEED = 11;
+
+const canvas = document.getElementById('pongCanvas');
+const ctx = canvas.getContext('2d');
+
+const modeLabelEl = document.getElementById('modeLabel');
+const scoreLeftEl = document.getElementById('scoreLeft');
+const scoreRightEl = document.getElementById('scoreRight');
+const rightLabelEl = document.getElementById('rightLabel');
+const overlayEl = document.getElementById('overlay');
+const overlayTitleEl = document.getElementById('overlayTitle');
+const overlaySubtitleEl = document.getElementById('overlaySubtitle');
+const playAgainBtn = document.getElementById('playAgainBtn');
+const resetHistoryBtn = document.getElementById('resetHistoryBtn');
+const historyListEl = document.getElementById('historyList');
+
+const state = {
+  mode: '1p',
+  leftScore: 0,
+  rightScore: 0,
+  isPaused: false,
+  matchOver: false,
+};
+
+const paddles = {
+  left: {
+    x: 36,
+    y: canvas.height / 2 - 70,
+    width: 14,
+    height: 140,
+    speed: 8,
+  },
+  right: {
+    x: canvas.width - 50,
+    y: canvas.height / 2 - 70,
+    width: 14,
+    height: 140,
+    speed: 8,
+    aiSpeed: 6.5,
+  },
+};
+
+const ball = {
+  x: canvas.width / 2,
+  y: canvas.height / 2,
+  radius: 10,
+  vx: 0,
+  vy: 0,
+  speed: BASE_BALL_SPEED,
+};
+
+const keys = new Set();
+let lastTime = null;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function setCookie(name, value, days = 30) {
+  const expires = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString();
+  document.cookie = `${name}=${value}; expires=${expires}; path=/`;
+}
+
+function getCookie(name) {
+  const nameEq = `${name}=`;
+  return document.cookie
+    .split(';')
+    .map(entry => entry.trim())
+    .find(entry => entry.startsWith(nameEq))
+    ?.substring(nameEq.length) || null;
+}
+
+function deleteCookie(name) {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}
+
+function loadHistory() {
+  const raw = getCookie(COOKIE_NAME);
+  if (!raw) {
+    return [];
+  }
+  try {
+    return JSON.parse(decodeURIComponent(raw));
+  } catch (error) {
+    console.warn('Unable to parse pong history cookie, resetting.', error);
+    deleteCookie(COOKIE_NAME);
+    return [];
+  }
+}
+
+function saveHistory(history) {
+  const serialised = encodeURIComponent(JSON.stringify(history));
+  setCookie(COOKIE_NAME, serialised);
+}
+
+function formatModeLabel(mode) {
+  return mode === '1p' ? '1 Player' : '2 Players';
+}
+
+function updateModeLabel() {
+  modeLabelEl.textContent = formatModeLabel(state.mode);
+  rightLabelEl.textContent = state.mode === '1p' ? 'Computer' : 'Player 2';
+}
+
+function updateScoreboard() {
+  scoreLeftEl.textContent = state.leftScore.toString();
+  scoreRightEl.textContent = state.rightScore.toString();
+}
+
+function renderHistory(history) {
+  historyListEl.innerHTML = '';
+
+  if (!history.length) {
+    const emptyItem = document.createElement('li');
+    emptyItem.classList.add('empty');
+    emptyItem.textContent = 'Play a match to start building your neon pong legacy.';
+    historyListEl.appendChild(emptyItem);
+    return;
+  }
+
+  history.forEach(entry => {
+    const item = document.createElement('li');
+
+    const resultSpan = document.createElement('span');
+    const winnerStrong = document.createElement('strong');
+    winnerStrong.textContent = entry.winner;
+    resultSpan.appendChild(winnerStrong);
+    resultSpan.appendChild(document.createTextNode(` defeated ${entry.loser}`));
+
+    const detailsSpan = document.createElement('span');
+    detailsSpan.textContent = `${entry.score} • ${entry.modeLabel}`;
+
+    const timeSpan = document.createElement('span');
+    const timestamp = new Date(entry.timestamp);
+    timeSpan.textContent = timestamp.toLocaleString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      month: 'short',
+      day: 'numeric',
+    });
+
+    item.append(resultSpan, detailsSpan, timeSpan);
+    historyListEl.appendChild(item);
+  });
+}
+
+function addHistoryEntry(entry) {
+  const history = loadHistory();
+  history.unshift(entry);
+  if (history.length > 20) {
+    history.length = 20;
+  }
+  saveHistory(history);
+  renderHistory(history);
+}
+
+function resetHistory() {
+  deleteCookie(COOKIE_NAME);
+  renderHistory([]);
+}
+
+function resetPaddles() {
+  paddles.left.y = canvas.height / 2 - paddles.left.height / 2;
+  paddles.right.y = canvas.height / 2 - paddles.right.height / 2;
+}
+
+function launchBall(direction = Math.random() > 0.5 ? 1 : -1) {
+  ball.x = canvas.width / 2;
+  ball.y = canvas.height / 2;
+  ball.speed = BASE_BALL_SPEED;
+  const angle = (Math.random() * Math.PI) / 4 - Math.PI / 8; // -22.5° to 22.5°
+  ball.vx = Math.cos(angle) * ball.speed * direction;
+  ball.vy = Math.sin(angle) * ball.speed;
+}
+
+function hideOverlay() {
+  overlayEl.classList.add('hidden');
+}
+
+function showOverlay(title, subtitle) {
+  overlayTitleEl.textContent = title;
+  overlaySubtitleEl.textContent = subtitle;
+  overlayEl.classList.remove('hidden');
+}
+
+function resetMatch() {
+  state.leftScore = 0;
+  state.rightScore = 0;
+  state.isPaused = false;
+  state.matchOver = false;
+  updateScoreboard();
+  hideOverlay();
+  resetPaddles();
+  keys.clear();
+  launchBall();
+}
+
+function handlePoint(scoringSide) {
+  if (scoringSide === 'left') {
+    state.leftScore += 1;
+  } else {
+    state.rightScore += 1;
+  }
+  updateScoreboard();
+
+  if (state.leftScore >= WINNING_SCORE || state.rightScore >= WINNING_SCORE) {
+    handleWin();
+  } else {
+    const direction = scoringSide === 'left' ? 1 : -1;
+    launchBall(direction);
+  }
+}
+
+function handleWin() {
+  state.isPaused = true;
+  state.matchOver = true;
+
+  const winnerIsLeft = state.leftScore > state.rightScore;
+  const winner = winnerIsLeft ? 'Player 1' : state.mode === '1p' ? 'Computer' : 'Player 2';
+  const loser = winnerIsLeft ? (state.mode === '1p' ? 'Computer' : 'Player 2') : 'Player 1';
+  const scoreLine = `${state.leftScore} - ${state.rightScore}`;
+  const modeLabel = state.mode === '1p' ? 'Solo Showdown' : 'Versus Duel';
+
+  showOverlay(`${winner} Wins!`, `${scoreLine} • ${modeLabel}`);
+
+  addHistoryEntry({
+    winner,
+    loser,
+    score: scoreLine,
+    modeLabel: formatModeLabel(state.mode),
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function setMode(nextMode) {
+  if (state.mode === nextMode) {
+    return;
+  }
+  state.mode = nextMode;
+  updateModeLabel();
+  resetMatch();
+}
+
+function toggleMode() {
+  setMode(state.mode === '1p' ? '2p' : '1p');
+}
+
+function update(delta) {
+  if (state.isPaused) {
+    return;
+  }
+
+  const step = Math.min(delta / 16.67, 1.6);
+
+  // Player 1 paddle
+  if (keys.has('w')) {
+    paddles.left.y -= paddles.left.speed * step;
+  }
+  if (keys.has('s')) {
+    paddles.left.y += paddles.left.speed * step;
+  }
+  paddles.left.y = clamp(paddles.left.y, 0, canvas.height - paddles.left.height);
+
+  // Player 2 or AI
+  if (state.mode === '2p') {
+    if (keys.has('o')) {
+      paddles.right.y -= paddles.right.speed * step;
+    }
+    if (keys.has('l')) {
+      paddles.right.y += paddles.right.speed * step;
+    }
+  } else {
+    const paddleCenter = paddles.right.y + paddles.right.height / 2;
+    const threshold = 16;
+    if (Math.abs(ball.y - paddleCenter) > threshold) {
+      const direction = ball.y < paddleCenter ? -1 : 1;
+      paddles.right.y += direction * paddles.right.aiSpeed * step;
+    }
+  }
+  paddles.right.y = clamp(paddles.right.y, 0, canvas.height - paddles.right.height);
+
+  // Move ball
+  ball.x += ball.vx * step;
+  ball.y += ball.vy * step;
+
+  // Wall collisions
+  if (ball.y - ball.radius <= 0 && ball.vy < 0) {
+    ball.y = ball.radius;
+    ball.vy *= -1;
+  } else if (ball.y + ball.radius >= canvas.height && ball.vy > 0) {
+    ball.y = canvas.height - ball.radius;
+    ball.vy *= -1;
+  }
+
+  // Paddle collisions
+  const leftPaddle = paddles.left;
+  if (
+    ball.x - ball.radius <= leftPaddle.x + leftPaddle.width &&
+    ball.y >= leftPaddle.y &&
+    ball.y <= leftPaddle.y + leftPaddle.height &&
+    ball.vx < 0
+  ) {
+    ball.x = leftPaddle.x + leftPaddle.width + ball.radius;
+    const relativeIntersect = (ball.y - (leftPaddle.y + leftPaddle.height / 2)) / (leftPaddle.height / 2);
+    const clampedIntersect = clamp(relativeIntersect, -1, 1);
+    ball.speed = Math.min(ball.speed + BALL_ACCELERATION, MAX_BALL_SPEED);
+    const bounceAngle = (Math.PI / 3) * clampedIntersect; // up to 60°
+    ball.vx = Math.cos(bounceAngle) * ball.speed;
+    ball.vy = Math.sin(bounceAngle) * ball.speed;
+  }
+
+  const rightPaddle = paddles.right;
+  if (
+    ball.x + ball.radius >= rightPaddle.x &&
+    ball.y >= rightPaddle.y &&
+    ball.y <= rightPaddle.y + rightPaddle.height &&
+    ball.vx > 0
+  ) {
+    ball.x = rightPaddle.x - ball.radius;
+    const relativeIntersect = (ball.y - (rightPaddle.y + rightPaddle.height / 2)) / (rightPaddle.height / 2);
+    const clampedIntersect = clamp(relativeIntersect, -1, 1);
+    ball.speed = Math.min(ball.speed + BALL_ACCELERATION, MAX_BALL_SPEED);
+    const bounceAngle = (Math.PI / 3) * clampedIntersect;
+    ball.vx = -Math.cos(bounceAngle) * ball.speed;
+    ball.vy = Math.sin(bounceAngle) * ball.speed;
+  }
+
+  // Scoring
+  if (ball.x + ball.radius < 0) {
+    handlePoint('right');
+  } else if (ball.x - ball.radius > canvas.width) {
+    handlePoint('left');
+  }
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const gradient = ctx.createRadialGradient(
+    canvas.width / 2,
+    canvas.height / 2,
+    80,
+    canvas.width / 2,
+    canvas.height / 2,
+    canvas.width
+  );
+  gradient.addColorStop(0, 'rgba(0, 234, 255, 0.12)');
+  gradient.addColorStop(1, 'rgba(5, 1, 20, 0.95)');
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Center line
+  ctx.save();
+  ctx.strokeStyle = 'rgba(0, 234, 255, 0.35)';
+  ctx.lineWidth = 4;
+  ctx.setLineDash([18, 18]);
+  ctx.beginPath();
+  ctx.moveTo(canvas.width / 2, 0);
+  ctx.lineTo(canvas.width / 2, canvas.height);
+  ctx.stroke();
+  ctx.restore();
+
+  // Paddles
+  drawPaddle(paddles.left, '#00eaff');
+  drawPaddle(paddles.right, '#ff00ff');
+
+  // Ball
+  drawBall();
+}
+
+function drawPaddle(paddle, color) {
+  ctx.save();
+  ctx.shadowColor = color;
+  ctx.shadowBlur = 25;
+  ctx.fillStyle = color;
+  ctx.fillRect(paddle.x, paddle.y, paddle.width, paddle.height);
+  ctx.restore();
+}
+
+function drawBall() {
+  ctx.save();
+  const gradient = ctx.createRadialGradient(ball.x, ball.y, 2, ball.x, ball.y, 16);
+  gradient.addColorStop(0, '#fcee09');
+  gradient.addColorStop(0.6, 'rgba(252, 238, 9, 0.5)');
+  gradient.addColorStop(1, 'rgba(252, 238, 9, 0)');
+  ctx.fillStyle = gradient;
+  ctx.shadowColor = '#fcee09';
+  ctx.shadowBlur = 25;
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function handleKeyDown(event) {
+  const key = event.key.toLowerCase();
+
+  if (['w', 's', 'o', 'l'].includes(key)) {
+    keys.add(key);
+  }
+
+  if (event.repeat) {
+    return;
+  }
+
+  if (key === '1') {
+    setMode('1p');
+  } else if (key === '2') {
+    setMode('2p');
+  } else if (key === 'p') {
+    toggleMode();
+  }
+}
+
+function handleKeyUp(event) {
+  const key = event.key.toLowerCase();
+  if (['w', 's', 'o', 'l'].includes(key)) {
+    keys.delete(key);
+  }
+}
+
+function handleBlur() {
+  keys.clear();
+}
+
+function gameLoop(timestamp) {
+  if (lastTime === null) {
+    lastTime = timestamp;
+  }
+  const delta = timestamp - lastTime;
+  lastTime = timestamp;
+
+  update(delta);
+  draw();
+
+  requestAnimationFrame(gameLoop);
+}
+
+playAgainBtn.addEventListener('click', () => {
+  resetMatch();
+});
+
+resetHistoryBtn.addEventListener('click', () => {
+  resetHistory();
+});
+
+document.addEventListener('keydown', handleKeyDown);
+document.addEventListener('keyup', handleKeyUp);
+window.addEventListener('blur', handleBlur);
+
+updateModeLabel();
+renderHistory(loadHistory());
+resetMatch();
+requestAnimationFrame(gameLoop);

--- a/src/apps/PongApp/PongApp.css
+++ b/src/apps/PongApp/PongApp.css
@@ -1,0 +1,30 @@
+.pong-app-shell {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.pong-iframe {
+  width: 100%;
+  min-height: 720px;
+  border: none;
+  border-radius: 24px;
+  box-shadow: 0 25px 60px rgba(0, 234, 255, 0.25);
+  background: #01010a;
+}
+
+.pong-note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+  max-width: 720px;
+}
+
+@media (max-width: 768px) {
+  .pong-iframe {
+    min-height: 540px;
+  }
+}

--- a/src/apps/PongApp/PongApp.js
+++ b/src/apps/PongApp/PongApp.js
@@ -1,0 +1,27 @@
+import React, { useMemo } from 'react';
+import './PongApp.css';
+
+const PongApp = () => {
+  const src = useMemo(() => {
+    const base = process.env.PUBLIC_URL || '';
+    return `${base}/html/pong.html`;
+  }, []);
+
+  return (
+    <div className="pong-app-shell">
+      <iframe
+        className="pong-iframe"
+        title="Neon Pong"
+        src={src}
+        loading="lazy"
+        allow="gamepad"
+      />
+      <p className="pong-note">
+        Tip: Use the keyboard controls listed inside the game window. Toggle between solo and versus modes with the
+        number keys.
+      </p>
+    </div>
+  );
+};
+
+export default PongApp;

--- a/src/apps/PongApp/index.js
+++ b/src/apps/PongApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './PongApp';

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -43,6 +43,20 @@ export const APP_REGISTRY = {
     created: '2024-01-01',
     featured: true
   },
+  'pong': {
+    id: 'pong',
+    title: 'Neon Pong',
+    description: 'Fast-paced neon Pong with solo and versus modes plus session history',
+    icon: '🏓',
+    category: 'Games',
+    component: null,
+    path: '/apps/pong',
+    tags: ['game', 'arcade', 'canvas', 'retro'],
+    version: '1.0.0',
+    author: 'OpenAI Assistant',
+    created: '2024-01-01',
+    featured: true
+  },
   'app-3': {
     id: 'app-3',
     title: 'Coming Soon',

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -6,6 +6,7 @@ import './AppContainer.css';
 const DaySwitcherApp = React.lazy(() => import('../apps/DaySwitcherApp'));
 const NPomodoroApp = React.lazy(() => import('../apps/NPomodoroApp'));
 const SnakeApp = React.lazy(() => import('../apps/SnakeApp'));
+const PongApp = React.lazy(() => import('../apps/PongApp'));
 
 const AppContainer = () => {
   const [currentView, setCurrentView] = useState('launcher'); // 'launcher' or 'app'
@@ -31,6 +32,8 @@ const AppContainer = () => {
         return <NPomodoroApp onBack={handleBackToLauncher} />;
       case 'snake':
         return <SnakeApp onBack={handleBackToLauncher} />;
+      case 'pong':
+        return <PongApp onBack={handleBackToLauncher} />;
       default:
         return (
           <div className="app-placeholder">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: './src/index.js',
@@ -29,6 +30,13 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './public/index.html',
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: path.resolve(__dirname, 'public/html'), to: 'html' },
+        { from: path.resolve(__dirname, 'public/css'), to: 'css' },
+        { from: path.resolve(__dirname, 'public/js'), to: 'js' },
+      ],
     }),
   ],
   devServer: {


### PR DESCRIPTION
## Summary
- add a neon-themed Pong experience with one and two-player modes, scoreboard, overlays, and keyboard toggles
- implement standalone canvas game assets with cookie-based match history and a resettable session log
- integrate the Pong app into the launcher/registry and update the build to ship the static assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4b3aceb8832bbb5c41b223667a8e