### PR TITLE
Add Krazy mode and multi-ball logic to Pong

### DIFF
--- a/src/apps/PongApp/PongApp.js
+++ b/src/apps/PongApp/PongApp.js
@@ -10,8 +10,8 @@ import {
 const CANVAS_WIDTH = DEFAULT_OPTIONS.width;
 const CANVAS_HEIGHT = DEFAULT_OPTIONS.height;
 
-function drawGame(ctx, state) {
-  const { bounds, options, ball, paddles, isPaused } = state;
+function drawGame(ctx, state, opponentName = 'Player 2') {
+  const { bounds, options, balls, paddles, isPaused, winner } = state;
   ctx.clearRect(0, 0, bounds.width, bounds.height);
 
   const background = ctx.createLinearGradient(0, 0, bounds.width, bounds.height);
@@ -44,20 +44,34 @@ function drawGame(ctx, state) {
   ctx.fillRect(paddles.right.x, paddles.right.y, options.paddleWidth, options.paddleHeight);
   ctx.restore();
 
-  ctx.save();
-  const ballGlow = ctx.createRadialGradient(ball.x, ball.y, 2, ball.x, ball.y, ball.radius * 3.2);
-  ballGlow.addColorStop(0, '#fefefe');
-  ballGlow.addColorStop(0.6, 'rgba(255, 255, 255, 0.8)');
-  ballGlow.addColorStop(1, 'rgba(255, 255, 255, 0)');
-  ctx.fillStyle = ballGlow;
-  ctx.shadowBlur = 25;
-  ctx.shadowColor = '#fefae0';
-  ctx.beginPath();
-  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.restore();
+  balls.forEach(ball => {
+    ctx.save();
+    const ballGlow = ctx.createRadialGradient(ball.x, ball.y, 2, ball.x, ball.y, ball.radius * 3.2);
+    ballGlow.addColorStop(0, '#fefefe');
+    ballGlow.addColorStop(0.6, 'rgba(255, 255, 255, 0.8)');
+    ballGlow.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.fillStyle = ballGlow;
+    ctx.shadowBlur = 25;
+    ctx.shadowColor = '#fefae0';
+    ctx.beginPath();
+    ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  });
 
-  if (isPaused) {
+  if (winner) {
+    ctx.save();
+    ctx.fillStyle = 'rgba(7, 5, 24, 0.35)';
+    ctx.fillRect(0, 0, bounds.width, bounds.height);
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '600 26px "Inter", "Helvetica Neue", sans-serif';
+    ctx.textAlign = 'center';
+    const winnerLabel = winner === 'left' ? 'Player 1' : opponentName;
+    ctx.fillText(`${winnerLabel} Wins!`, bounds.width / 2, bounds.height / 2 - 10);
+    ctx.font = '400 16px "Inter", "Helvetica Neue", sans-serif';
+    ctx.fillText('Press R to restart', bounds.width / 2, bounds.height / 2 + 18);
+    ctx.restore();
+  } else if (isPaused) {
     ctx.save();
     ctx.fillStyle = 'rgba(7, 5, 24, 0.35)';
     ctx.fillRect(0, 0, bounds.width, bounds.height);
@@ -82,37 +96,72 @@ const PongApp = () => {
   const [score, setScore] = useState({ left: 0, right: 0 });
   const [isPaused, setIsPaused] = useState(false);
   const [mode, setMode] = useState('cpu');
+  const [krazyMode, setKrazyMode] = useState(false);
+  const [targetScore, setTargetScore] = useState(DEFAULT_OPTIONS.winScore);
+  const [winner, setWinner] = useState(null);
 
-  const opponentLabel = useMemo(() => (mode === 'cpu' ? 'CPU' : 'Player 2'), [mode]);
+  const opponentLabel = useMemo(() => {
+    if (mode === 'pvp') {
+      return 'Player 2';
+    }
+    if (mode === 'cpu-slow') {
+      return 'Slow CPU';
+    }
+    return 'CPU';
+  }, [mode]);
+
+  const opponentNameRef = useRef(opponentLabel);
+  const hasAppliedSettingsRef = useRef(false);
+
+  const buildOptions = useCallback(() => {
+    const winScore = krazyMode ? DEFAULT_OPTIONS.krazyWinScore : DEFAULT_OPTIONS.winScore;
+    const aiDelay = mode === 'cpu-slow' ? 0.3 : 0;
+    return {
+      krazyMode,
+      winScore,
+      aiDelay,
+    };
+  }, [krazyMode, mode]);
 
   const initialiseState = useCallback(() => {
     const context = ctxRef.current;
     if (!context) {
       return;
     }
-    const next = createInitialState(baseOptionsRef.current || {});
+    const options = buildOptions();
+    const next = createInitialState(options);
     baseOptionsRef.current = next.options;
     stateRef.current = next;
     setScore({ ...next.scores });
     setIsPaused(next.isPaused);
-    drawGame(context, next);
-  }, []);
+    setTargetScore(next.options.winScore);
+    setWinner(next.winner);
+    drawGame(context, next, opponentNameRef.current);
+  }, [buildOptions]);
 
   const resetGame = useCallback(() => {
     inputRef.current.left = 0;
     inputRef.current.right = 0;
     inputRef.current.pausePressed = false;
+    inputRef.current.aiDelay = mode === 'cpu-slow' ? 0.3 : 0;
     initialiseState();
-  }, [initialiseState]);
+  }, [initialiseState, mode]);
 
   const togglePause = useCallback(() => {
     inputRef.current.pausePressed = true;
   }, []);
 
-  const toggleMode = useCallback(() => {
-    setMode(prev => (prev === 'cpu' ? 'pvp' : 'cpu'));
-    resetGame();
-  }, [resetGame]);
+  const cycleMode = useCallback(() => {
+    setMode(prev => {
+      if (prev === 'cpu') {
+        return 'cpu-slow';
+      }
+      if (prev === 'cpu-slow') {
+        return 'pvp';
+      }
+      return 'cpu';
+    });
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -122,12 +171,15 @@ const PongApp = () => {
     const context = canvas.getContext('2d');
     ctxRef.current = context;
 
-    const initial = createInitialState();
+    const options = buildOptions();
+    const initial = createInitialState(options);
     baseOptionsRef.current = initial.options;
     stateRef.current = initial;
     setScore({ ...initial.scores });
     setIsPaused(initial.isPaused);
-    drawGame(context, initial);
+    setTargetScore(initial.options.winScore);
+    setWinner(initial.winner);
+    drawGame(context, initial, opponentNameRef.current);
 
     let lastTime = null;
     const loop = (time) => {
@@ -143,13 +195,16 @@ const PongApp = () => {
 
       const { state, events } = stepGame(stateRef.current, inputRef.current, delta);
       stateRef.current = state;
-      drawGame(context, state);
+      drawGame(context, state, opponentNameRef.current);
 
       events.forEach(event => {
         if (event.type === 'score') {
           setScore(event.scores);
         } else if (event.type === 'pause') {
           setIsPaused(event.isPaused);
+        } else if (event.type === 'win') {
+          setWinner(event.winner);
+          setIsPaused(true);
         }
       });
 
@@ -163,14 +218,27 @@ const PongApp = () => {
         cancelAnimationFrame(animationRef.current);
       }
     };
-  }, []);
+  }, [buildOptions]);
 
   useEffect(() => {
-    inputRef.current.usesAi = mode === 'cpu';
-    if (mode === 'cpu') {
+    opponentNameRef.current = opponentLabel;
+  }, [opponentLabel]);
+
+  useEffect(() => {
+    inputRef.current.usesAi = mode !== 'pvp';
+    inputRef.current.aiDelay = mode === 'cpu-slow' ? 0.3 : 0;
+    if (mode !== 'pvp') {
       inputRef.current.right = 0;
     }
   }, [mode]);
+
+  useEffect(() => {
+    if (!hasAppliedSettingsRef.current) {
+      hasAppliedSettingsRef.current = true;
+      return;
+    }
+    resetGame();
+  }, [mode, krazyMode, resetGame]);
 
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -189,6 +257,18 @@ const PongApp = () => {
       } else if (key === 'r') {
         event.preventDefault();
         resetGame();
+      } else if (key === 'k') {
+        event.preventDefault();
+        setKrazyMode(prev => !prev);
+      } else if (key === 'c') {
+        event.preventDefault();
+        setMode('cpu');
+      } else if (key === 'p') {
+        event.preventDefault();
+        setMode('pvp');
+      } else if (key === 'x') {
+        event.preventDefault();
+        setMode('cpu-slow');
       }
     };
 
@@ -240,7 +320,11 @@ const PongApp = () => {
           <strong>{score.left}</strong>
         </div>
         <div className="pong-app__controls">
-          <span className="pong-app__status">{isPaused ? 'Paused' : 'In play'}</span>
+          <span className="pong-app__status">
+            {winner ? `${winner === 'left' ? 'Player 1' : opponentLabel} wins` : isPaused ? 'Paused' : 'In play'}
+          </span>
+          <span className="pong-app__status">First to {targetScore}</span>
+          <span className="pong-app__status">{krazyMode ? 'Krazy Mode' : 'Classic Mode'}</span>
           <div className="pong-app__button-row">
             <button className="pong-app__button" type="button" onClick={togglePause}>
               {isPaused ? 'Resume' : 'Pause'}
@@ -248,8 +332,19 @@ const PongApp = () => {
             <button className="pong-app__button" type="button" onClick={resetGame}>
               Restart
             </button>
-            <button className="pong-app__button" type="button" onClick={toggleMode}>
-              {mode === 'cpu' ? 'Switch to 2 players' : 'Switch to CPU'}
+            <button className="pong-app__button" type="button" onClick={cycleMode}>
+              {mode === 'cpu'
+                ? 'Switch to Slow CPU'
+                : mode === 'cpu-slow'
+                ? 'Switch to 2 players'
+                : 'Switch to CPU'}
+            </button>
+            <button
+              className="pong-app__button"
+              type="button"
+              onClick={() => setKrazyMode(prev => !prev)}
+            >
+              {krazyMode ? 'Disable Krazy Mode' : 'Enable Krazy Mode'}
             </button>
           </div>
         </div>
@@ -267,7 +362,8 @@ const PongApp = () => {
         aria-hidden="true"
       />
       <p className="pong-app__note">
-        Controls: W/S for Player 1 • Arrow keys for Player 2 • Space toggles pause • R restarts the match
+        Controls: W/S for Player 1 • Arrow keys for Player 2 • Space toggles pause • R restarts the match •
+        C for CPU • X for slow CPU • P for 2 players • K toggles Krazy Mode
       </p>
     </div>
   );

--- a/src/apps/PongApp/__tests__/gameLogic.test.js
+++ b/src/apps/PongApp/__tests__/gameLogic.test.js
@@ -8,10 +8,11 @@ import {
 describe('pong game logic', () => {
   it('creates a centred ball that is already moving toward the opponent', () => {
     const state = createInitialState();
-    expect(state.ball.x).toBeCloseTo(DEFAULT_OPTIONS.width / 2, 5);
-    expect(state.ball.y).toBeCloseTo(DEFAULT_OPTIONS.height / 2, 5);
-    expect(state.ball.vx).toBeGreaterThan(0);
-    expect(Math.abs(state.ball.vy)).toBeGreaterThan(0);
+    const [ball] = state.balls;
+    expect(ball.x).toBeCloseTo(DEFAULT_OPTIONS.width / 2, 5);
+    expect(ball.y).toBeCloseTo(DEFAULT_OPTIONS.height / 2, 5);
+    expect(ball.vx).toBeGreaterThan(0);
+    expect(Math.abs(ball.vy)).toBeGreaterThan(0);
   });
 
   it('moves paddles according to player input and clamps them within bounds', () => {
@@ -46,32 +47,82 @@ describe('pong game logic', () => {
     expect(paused.events).toContainEqual({ type: 'pause', isPaused: true });
 
     const followUp = stepGame(paused.state, createInputState(), 0.5);
-    expect(followUp.state.ball.x).toBeCloseTo(paused.state.ball.x);
-    expect(followUp.state.ball.y).toBeCloseTo(paused.state.ball.y);
+    const pausedBall = paused.state.balls[0];
+    const followUpBall = followUp.state.balls[0];
+    expect(followUpBall.x).toBeCloseTo(pausedBall.x);
+    expect(followUpBall.y).toBeCloseTo(pausedBall.y);
   });
 
   it('awards points and re-centres the ball when it crosses a boundary', () => {
     const state = createInitialState();
-    state.ball.x = state.bounds.width + state.ball.radius + 4;
-    state.ball.vx = Math.abs(state.ball.vx) + 80;
-    state.ball.vy = 0;
+    const ball = state.balls[0];
+    ball.x = state.bounds.width + ball.radius + 4;
+    ball.vx = Math.abs(ball.vx) + 80;
+    ball.vy = 0;
 
     const result = stepGame(state, createInputState(), 0.2);
     const scoreEvent = result.events.find(event => event.type === 'score');
     expect(scoreEvent).toBeDefined();
     expect(scoreEvent.side).toBe('left');
     expect(result.state.scores.left).toBe(1);
-    expect(result.state.ball.x).toBeCloseTo(state.bounds.width / 2, 5);
-    expect(result.state.ball.vx).toBeGreaterThan(0);
+    const [servedBall] = result.state.balls;
+    expect(servedBall.x).toBeCloseTo(state.bounds.width / 2, 5);
+    expect(servedBall.vx).toBeGreaterThan(0);
   });
 
   it('allows the AI paddle to track the ball position', () => {
     const state = createInitialState();
-    state.ball.y = 12;
+    state.balls[0].y = 12;
     state.paddles.right.y = DEFAULT_OPTIONS.height / 2;
 
     const { state: nextState } = stepGame(state, createInputState(), 0.05);
     expect(nextState.paddles.right.y).toBeLessThan(state.paddles.right.y);
+  });
+
+  it('spawns additional balls after five paddle bounces in Krazy mode', () => {
+    let current = createInitialState({ krazyMode: true });
+    const input = createInputState({ usesAi: false, right: 0 });
+
+    const positionBallForBounce = (state, side) => {
+      const [ball] = state.balls;
+      const { paddles, options } = state;
+      ball.y = paddles[side].y + options.paddleHeight / 2;
+      ball.vy = 0;
+      ball.speed = options.ballSpeed;
+      if (side === 'left') {
+        ball.x = paddles.left.x + options.paddleWidth + ball.radius + 1;
+        ball.vx = -options.ballSpeed;
+      } else {
+        ball.x = paddles.right.x - ball.radius - 1;
+        ball.vx = options.ballSpeed;
+      }
+    };
+
+    ['right', 'left', 'right', 'left', 'right'].forEach(side => {
+      positionBallForBounce(current, side);
+      const step = stepGame(current, input, 0.016);
+      current = step.state;
+    });
+
+    expect(current.balls.length).toBeGreaterThan(1);
+    expect(current.successfulPasses).toBeGreaterThanOrEqual(5);
+  });
+
+  it('ends the game when a player reaches the win score', () => {
+    const state = createInitialState();
+    state.scores.left = state.options.winScore - 1;
+    const ball = state.balls[0];
+    ball.x = state.bounds.width + ball.radius + 4;
+    ball.vx = Math.abs(ball.vx) + 100;
+    ball.vy = 0;
+
+    const result = stepGame(state, createInputState(), 0.2);
+    const winEvent = result.events.find(event => event.type === 'win');
+    expect(winEvent).toBeDefined();
+    expect(result.state.scores.left).toBe(state.options.winScore);
+    expect(result.state.winner).toBe('left');
+    expect(result.state.isPaused).toBe(true);
+    expect(result.state.balls).toHaveLength(0);
   });
 
   it('does not mutate the previous state object', () => {
@@ -83,6 +134,6 @@ describe('pong game logic', () => {
     expect(state).toEqual(snapshot);
     expect(result.state).not.toBe(state);
     expect(result.state.paddles.left).not.toBe(state.paddles.left);
-    expect(result.state.ball).not.toBe(state.ball);
+    expect(result.state.balls[0]).not.toBe(state.balls[0]);
   });
 });

--- a/src/apps/PongApp/gameLogic.js
+++ b/src/apps/PongApp/gameLogic.js
@@ -7,12 +7,17 @@ const DEFAULT_OPTIONS = {
   paddleSpeed: 360,
   aiSpeed: 320,
   aiReactionDistance: 14,
+  aiDelay: 0,
   ballRadius: 8,
   ballSpeed: 360,
   ballSpeedIncrement: 18,
   ballMaxSpeed: 520,
   maxBounceAngle: Math.PI / 3,
   serveAngle: Math.PI / 5,
+  winScore: 3,
+  krazyWinScore: 10,
+  krazyPasses: 5,
+  krazyMode: false,
 };
 
 const LEFT = 'left';
@@ -36,7 +41,7 @@ function cloneState(state) {
       left: { ...state.paddles.left },
       right: { ...state.paddles.right },
     },
-    ball: { ...state.ball },
+    balls: state.balls.map(ball => ({ ...ball })),
     scores: { ...state.scores },
   };
 }
@@ -45,34 +50,52 @@ function serveBall(state, direction = 1) {
   const { bounds, options } = state;
   const { serveAngle } = options;
 
-  state.ball.x = bounds.width / 2;
-  state.ball.y = bounds.height / 2;
-  state.ball.speed = options.ballSpeed;
   const verticalSign = state.nextServeVertical;
   state.nextServeVertical *= -1;
 
   const cos = Math.cos(serveAngle);
   const sin = Math.sin(serveAngle) * verticalSign;
 
-  state.ball.vx = cos * state.ball.speed * direction;
-  state.ball.vy = sin * state.ball.speed;
-
-  return state;
+  const speed = options.ballSpeed;
+  return {
+    id: state.nextBallId += 1,
+    x: bounds.width / 2,
+    y: bounds.height / 2,
+    vx: cos * speed * direction,
+    vy: sin * speed,
+    radius: options.ballRadius,
+    speed,
+  };
 }
 
 function awardPoint(state, side, events) {
   state.scores[side] += 1;
   const serveDirection = side === LEFT ? 1 : -1;
-  serveBall(state, serveDirection);
+  const winner = state.scores[side] >= state.options.winScore;
+
   events.push({
     type: 'score',
     side,
     scores: { ...state.scores },
   });
+
+  if (winner) {
+    state.isPaused = true;
+    state.winner = side;
+    state.balls = [];
+    events.push({ type: 'win', winner: side, scores: { ...state.scores } });
+    return;
+  }
+
+  state.balls = [serveBall(state, serveDirection)];
+  state.successfulPasses = 0;
+  if (serveDirection === 1) {
+    state.aiDelayTimer = 0;
+  }
 }
 
-function handlePaddleInteraction(state, side) {
-  const { ball, paddles, options } = state;
+function handlePaddleInteraction(state, ball, side) {
+  const { paddles, options } = state;
   const paddle = paddles[side];
   const headingTowardPaddle = side === LEFT ? ball.vx < 0 : ball.vx > 0;
 
@@ -104,17 +127,16 @@ function handlePaddleInteraction(state, side) {
   const clampedIntersect = clamp(relativeIntersect, -1, 1);
 
   const speed = Math.min(ball.speed + options.ballSpeedIncrement, options.ballMaxSpeed);
-  state.ball.speed = speed;
+  ball.speed = speed;
   const bounceAngle = clampedIntersect * options.maxBounceAngle;
   const directionMultiplier = side === LEFT ? 1 : -1;
 
   const cos = Math.cos(bounceAngle);
   const sin = Math.sin(bounceAngle);
-  state.ball.vx = cos * speed * directionMultiplier;
-  state.ball.vy = sin * speed;
+  ball.vx = cos * speed * directionMultiplier;
+  ball.vy = sin * speed;
 
-  state.ball.x =
-    side === LEFT ? paddle.x + options.paddleWidth + ball.radius : paddle.x - ball.radius;
+  ball.x = side === LEFT ? paddle.x + options.paddleWidth + ball.radius : paddle.x - ball.radius;
 
   return 'bounce';
 }
@@ -125,12 +147,16 @@ export function createInputState(overrides = {}) {
     right: 0,
     usesAi: true,
     pausePressed: false,
+    aiDelay: 0,
     ...overrides,
   };
 }
 
 export function createInitialState(overrides = {}) {
   const options = deepMergeOptions(overrides);
+  if (options.krazyMode && overrides.winScore == null) {
+    options.winScore = DEFAULT_OPTIONS.krazyWinScore;
+  }
   const bounds = { width: options.width, height: options.height };
   const paddles = {
     left: {
@@ -147,23 +173,20 @@ export function createInitialState(overrides = {}) {
     options,
     bounds,
     paddles,
-    ball: {
-      x: bounds.width / 2,
-      y: bounds.height / 2,
-      vx: 0,
-      vy: 0,
-      radius: options.ballRadius,
-      speed: options.ballSpeed,
-    },
+    balls: [],
     scores: {
       left: 0,
       right: 0,
     },
     isPaused: false,
     nextServeVertical: 1,
+    nextBallId: 0,
+    successfulPasses: 0,
+    winner: null,
+    aiDelayTimer: 0,
   };
 
-  serveBall(state, 1);
+  state.balls.push(serveBall(state, 1));
 
   return state;
 }
@@ -193,13 +216,41 @@ export function stepGame(state, input, deltaSeconds, overrides = {}) {
   );
 
   let rightMovement = 0;
+  const aiDelay = input.aiDelay ?? 0;
+  if (input.usesAi) {
+    if (aiDelay > 0 && next.aiDelayTimer < aiDelay) {
+      next.aiDelayTimer = Math.min(aiDelay, next.aiDelayTimer + clampedDelta);
+    }
+  } else {
+    next.aiDelayTimer = 0;
+  }
+
+  let targetBall = null;
+  let closestDistance = Infinity;
+  next.balls.forEach(ball => {
+    const headingRight = ball.vx > 0;
+    if (headingRight) {
+      const distance = Math.abs(bounds.width - ball.x);
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        targetBall = ball;
+      }
+    }
+  });
+
+  if (!targetBall) {
+    targetBall = next.balls[0] ?? null;
+  }
+
   if (!input.usesAi) {
     rightMovement = clamp(input.right ?? 0, -1, 1);
   } else {
-    const targetY = next.ball.y;
+    const targetY = targetBall ? targetBall.y : bounds.height / 2;
     const paddleCenter = next.paddles.right.y + options.paddleHeight / 2;
     const deltaY = targetY - paddleCenter;
-    if (Math.abs(deltaY) > options.aiReactionDistance) {
+    const headingRight = targetBall ? targetBall.vx > 0 : false;
+    const delaying = headingRight && aiDelay > 0 && next.aiDelayTimer < aiDelay;
+    if (!delaying && Math.abs(deltaY) > options.aiReactionDistance) {
       rightMovement = deltaY > 0 ? 1 : -1;
     }
   }
@@ -211,37 +262,66 @@ export function stepGame(state, input, deltaSeconds, overrides = {}) {
     bounds.height - options.paddleHeight,
   );
 
-  next.ball.x += next.ball.vx * clampedDelta;
-  next.ball.y += next.ball.vy * clampedDelta;
+  for (let i = 0; i < next.balls.length; i += 1) {
+    const ball = next.balls[i];
+    ball.x += ball.vx * clampedDelta;
+    ball.y += ball.vy * clampedDelta;
 
-  if (next.ball.y - next.ball.radius <= 0) {
-    next.ball.y = next.ball.radius;
-    next.ball.vy = Math.abs(next.ball.vy);
-  } else if (next.ball.y + next.ball.radius >= bounds.height) {
-    next.ball.y = bounds.height - next.ball.radius;
-    next.ball.vy = -Math.abs(next.ball.vy);
-  }
+    if (ball.y - ball.radius <= 0) {
+      ball.y = ball.radius;
+      ball.vy = Math.abs(ball.vy);
+    } else if (ball.y + ball.radius >= bounds.height) {
+      ball.y = bounds.height - ball.radius;
+      ball.vy = -Math.abs(ball.vy);
+    }
 
-  const leftResult = handlePaddleInteraction(next, LEFT);
-  if (leftResult === 'miss') {
-    awardPoint(next, RIGHT, events);
-    return { state: next, events };
-  }
+    const leftResult = handlePaddleInteraction(next, ball, LEFT);
+    if (leftResult === 'miss') {
+      awardPoint(next, RIGHT, events);
+      return { state: next, events };
+    }
+    if (leftResult === 'bounce') {
+      next.successfulPasses += 1;
+      if (ball.vx > 0 && aiDelay > 0) {
+        next.aiDelayTimer = 0;
+      }
+      if (options.krazyMode && next.successfulPasses % options.krazyPasses === 0) {
+        const newBall = serveBall(next, ball.vx > 0 ? -1 : 1);
+        next.balls.push(newBall);
+        if (newBall.vx > 0 && aiDelay > 0) {
+          next.aiDelayTimer = 0;
+        }
+      }
+    }
 
-  const rightResult = handlePaddleInteraction(next, RIGHT);
-  if (rightResult === 'miss') {
-    awardPoint(next, LEFT, events);
-    return { state: next, events };
-  }
+    const rightResult = handlePaddleInteraction(next, ball, RIGHT);
+    if (rightResult === 'miss') {
+      awardPoint(next, LEFT, events);
+      return { state: next, events };
+    }
+    if (rightResult === 'bounce') {
+      next.successfulPasses += 1;
+      if (ball.vx > 0 && aiDelay > 0) {
+        next.aiDelayTimer = 0;
+      }
+      if (options.krazyMode && next.successfulPasses % options.krazyPasses === 0) {
+        const newBall = serveBall(next, ball.vx > 0 ? -1 : 1);
+        next.balls.push(newBall);
+        if (newBall.vx > 0 && aiDelay > 0) {
+          next.aiDelayTimer = 0;
+        }
+      }
+    }
 
-  if (next.ball.x + next.ball.radius < 0) {
-    awardPoint(next, RIGHT, events);
-    return { state: next, events };
-  }
+    if (ball.x + ball.radius < 0) {
+      awardPoint(next, RIGHT, events);
+      return { state: next, events };
+    }
 
-  if (next.ball.x - next.ball.radius > bounds.width) {
-    awardPoint(next, LEFT, events);
-    return { state: next, events };
+    if (ball.x - ball.radius > bounds.width) {
+      awardPoint(next, LEFT, events);
+      return { state: next, events };
+    }
   }
 
   return { state: next, events };


### PR DESCRIPTION
## Summary
- add configurable win targets, Krazy mode multi-ball spawns, and win tracking to the Pong game logic
- update the Pong UI with Krazy mode toggles, CPU speed hotkeys, and on-canvas win messaging
- expand game logic tests to cover multi-ball, Krazy mode spawning, and win condition handling

## Testing
- npx jest --runTestsByPath src/apps/PongApp/__tests__/gameLogic.test.js src/apps/PongApp/__tests__/PongApp.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ca6c91aa10832bada6beec5c972373