### PR TITLE
Add chess sub-app with Stockfish support and tests

### DIFF
--- a/CHESS.md
+++ b/CHESS.md
@@ -1,0 +1,49 @@
+# Chess Sub-App
+
+The Chess sub-application is delivered in two incremental phases. It lives alongside the existing project as a collection of static assets (`html/`, `js/`, and `css/`) so it can be served without impacting the React bundle.
+
+## Phase 1 – Local Two-Player Chessboard
+
+### Setup
+1. Open `html/chess.html` in your browser. No local build step is required; all dependencies are loaded via CDNs.
+2. The page includes [Chessboard.js](https://github.com/oakmac/chessboardjs) for the visual board and [Chess.js](https://github.com/jhlywa/chess.js) for rules enforcement.
+3. `js/boardManager.js` handles board wiring, move validation, and integrates with Chess.js so only legal moves are accepted.
+
+### Usage
+- Drag pieces to make moves. Illegal moves automatically snap back.
+- The **New Game** button resets the position.
+- Status messaging (whose turn, check, mate, draw) updates after every move.
+
+## Phase 2 – Stockfish Integration
+
+### Setup
+1. The same HTML entry point (`html/chess.html`) now also loads [Stockfish.js](https://github.com/official-stockfish/Stockfish) via jsDelivr CDN.
+2. `js/stockfishEngine.js` wraps the global `Stockfish()` worker so engine logic is isolated from board state.
+3. `js/chess.js` composes the board and engine layers and exposes UI controls for the active mode and Stockfish skill level.
+
+### Usage
+- Use the **Mode** dropdown to choose between:
+  - **2 Player Local** – both sides are human controlled.
+  - **Play vs Stockfish** – you play White, Stockfish plays Black.
+- In engine mode Stockfish always replies 1 second after your move. It spends 0.5 seconds thinking (`go movetime 500`) before responding.
+- Adjust the **Skill Level** slider (0–20) to tweak Stockfish’s strength. The slider is disabled in two-player mode.
+- The board logic and engine logic are modular; Stockfish can be swapped or disabled by updating the `StockfishEngine` wrapper without touching the board manager.
+
+### Rationale for CDN Stockfish
+Stockfish distributes WebAssembly binaries. GitHub forbids storing large engine binaries in source control, so the app references Stockfish.js directly from a CDN. This keeps the repository lightweight and guarantees users always load the official build.
+
+## Running Tests
+1. Install dependencies: `npm install` (if not already done).
+2. Execute the automated suite: `npm test`.
+
+The Jest tests cover:
+- Local move validation via `BoardManager`.
+- Engine timing to ensure Stockfish waits a full second before moving.
+- Verification that the HTML entry point references the CDN-hosted Stockfish script.
+
+## Future Enhancements
+- Clock support for blitz/rapid/classical time controls.
+- Move history panel with undo/redo actions.
+- Export played games as PGN.
+- Highlight last move and show captured material balance.
+- Multiplayer over the network with WebRTC or WebSockets.

--- a/css/chess.css
+++ b/css/chess.css
@@ -1,0 +1,104 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: #f1f5f9;
+  margin: 0;
+  padding: 0;
+  color: #0f172a;
+}
+
+.chess-app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.chess-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  background: #fff;
+  padding: 12px 16px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.1);
+}
+
+.chess-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+}
+
+.chess-toolbar select,
+.chess-toolbar input[type="range"],
+.chess-toolbar button {
+  font-size: 0.95rem;
+  padding: 6px 10px;
+  border: 1px solid #cbd5f5;
+  border-radius: 8px;
+  background: #eef2ff;
+  color: #1e293b;
+}
+
+.chess-toolbar button {
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chess-toolbar button:hover {
+  background: #c7d2fe;
+  box-shadow: 0 3px 6px rgba(79, 70, 229, 0.25);
+}
+
+.chess-board-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+#chessboard {
+  width: 480px;
+  max-width: 100%;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+#chess-status {
+  flex: 1 1 220px;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.12);
+  min-width: 220px;
+}
+
+#chess-status h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.status-line {
+  margin: 8px 0;
+  font-weight: 500;
+}
+
+.mode-note {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+@media (max-width: 600px) {
+  .chess-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #chess-status {
+    order: -1;
+  }
+}

