### PR TITLE
Revamp N-Pomodoro timer with customizable sessions

### DIFF
--- a/src/apps/NPomodoroApp/NPomodoroApp.css
+++ b/src/apps/NPomodoroApp/NPomodoroApp.css
@@ -1,41 +1,52 @@
 .n-pomodoro-app {
-  min-height: 100vh;
   position: relative;
-  overflow: hidden;
-  background: radial-gradient(ellipse at center, #1a1a2e 0%, #16213e 50%, #0f0f23 100%);
+  min-height: 100vh;
+  width: 100%;
+  overflow-x: hidden;
+  color: #f6f8ff;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
 }
 
-.space-background {
+.cosmic-backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
+  background: radial-gradient(circle at top, #1b1f44 0%, #0b1029 55%, #050716 100%);
   z-index: 1;
+  overflow: hidden;
 }
 
-.stars {
+.stellar-dust {
   position: absolute;
-  width: 100%;
-  height: 100%;
-  background-image: 
-    radial-gradient(2px 2px at 20px 30px, #eee, transparent),
-    radial-gradient(2px 2px at 40px 70px, rgba(255,255,255,0.8), transparent),
-    radial-gradient(1px 1px at 90px 40px, #fff, transparent),
-    radial-gradient(1px 1px at 130px 80px, rgba(255,255,255,0.6), transparent),
-    radial-gradient(2px 2px at 160px 30px, #ddd, transparent);
-  background-repeat: repeat;
-  background-size: 200px 100px;
-  animation: twinkle 20s linear infinite;
-  opacity: calc(var(--star-count, 200) / 200);
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background-image:
+    radial-gradient(2px 2px at 20px 40px, rgba(255, 255, 255, 0.9), transparent),
+    radial-gradient(2px 2px at 140px 90px, rgba(255, 255, 255, 0.7), transparent),
+    radial-gradient(1px 1px at 80px 160px, rgba(255, 255, 255, 0.8), transparent),
+    radial-gradient(1px 1px at 220px 110px, rgba(255, 255, 255, 0.6), transparent);
+  background-size: 220px 220px;
+  animation: starDrift 60s linear infinite;
+  opacity: calc(var(--star-count, 200) / 260);
+  filter: blur(0.3px);
 }
 
-@keyframes twinkle {
-  0% { transform: translateY(0px); }
-  100% { transform: translateY(-100px); }
+.aurora {
+  position: absolute;
+  top: -30%;
+  left: -30%;
+  width: 160%;
+  height: 160%;
+  background: radial-gradient(circle at 30% 30%, rgba(127, 90, 240, 0.25), transparent 60%),
+    radial-gradient(circle at 70% 40%, rgba(44, 177, 188, 0.22), transparent 65%),
+    radial-gradient(circle at 50% 70%, rgba(242, 95, 76, 0.25), transparent 70%);
+  mix-blend-mode: screen;
+  opacity: 0.38;
+  animation: auroraPulse 18s ease-in-out infinite;
 }
 
-.app-content {
+.n-pomodoro-shell {
   position: relative;
   z-index: 2;
   min-height: 100vh;
@@ -43,363 +54,916 @@
   flex-direction: column;
 }
 
-.app-header {
+.n-pomodoro-header {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
-  padding: 20px 40px;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(10px);
+  gap: clamp(24px, 4vw, 48px);
+  padding: clamp(32px, 6vw, 72px) clamp(40px, 7vw, 96px) 0;
 }
 
-/* Re-enable app-level header styles for internal controls, but navigation will come from container */
-
-.back-btn, .config-btn {
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 12px 24px;
-  border-radius: 25px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-  font-size: 1rem;
-}
-
-.back-btn:hover, .config-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: translateY(-2px);
-}
-
-.app-title {
-  color: white;
-  font-size: 2.5rem;
-  font-weight: 300;
+.header-copy h1 {
+  font-size: clamp(2.6rem, 4vw, 3.8rem);
   margin: 0;
-  text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-shadow: 0 12px 40px rgba(12, 10, 40, 0.6);
 }
 
-.config-panel {
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(20px);
-  border-radius: 20px;
-  padding: 40px;
-  margin: 20px 40px;
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  max-width: 800px;
-  margin-left: auto;
-  margin-right: auto;
+.header-copy p {
+  margin: 14px 0 0 0;
+  max-width: 620px;
+  line-height: 1.7;
+  color: rgba(241, 245, 255, 0.75);
+  font-size: 1.05rem;
 }
 
-.config-panel h3 {
-  margin-top: 0;
-  color: #667eea;
-  font-size: 1.8rem;
-}
-
-.presets h4 {
-  color: #4ecdc4;
-  margin-bottom: 20px;
-  font-size: 1.3rem;
-}
-
-.preset-buttons {
+.header-actions {
   display: flex;
-  gap: 20px;
-  flex-wrap: wrap;
-  margin-bottom: 30px;
+  align-items: center;
+  gap: clamp(18px, 3vw, 32px);
 }
 
-.preset-btn {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
-  border: none;
-  padding: 15px 25px;
-  border-radius: 25px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.preset-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
-}
-
-.close-config-btn {
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 12px 25px;
-  border-radius: 25px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 1rem;
-}
-
-.timer-interface {
-  flex: 1;
+.journey-progress {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px;
-  text-align: center;
-  max-width: 1000px;
-  margin: 0 auto;
-  width: 100%;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 18px 24px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 18, 48, 0.65);
+  box-shadow: 0 22px 60px rgba(7, 9, 28, 0.45);
+  backdrop-filter: blur(20px);
 }
 
-.activity-info {
-  margin-bottom: 50px;
+.journey-progress .label {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
 }
 
-.current-activity {
-  color: white;
-  font-size: 3rem;
-  font-weight: 300;
-  margin: 0 0 15px 0;
-  text-shadow: 0 0 30px rgba(255, 255, 255, 0.5);
-}
-
-.activity-progress {
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 1.3rem;
-  margin: 0;
-}
-
-.timer-display {
-  margin-bottom: 50px;
+.progress-track {
   position: relative;
+  width: clamp(160px, 20vw, 240px);
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
 }
 
-.time-circle {
-  position: relative;
-  width: 450px;
-  height: 450px;
-  margin: 0 auto;
-}
-
-.time-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  color: white;
-  font-size: 4.5rem;
-  font-weight: 300;
-  font-family: 'Courier New', monospace;
-  text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
-  z-index: 3;
-}
-
-.progress-ring {
+.progress-fill {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
   height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(120deg, #7f5af0 0%, #2cb1bc 100%);
+  box-shadow: 0 0 18px rgba(127, 90, 240, 0.6);
+  transition: width 0.6s ease;
 }
 
-.progress-ring-svg {
-  transform: rotate(-90deg);
-  width: 100%;
-  height: 100%;
-}
-
-.progress-ring-circle {
-  transition: stroke-dashoffset 0.5s ease;
-  filter: drop-shadow(0 0 10px currentColor);
-}
-
-.timer-controls {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 50px;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.control-btn {
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 18px 32px;
-  border-radius: 30px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-size: 1.1rem;
-  font-weight: 600;
-  backdrop-filter: blur(10px);
-  min-width: 120px;
-}
-
-.control-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: translateY(-2px);
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-}
-
-.start-btn, .resume-btn {
-  background: linear-gradient(135deg, #4ecdc4, #44a08d);
-  border-color: #4ecdc4;
-}
-
-.pause-btn {
-  background: linear-gradient(135deg, #ff6b6b, #ee5a24);
-  border-color: #ff6b6b;
-}
-
-.reset-btn {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  border-color: #667eea;
-}
-
-.next-btn {
-  background: linear-gradient(135deg, #96ceb4, #85c1a3);
-  border-color: #96ceb4;
-}
-
-.completion-message {
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(20px);
-  border-radius: 20px;
-  padding: 40px;
-  margin-bottom: 40px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: white;
-  text-align: center;
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.completion-message h3 {
-  color: #4ecdc4;
-  font-size: 2.3rem;
-  margin: 0 0 15px 0;
-}
-
-.completion-message p {
-  color: rgba(255, 255, 255, 0.7);
+.journey-progress .value {
   font-size: 1.2rem;
-  margin: 0 0 25px 0;
+  font-weight: 700;
+  letter-spacing: 0.08em;
 }
 
-.activity-list {
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(10px);
-  border-radius: 15px;
-  padding: 30px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  max-width: 600px;
+.journey-progress .supplement {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.planner-toggle {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 12px 24px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f6f8ff;
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  backdrop-filter: blur(12px);
+}
+
+.planner-toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(8, 10, 28, 0.35);
+}
+
+.n-pomodoro-layout {
+  position: relative;
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  gap: clamp(24px, 4vw, 56px);
+  padding: clamp(20px, 4vw, 56px) clamp(40px, 7vw, 96px) clamp(64px, 7vw, 110px);
+  transition: grid-template-columns 0.4s ease, gap 0.4s ease;
+}
+
+.n-pomodoro-layout.planner-collapsed {
+  grid-template-columns: 0 minmax(0, 1fr);
+  gap: 0;
+}
+
+.n-pomodoro-layout.planner-collapsed .planner-panel {
+  opacity: 0;
+  transform: translateX(-32px);
+  pointer-events: none;
+}
+
+.planner-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: clamp(24px, 3vw, 36px);
+  border-radius: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 18, 48, 0.72);
+  backdrop-filter: blur(26px);
+  box-shadow: 0 34px 90px rgba(8, 11, 30, 0.55);
+  overflow: hidden;
+}
+
+.planner-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.planner-header p {
+  margin: 12px 0 0 0;
+  color: rgba(240, 245, 255, 0.68);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.session-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  padding-right: 6px;
+  max-height: calc(100vh - 360px);
+}
+
+.session-stack::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-stack::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+}
+
+.session-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 18px 46px rgba(8, 10, 28, 0.45);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.session-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  transition: border-color 0.3s ease, opacity 0.3s ease;
+  opacity: 0;
+}
+
+.session-card.active {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 28px 70px rgba(12, 15, 40, 0.55);
+}
+
+.session-card.active::before {
+  border-color: var(--session-accent, #7f5af0);
+  opacity: 0.55;
+}
+
+.session-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.session-name-input {
   width: 100%;
+  padding: 10px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(8, 12, 32, 0.55);
+  color: #f6f8ff;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-.activity-list h4 {
-  color: white;
-  margin: 0 0 20px 0;
-  font-size: 1.4rem;
+.session-name-input:focus {
+  outline: none;
+  border-color: rgba(127, 90, 240, 0.7);
+  box-shadow: 0 0 0 2px rgba(127, 90, 240, 0.25);
 }
 
-.activities {
+.session-duration {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.session-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.session-focus-btn,
+.session-remove-btn {
+  appearance: none;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+}
+
+.session-focus-btn {
+  border: none;
+  color: #0a0f24;
+  background: linear-gradient(120deg, var(--session-accent, #7f5af0) 0%, #2cb1bc 100%);
+  box-shadow: 0 16px 38px rgba(32, 24, 76, 0.45);
+}
+
+.session-focus-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 44px rgba(32, 24, 76, 0.55);
+}
+
+.session-remove-btn {
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.session-remove-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(8, 10, 28, 0.35);
+}
+
+.session-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.block-editor {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.activity-item {
-  display: flex;
-  justify-content: space-between;
+.block-row {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto auto auto;
   align-items: center;
-  padding: 15px 25px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  transition: all 0.3s ease;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 8, 24, 0.55);
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
-.activity-item.active {
-  background: var(--activity-color, #667eea);
-  border-color: var(--activity-color, #667eea);
-  box-shadow: 0 0 20px rgba(102, 126, 234, 0.3);
-  transform: scale(1.02);
+.block-row.current {
+  border-color: var(--session-accent, #7f5af0);
+  box-shadow: 0 0 0 1px rgba(127, 90, 240, 0.35), 0 18px 38px rgba(18, 20, 40, 0.45);
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.09);
 }
 
-.activity-item.completed {
-  opacity: 0.6;
-  background: rgba(76, 175, 80, 0.2);
-  border-color: rgba(76, 175, 80, 0.3);
-}
-
-.activity-name {
-  color: white;
+.block-handle {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f6f8ff;
   font-weight: 600;
-  font-size: 1.1rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.activity-duration {
+.block-handle:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(12, 14, 30, 0.35);
+}
+
+.block-name-input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: #f6f8ff;
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.block-name-input:focus {
+  outline: none;
+}
+
+.block-duration-input {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.block-duration-input input {
+  width: 52px;
+  border: none;
+  background: transparent;
+  color: #f6f8ff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: right;
+}
+
+.block-duration-input input:focus {
+  outline: none;
+}
+
+.block-duration-input span {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
   color: rgba(255, 255, 255, 0.7);
-  font-size: 1rem;
+  text-transform: uppercase;
 }
 
-/* Responsive Design */
-@media (max-width: 1200px) {
-  .time-circle {
-    width: 400px;
-    height: 400px;
+.block-color-input {
+  appearance: none;
+  border: none;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.24);
+  background: transparent;
+}
+
+.block-color-input::-webkit-color-swatch,
+.block-color-input::-moz-color-swatch {
+  border-radius: 10px;
+  border: none;
+}
+
+.block-remove-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.block-remove-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(242, 95, 76, 0.35);
+  color: #1b0c1f;
+}
+
+.block-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.add-block-btn {
+  align-self: flex-start;
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.08);
+  color: #f6f8ff;
+  padding: 9px 18px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.add-block-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.planner-footer {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.add-session-btn,
+.restore-defaults-btn {
+  appearance: none;
+  border-radius: 14px;
+  padding: 11px 18px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.add-session-btn {
+  border: none;
+  color: #081023;
+  background: linear-gradient(120deg, #7f5af0 0%, #2cb1bc 100%);
+  box-shadow: 0 20px 44px rgba(30, 25, 66, 0.55);
+}
+
+.add-session-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 26px 54px rgba(30, 25, 66, 0.65);
+}
+
+.restore-defaults-btn {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.restore-defaults-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(10, 12, 30, 0.35);
+}
+
+.play-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 48px);
+  padding: clamp(24px, 4vw, 48px);
+  border-radius: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(11, 17, 40, 0.72);
+  backdrop-filter: blur(30px);
+  box-shadow: 0 42px 110px rgba(8, 11, 30, 0.6);
+  overflow: hidden;
+}
+
+.timer-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 3vw, 40px);
+  padding: clamp(24px, 4vw, 42px);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(127, 90, 240, 0.35) 0%, rgba(44, 177, 188, 0.18) 100%);
+  box-shadow: 0 30px 70px rgba(15, 16, 46, 0.45);
+  overflow: hidden;
+}
+
+.timer-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.16), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.timer-meta {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.session-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(9, 13, 28, 0.8);
+  font-weight: 700;
+}
+
+.timer-meta h2 {
+  margin: 0;
+  font-size: clamp(2.1rem, 3.2vw, 2.9rem);
+  font-weight: 700;
+  text-shadow: 0 20px 50px rgba(9, 10, 32, 0.6);
+}
+
+.block-label {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(241, 245, 255, 0.75);
+}
+
+.timer-visual {
+  position: relative;
+  width: clamp(220px, 32vw, 360px);
+  aspect-ratio: 1;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.time-display {
+  position: absolute;
+  z-index: 2;
+  font-size: clamp(2.6rem, 5vw, 3.6rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #f6f8ff;
+  text-shadow: 0 12px 35px rgba(8, 10, 26, 0.6);
+}
+
+.progress-ring {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+  filter: drop-shadow(0 0 25px rgba(255, 255, 255, 0.35));
+}
+
+.progress-ring-bg,
+.progress-ring-track,
+.progress-ring-indicator {
+  fill: none;
+  stroke-width: 12;
+}
+
+.progress-ring-bg {
+  stroke: rgba(255, 255, 255, 0.08);
+}
+
+.progress-ring-track {
+  stroke: rgba(255, 255, 255, 0.18);
+}
+
+.progress-ring-indicator {
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.6s ease, stroke 0.6s ease;
+}
+
+.quick-stats {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.stat-card {
+  padding: 16px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 12, 32, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 18px 40px rgba(8, 10, 28, 0.4);
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.timer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+  position: relative;
+  z-index: 1;
+}
+
+.control-btn {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 26px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
+  min-width: 150px;
+}
+
+.control-btn.primary {
+  color: #0a1022;
+  background: linear-gradient(120deg, #7f5af0 0%, #2cb1bc 100%);
+  box-shadow: 0 22px 46px rgba(32, 24, 76, 0.55);
+}
+
+.control-btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 54px rgba(32, 24, 76, 0.65);
+}
+
+.control-btn.warning {
+  color: #1b0e24;
+  background: linear-gradient(120deg, #f25f4c 0%, #ffb627 100%);
+  box-shadow: 0 22px 46px rgba(76, 26, 24, 0.55);
+}
+
+.control-btn.warning:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 52px rgba(76, 26, 24, 0.6);
+}
+
+.control-btn.ghost {
+  color: #f6f8ff;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 16px 36px rgba(8, 10, 26, 0.35);
+}
+
+.control-btn.ghost:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.control-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.completion-banner {
+  margin-top: 4px;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(10, 18, 44, 0.78);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 24px 60px rgba(10, 12, 32, 0.45);
+}
+
+.completion-banner h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.completion-banner p {
+  margin: 0;
+  color: rgba(241, 245, 255, 0.75);
+  line-height: 1.6;
+}
+
+.session-timeline {
+  position: relative;
+  display: flex;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(6, 10, 26, 0.6);
+}
+
+.timeline-segment {
+  position: relative;
+  flex: 1;
+  min-width: 90px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 12px 14px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  color: #f6f8ff;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.timeline-segment::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 75%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.timeline-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(120deg, var(--segment-accent, #7f5af0) 0%, rgba(255, 255, 255, 0.2) 100%);
+  opacity: 0.45;
+  transition: width 0.6s ease;
+}
+
+.timeline-label {
+  position: relative;
+  z-index: 1;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-shadow: 0 2px 10px rgba(8, 10, 26, 0.5);
+}
+
+.timeline-segment:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 46px rgba(14, 16, 40, 0.45);
+}
+
+.timeline-segment.active {
+  border-color: var(--segment-accent, #7f5af0);
+  box-shadow: 0 24px 60px rgba(127, 90, 240, 0.45);
+}
+
+.planner-overlay {
+  display: none;
+}
+
+@media (max-width: 1280px) {
+  .n-pomodoro-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
-  
-  .time-text {
-    font-size: 4rem;
+
+  .header-actions {
+    align-self: stretch;
+    justify-content: space-between;
   }
-  
-  .current-activity {
-    font-size: 2.5rem;
+
+  .session-stack {
+    max-height: calc(100vh - 420px);
+  }
+}
+
+@media (max-width: 960px) {
+  .n-pomodoro-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 28px clamp(20px, 7vw, 36px) clamp(72px, 12vw, 120px);
+  }
+
+  .planner-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(420px, 100%);
+    max-width: 100%;
+    border-radius: 0 0 0 32px;
+    transform: translateX(100%);
+    opacity: 1;
+    pointer-events: auto;
+    transition: transform 0.4s ease;
+    z-index: 6;
+  }
+
+  .n-pomodoro-layout.planner-open .planner-panel {
+    transform: translateX(0);
+  }
+
+  .planner-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: none;
+    background: rgba(4, 6, 18, 0.7);
+    backdrop-filter: blur(6px);
+    z-index: 5;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    cursor: pointer;
+  }
+
+  .n-pomodoro-layout.planner-open .planner-overlay {
+    opacity: 1;
+  }
+
+  .session-stack {
+    max-height: none;
   }
 }
 
 @media (max-width: 768px) {
-  .app-header {
-    padding: 15px 20px;
+  .n-pomodoro-header {
+    padding: 28px 24px 0;
+  }
+
+  .planner-toggle {
+    width: 100%;
+    text-align: center;
+  }
+
+  .timer-card {
+    padding: 24px;
+  }
+
+  .timer-visual {
+    width: min(280px, 70vw);
+  }
+
+  .quick-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .session-timeline {
     flex-direction: column;
-    gap: 15px;
   }
-  
-  .app-title {
-    font-size: 1.5rem;
+
+  .timeline-segment {
+    min-height: 72px;
   }
-  
-  .time-circle {
-    width: 250px;
-    height: 250px;
+}
+
+@media (max-width: 520px) {
+  .journey-progress {
+    width: 100%;
+    align-items: flex-start;
   }
-  
-  .time-text {
-    font-size: 2.5rem;
-  }
-  
-  .current-activity {
-    font-size: 2rem;
-  }
-  
-  .timer-controls {
+
+  .header-actions {
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
   }
-  
+
+  .quick-stats {
+    grid-template-columns: 1fr;
+  }
+
   .control-btn {
-    width: 200px;
+    width: 100%;
   }
-  
-  .config-panel {
-    margin: 10px;
-    padding: 20px;
+}
+
+@keyframes starDrift {
+  0% {
+    transform: translate3d(0, 0, 0);
   }
-  
-  .preset-buttons {
-    flex-direction: column;
+  50% {
+    transform: translate3d(60px, -80px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes auroraPulse {
+  0% {
+    transform: scale(1) rotate(0deg);
+    opacity: 0.32;
+  }
+  50% {
+    transform: scale(1.05) rotate(1.5deg);
+    opacity: 0.48;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 0.32;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the N-Pomodoro experience so the timer stretches full-width with an immersive cosmic backdrop
- add a session planner that allows naming, coloring, and expanding blocks beyond five sessions with automatic persistence
- enrich the run view with detailed stats, progress timeline, and responsive controls for a polished experience

## Testing
- npm test *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca652ca72c832b95fa4fa08e94e92d