--- a/html/chess.html
+++ b/html/chess.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chess</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.css"
+    />
+    <link rel="stylesheet" href="../css/chess.css" />
+  </head>
+  <body>
+    <div class="chess-app">
+      <h1>Chess</h1>
+      <div class="chess-toolbar">
+        <label for="mode-select">
+          Mode
+          <select id="mode-select">
+            <option value="two">2 Player Local</option>
+            <option value="single">Play vs Stockfish</option>
+          </select>
+        </label>
+        <label for="skill-level">
+          Skill Level
+          <input type="range" id="skill-level" min="0" max="20" value="5" />
+          <span id="skill-value">5</span>
+        </label>
+        <button id="new-game">New Game</button>
+      </div>
+      <div class="chess-board-container">
+        <div id="chessboard"></div>
+        <div id="chess-status">
+          <h2>Status</h2>
+          <div id="status-turn" class="status-line">Turn: White</div>
+          <div id="status-info" class="status-line">White to move.</div>
+          <p id="mode-note" class="mode-note"></p>
+        </div>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chess.js@1.0.0/dist/chess.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stockfish@16.1.1/dist/stockfish.js"></script>
+    <script src="../js/boardManager.js"></script>
+    <script src="../js/stockfishEngine.js"></script>
+    <script src="../js/chess.js"></script>
+  </body>
+</html>

--- a/js/boardManager.js
+++ b/js/boardManager.js
@@ -1,0 +1,189 @@
+(function (global) {
+  const DEFAULT_PROMOTION = 'q';
+
+  function getGlobalChess() {
+    if (global && global.Chess) {
+      return global.Chess;
+    }
+    throw new Error('Chess.js is required before creating a BoardManager');
+  }
+
+  function extractMoveParts(moveString) {
+    if (!moveString) {
+      return null;
+    }
+    const from = moveString.slice(0, 2);
+    const to = moveString.slice(2, 4);
+    const promotion = moveString.slice(4) || DEFAULT_PROMOTION;
+    return { from, to, promotion };
+  }
+
+  class BoardManager {
+    constructor(options = {}) {
+      const {
+        elementId = 'chessboard',
+        orientation = 'white',
+        boardFactory,
+        createGame,
+      } = options;
+
+      this.elementId = elementId;
+      this.orientation = orientation;
+      this.createGame = createGame || (() => new (getGlobalChess())());
+      this.players = {
+        white: 'human',
+        black: 'human',
+      };
+      this.afterMoveCallbacks = [];
+      this.game = this.createGame();
+      this.boardFactory = boardFactory || ((config) => {
+        if (!global.Chessboard) {
+          throw new Error('Chessboard.js must be loaded before initializing the board');
+        }
+        return global.Chessboard(this.elementId, config);
+      });
+
+      const config = {
+        draggable: true,
+        position: 'start',
+        orientation: this.orientation,
+        pieceTheme:
+          'https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/img/chesspieces/wikipedia/{piece}.png',
+        onDragStart: this.handleDragStart.bind(this),
+        onDrop: this.handleDrop.bind(this),
+        onSnapEnd: this.syncBoard.bind(this),
+      };
+
+      this.board = this.boardFactory(config);
+    }
+
+    reset() {
+      this.game = this.createGame();
+      this.syncBoard();
+    }
+
+    setPlayers(config = {}) {
+      this.players = {
+        white: config.white || 'human',
+        black: config.black || 'human',
+      };
+    }
+
+    onAfterMove(callback) {
+      if (typeof callback === 'function') {
+        this.afterMoveCallbacks.push(callback);
+      }
+    }
+
+    getCurrentTurn() {
+      return this.game.turn();
+    }
+
+    isGameOver() {
+      return this.game.isGameOver();
+    }
+
+    getFen() {
+      return this.game.fen();
+    }
+
+    attemptMove(from, to, promotion = DEFAULT_PROMOTION) {
+      let move = null;
+      try {
+        move = this.game.move({ from, to, promotion });
+      } catch (error) {
+        move = null;
+      }
+      if (move) {
+        this.syncBoard();
+        this.notifyAfterMove(move);
+      }
+      return move;
+    }
+
+    attemptLocalMove(from, to) {
+      return this.attemptMove(from, to, DEFAULT_PROMOTION);
+    }
+
+    handleDragStart(source, piece) {
+      if (this.isGameOver()) {
+        return false;
+      }
+
+      const pieceColor = piece.charAt(0) === 'w' ? 'w' : 'b';
+      const playersTurn = this.getCurrentTurn();
+
+      if (pieceColor !== playersTurn) {
+        return false;
+      }
+
+      const isHumanTurn =
+        (playersTurn === 'w' && this.players.white === 'human') ||
+        (playersTurn === 'b' && this.players.black === 'human');
+
+      return isHumanTurn;
+    }
+
+    handleDrop(source, target) {
+      if (source === target) {
+        return 'snapback';
+      }
+
+      const isHumanTurn =
+        (this.getCurrentTurn() === 'w' && this.players.white === 'human') ||
+        (this.getCurrentTurn() === 'b' && this.players.black === 'human');
+
+      if (!isHumanTurn) {
+        return 'snapback';
+      }
+
+      const move = this.attemptMove(source, target, DEFAULT_PROMOTION);
+      if (!move) {
+        return 'snapback';
+      }
+
+      return undefined;
+    }
+
+    syncBoard() {
+      if (this.board && typeof this.board.position === 'function') {
+        this.board.position(this.game.fen());
+      }
+    }
+
+    applyEngineMove(moveString) {
+      const moveParts = extractMoveParts(moveString);
+      if (!moveParts) {
+        return null;
+      }
+
+      const move = this.attemptMove(moveParts.from, moveParts.to, moveParts.promotion);
+      return move;
+    }
+
+    isEngineTurn() {
+      const turn = this.getCurrentTurn();
+      return (
+        (turn === 'w' && this.players.white === 'engine') ||
+        (turn === 'b' && this.players.black === 'engine')
+      );
+    }
+
+    notifyAfterMove(move) {
+      const payload = {
+        move,
+        fen: this.getFen(),
+        game: this.game,
+      };
+      this.afterMoveCallbacks.forEach((callback) => {
+        callback(payload);
+      });
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = BoardManager;
+  } else {
+    global.BoardManager = BoardManager;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/js/chess.js
+++ b/js/chess.js
@@ -1,0 +1,169 @@
+(function (global) {
+  function ready(callback) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function describeStatus(game) {
+    if (game.isCheckmate()) {
+      const winner = game.turn() === 'w' ? 'Black' : 'White';
+      return `${winner} wins by checkmate.`;
+    }
+
+    if (game.isDraw()) {
+      return 'Drawn position.';
+    }
+
+    if (game.isCheck()) {
+      const defender = game.turn() === 'w' ? 'White' : 'Black';
+      return `${defender} is in check.`;
+    }
+
+    const turn = game.turn() === 'w' ? 'White' : 'Black';
+    return `${turn} to move.`;
+  }
+
+  ready(() => {
+    const boardElementId = 'chessboard';
+    const modeSelect = document.getElementById('mode-select');
+    const newGameButton = document.getElementById('new-game');
+    const statusTurn = document.getElementById('status-turn');
+    const statusInfo = document.getElementById('status-info');
+    const modeNote = document.getElementById('mode-note');
+    const skillInput = document.getElementById('skill-level');
+    const skillValue = document.getElementById('skill-value');
+
+    if (!global.BoardManager) {
+      throw new Error('BoardManager must be loaded before chess.js');
+    }
+
+    const boardManager = new global.BoardManager({
+      elementId: boardElementId,
+    });
+
+    let engineEnabled = false;
+    let engineMoveInProgress = false;
+    let engineInstance = null;
+    let engineRequestId = 0;
+
+    function ensureEngine() {
+      if (!engineInstance) {
+        if (!global.StockfishEngine) {
+          throw new Error('StockfishEngine must be loaded before enabling single player mode');
+        }
+        engineInstance = new global.StockfishEngine();
+      }
+      return engineInstance;
+    }
+
+    function updateSkillDisplay() {
+      const value = parseInt(skillInput.value, 10);
+      skillValue.textContent = value;
+      if (engineInstance) {
+        engineInstance.setSkillLevel(value);
+      }
+    }
+
+    function updateModeNote() {
+      modeNote.textContent = engineEnabled
+        ? 'You control White. Stockfish will play Black after a short delay.'
+        : 'Both sides are controlled locally. Take turns at the board!';
+      skillInput.disabled = !engineEnabled;
+    }
+
+    function updateStatus() {
+      const turn = boardManager.getCurrentTurn() === 'w' ? 'White' : 'Black';
+      statusTurn.textContent = `Turn: ${turn}`;
+      statusInfo.textContent = describeStatus(boardManager.game);
+    }
+
+    async function triggerEngineMove() {
+      if (!engineEnabled || engineMoveInProgress) {
+        return;
+      }
+
+      if (boardManager.isGameOver()) {
+        return;
+      }
+
+      if (!boardManager.isEngineTurn()) {
+        return;
+      }
+
+      engineMoveInProgress = true;
+      const requestId = ++engineRequestId;
+      const engine = ensureEngine();
+      const fen = boardManager.getFen();
+      const move = await engine.requestMove(fen);
+      engineMoveInProgress = false;
+
+      if (requestId !== engineRequestId) {
+        return;
+      }
+
+      if (!engineEnabled) {
+        return;
+      }
+
+      if (move) {
+        const applied = boardManager.applyEngineMove(move);
+        if (applied) {
+          updateStatus();
+        }
+      }
+    }
+
+    boardManager.onAfterMove(() => {
+      updateStatus();
+      triggerEngineMove();
+    });
+
+    newGameButton.addEventListener('click', () => {
+      engineMoveInProgress = false;
+      engineRequestId += 1;
+      if (engineInstance) {
+        engineInstance.stop();
+      }
+      boardManager.reset();
+      if (engineEnabled) {
+        boardManager.setPlayers({ white: 'human', black: 'engine' });
+      } else {
+        boardManager.setPlayers({ white: 'human', black: 'human' });
+      }
+      updateStatus();
+      updateModeNote();
+    });
+
+    modeSelect.addEventListener('change', (event) => {
+      const value = event.target.value;
+      if (value === 'single') {
+        engineEnabled = true;
+        boardManager.setPlayers({ white: 'human', black: 'engine' });
+        ensureEngine();
+        updateSkillDisplay();
+      } else {
+        engineEnabled = false;
+        engineRequestId += 1;
+        if (engineInstance) {
+          engineInstance.stop();
+        }
+        boardManager.setPlayers({ white: 'human', black: 'human' });
+      }
+      updateModeNote();
+      updateStatus();
+      triggerEngineMove();
+    });
+
+    skillInput.addEventListener('input', () => {
+      updateSkillDisplay();
+    });
+
+    boardManager.setPlayers({ white: 'human', black: 'human' });
+    updateSkillDisplay();
+    updateModeNote();
+    updateStatus();
+  });
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/js/stockfishEngine.js
+++ b/js/stockfishEngine.js
@@ -1,0 +1,197 @@
+(function (global) {
+  const DEFAULT_MOVE_DELAY = 1000;
+  const DEFAULT_THINK_TIME = 500;
+  const DEFAULT_SKILL = 5;
+  const MIN_SKILL = 0;
+  const MAX_SKILL = 20;
+
+  function now() {
+    if (typeof performance !== 'undefined' && performance.now) {
+      return performance.now();
+    }
+    return Date.now();
+  }
+
+  class StockfishEngine {
+    constructor(options = {}) {
+      const {
+        moveDelay = DEFAULT_MOVE_DELAY,
+        thinkTime = DEFAULT_THINK_TIME,
+        skillLevel = DEFAULT_SKILL,
+        stockfishFactory,
+      } = options;
+
+      const factory =
+        stockfishFactory ||
+        (() => {
+          if (typeof global.Stockfish === 'function') {
+            return global.Stockfish();
+          }
+          throw new Error('Stockfish.js must be loaded before using StockfishEngine');
+        });
+
+      this.worker = factory();
+      this.moveDelay = moveDelay;
+      this.thinkTime = thinkTime;
+      this.skillLevel = this.clampSkill(skillLevel);
+      this.isReady = false;
+      this.messageHandlers = new Set();
+      this.pendingRequest = null;
+
+      this.handleMessage = this.handleMessage.bind(this);
+      if (typeof this.worker.addEventListener === 'function') {
+        this.worker.addEventListener('message', this.handleMessage);
+      } else {
+        this.worker.onmessage = this.handleMessage;
+      }
+
+      this.ready = new Promise((resolve) => {
+        this.resolveReady = resolve;
+      });
+
+      this.bootstrap();
+    }
+
+    bootstrap() {
+      this.post('uci');
+      this.post('isready');
+    }
+
+    clampSkill(level) {
+      if (level < MIN_SKILL) return MIN_SKILL;
+      if (level > MAX_SKILL) return MAX_SKILL;
+      return level;
+    }
+
+    post(command) {
+      if (this.worker && typeof this.worker.postMessage === 'function') {
+        this.worker.postMessage(command);
+      }
+    }
+
+    cancelPendingRequest(result = null) {
+      if (!this.pendingRequest) {
+        return;
+      }
+
+      const request = this.pendingRequest;
+      this.pendingRequest = null;
+
+      if (request.handler) {
+        this.messageHandlers.delete(request.handler);
+        request.handler = null;
+      }
+
+      if (request.timerId) {
+        clearTimeout(request.timerId);
+        request.timerId = null;
+      }
+
+      if (!request.resolved) {
+        request.resolved = true;
+        request.resolve(result);
+      }
+    }
+
+    stop() {
+      this.post('stop');
+      this.cancelPendingRequest(null);
+      this.messageHandlers.clear();
+    }
+
+    handleMessage(event) {
+      const data = typeof event === 'string' ? event : event.data;
+      if (typeof data !== 'string') {
+        return;
+      }
+
+      if (data.includes('readyok') && !this.isReady) {
+        this.isReady = true;
+        this.setSkillLevel(this.skillLevel);
+        if (typeof this.resolveReady === 'function') {
+          this.resolveReady();
+          this.resolveReady = null;
+        }
+        return;
+      }
+
+      if (data.startsWith('bestmove')) {
+        const parts = data.split(' ');
+        const move = parts[1];
+        this.messageHandlers.forEach((handler) => handler(move));
+      }
+    }
+
+    async requestMove(fen) {
+      await this.ready;
+      this.cancelPendingRequest(null);
+
+      const startTime = now();
+
+      this.post(`position fen ${fen}`);
+
+      const thinkDelay = Math.max(0, this.moveDelay - this.thinkTime);
+
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          this.post(`go movetime ${this.thinkTime}`);
+          resolve();
+        }, thinkDelay);
+      });
+
+      return new Promise((resolve) => {
+        const request = {
+          resolve,
+          handler: null,
+          timerId: null,
+          resolved: false,
+        };
+
+        request.handler = (move) => {
+          this.messageHandlers.delete(request.handler);
+          const elapsed = now() - startTime;
+          const remaining = Math.max(0, this.moveDelay - elapsed);
+          request.timerId = setTimeout(() => {
+            this.pendingRequest = null;
+            if (!request.resolved) {
+              request.resolved = true;
+              resolve(move);
+            }
+          }, remaining);
+        };
+
+        this.messageHandlers.add(request.handler);
+        this.pendingRequest = request;
+      });
+    }
+
+    setSkillLevel(level) {
+      const nextLevel = this.clampSkill(level);
+      this.skillLevel = nextLevel;
+      if (this.isReady) {
+        this.post(`setoption name Skill Level value ${nextLevel}`);
+      }
+    }
+
+    dispose() {
+      this.stop();
+      if (this.worker) {
+        if (typeof this.worker.terminate === 'function') {
+          this.worker.terminate();
+        }
+        if (typeof this.worker.removeEventListener === 'function') {
+          this.worker.removeEventListener('message', this.handleMessage);
+        } else {
+          this.worker.onmessage = null;
+        }
+      }
+      this.messageHandlers.clear();
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = StockfishEngine;
+  } else {
+    global.StockfishEngine = StockfishEngine;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/user-event": "^14.6.1",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.0",
+        "chess.js": "^1.0.0",
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.8.0",
         "gh-pages": "^6.0.0",
@@ -4249,6 +4250,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "html-webpack-plugin": "^5.5.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.1.2",
+    "chess.js": "^1.0.0",
     "style-loader": "^3.3.0",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0",

--- a/src/chess/__tests__/chess.test.js
+++ b/src/chess/__tests__/chess.test.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const path = require('path');
+const { Chess } = require('chess.js');
+
+const BoardManager = require('../../../js/boardManager.js');
+const StockfishEngine = require('../../../js/stockfishEngine.js');
+
+class FakeWorker {
+  constructor() {
+    this.postMessage = jest.fn();
+    this.listeners = new Set();
+  }
+
+  addEventListener(type, handler) {
+    if (type === 'message') {
+      this.listeners.add(handler);
+    }
+  }
+
+  removeEventListener(type, handler) {
+    if (type === 'message') {
+      this.listeners.delete(handler);
+    }
+  }
+
+  emit(data) {
+    this.listeners.forEach((handler) => handler({ data }));
+  }
+}
+
+describe('BoardManager', () => {
+  beforeEach(() => {
+    global.Chess = Chess;
+  });
+
+  afterEach(() => {
+    delete global.Chess;
+  });
+
+  test('enforces legal local moves in two-player mode', () => {
+    const boardFactory = jest.fn().mockImplementation(() => ({
+      position: jest.fn(),
+    }));
+
+    const manager = new BoardManager({
+      boardFactory,
+      createGame: () => new Chess(),
+    });
+
+    manager.setPlayers({ white: 'human', black: 'human' });
+
+    const legalMove = manager.attemptLocalMove('e2', 'e4');
+    expect(legalMove).not.toBeNull();
+
+    const illegalMove = manager.attemptLocalMove('e2', 'e5');
+    expect(illegalMove).toBeNull();
+
+    const blackReply = manager.attemptLocalMove('e7', 'e5');
+    expect(blackReply).not.toBeNull();
+  });
+});
+
+describe('StockfishEngine', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete global.Stockfish;
+  });
+
+  test('waits one second before resolving the engine move', async () => {
+    const worker = new FakeWorker();
+    global.Stockfish = jest.fn(() => worker);
+
+    const engine = new StockfishEngine({ moveDelay: 1000, thinkTime: 500 });
+
+    worker.emit('readyok');
+    await engine.ready;
+
+    const movePromise = engine.requestMove('startpos');
+    await Promise.resolve();
+
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    const commands = worker.postMessage.mock.calls.map(([command]) => command);
+    expect(commands).toContain('go movetime 500');
+    const goIndex = commands.lastIndexOf('go movetime 500');
+    const positionIndex = commands.lastIndexOf('position fen startpos');
+    expect(goIndex).toBeGreaterThan(positionIndex);
+
+    let resolved = false;
+    movePromise.then(() => {
+      resolved = true;
+    });
+
+    worker.emit('bestmove e2e4');
+
+    jest.advanceTimersByTime(499);
+    expect(resolved).toBe(false);
+
+    jest.advanceTimersByTime(1);
+    await expect(movePromise).resolves.toBe('e2e4');
+  });
+});
+
+describe('Chess HTML integration', () => {
+  test('references the CDN hosted Stockfish script', () => {
+    const htmlPath = path.resolve(__dirname, '../../../html/chess.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    expect(html).toMatch(/cdn.jsdelivr.net\/npm\/stockfish/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a standalone chess HTML entry point that loads the board, chess rules, and Stockfish from CDNs with UI controls for mode and skill level
- implement board and engine management modules plus orchestration to support local play and Stockfish responses with configurable timing
- add styling, documentation, and Jest tests covering move legality, engine timing, and CDN integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cadaf4b3f0832b8f24d22aa89619a1