### PR TITLE
Add CirclePong futuristic canvas app

### DIFF
--- a/APPS.md
+++ b/APPS.md
@@ -18,6 +18,12 @@ Snake Game modernizes the classic grid chase with keyboard-friendly controls, re
 - Publish leaderboards and social sharing to encourage friendly competition.
 - Offer touch controls and haptic feedback for mobile and tablet players.
 
+## CirclePong
+CirclePong reimagines Pong inside a circular quartz arena with luminous marble flourishes. Paddles glide along arcs of a perfect ring, defending their hemisphere as a glowing sphere rebounds with crisp physicality. Solo pilots can spar with an adaptive AI or battle locally, with rounds racing to three points amid ethereal neon scoring overlays.
+- Layer in dynamic backgrounds with refraction shaders for evolving ambience.
+- Introduce adjustable paddle arcs and experimental power-ups for advanced modes.
+- Extend online multiplayer with latency-friendly predictive inputs and leaderboards.
+
 ## Coming Soon
 Coming Soon placeholder reserves space for upcoming experiments within the launcher. It reminds contributors to ideate beyond the initial trio, surfacing metadata hooks, routing, and categories that future experiences will inherit. Documented scaffolding ensures new concepts launch smoothly while signaling a living roadmap to collaborators continuously exploring the ecosystem's potential.
 - Define a template generator for scaffolding new app directories, tests, and documentation.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A small, modular React playground bundling multiple apps behind a simple launche
 - Day Switcher (switch between days of the week)
 - NPomodoro (Pomodoro timer)
 - Snake (classic snake game)
+- CirclePong (futuristic circular pong arena)
 
 ## Live demo
 

--- a/src/apps/CirclePongApp/CirclePongApp.css
+++ b/src/apps/CirclePongApp/CirclePongApp.css
@@ -1,0 +1,246 @@
+.circle-pong {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: 2.5rem 1rem;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.12), rgba(31, 41, 55, 0.92) 65%);
+  color: #fdfdfd;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+.circle-pong__menu {
+  max-width: 28rem;
+  width: 100%;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  background: rgba(31, 41, 55, 0.85);
+  border: 1px solid rgba(147, 197, 253, 0.3);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.55);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.circle-pong__title {
+  font-size: 2.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fdfdfd;
+  text-shadow: 0 0 32px rgba(147, 197, 253, 0.5);
+}
+
+.circle-pong__subtitle {
+  font-size: 1rem;
+  color: rgba(209, 213, 219, 0.78);
+  line-height: 1.6;
+}
+
+.circle-pong__menu-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.circle-pong__menu-options button {
+  padding: 0.85rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(147, 197, 253, 0.4);
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.25), rgba(56, 189, 248, 0.25));
+  color: #fdfdfd;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease;
+  box-shadow: 0 15px 30px rgba(56, 189, 248, 0.25);
+}
+
+.circle-pong__menu-options button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.35);
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.35), rgba(56, 189, 248, 0.35));
+}
+
+.circle-pong__menu-options button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.4);
+}
+
+.circle-pong__tips {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: rgba(209, 213, 219, 0.9);
+}
+
+.circle-pong__stage {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle-pong__canvas {
+  width: 520px;
+  height: 520px;
+  border-radius: 50%;
+  border: 1px solid rgba(147, 197, 253, 0.2);
+  background: radial-gradient(circle at 30% 30%, rgba(253, 253, 253, 0.08), rgba(31, 41, 55, 0.8));
+  box-shadow: 0 40px 100px rgba(15, 23, 42, 0.55);
+}
+
+.circle-pong__hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.5rem;
+}
+
+.circle-pong__scoreboard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.circle-pong__score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(31, 41, 55, 0.65);
+  border: 1px solid rgba(147, 197, 253, 0.35);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.45);
+}
+
+.circle-pong__score .label {
+  font-size: 0.75rem;
+  color: rgba(209, 213, 219, 0.85);
+}
+
+.circle-pong__score .value {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: #fdfdfd;
+}
+
+.circle-pong__mode {
+  padding: 0.6rem 1.6rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.25);
+  color: #fdfdfd;
+  font-weight: 600;
+}
+
+.circle-pong__controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.85rem;
+  color: rgba(209, 213, 219, 0.8);
+}
+
+.circle-pong__controls .divider {
+  width: 40px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(147, 197, 253, 0), rgba(147, 197, 253, 0.5), rgba(147, 197, 253, 0));
+}
+
+.circle-pong__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(31, 41, 55, 0.65);
+  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  text-align: center;
+  padding: 2rem;
+  border-radius: 50%;
+}
+
+.circle-pong__overlay h2 {
+  font-size: 2.3rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 0 30px rgba(147, 197, 253, 0.6);
+  margin: 0;
+}
+
+.circle-pong__overlay p {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(209, 213, 219, 0.88);
+}
+
+.circle-pong__overlay-actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.circle-pong__overlay-actions button {
+  pointer-events: auto;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(147, 197, 253, 0.4);
+  background: linear-gradient(135deg, rgba(147, 197, 253, 0.35), rgba(56, 189, 248, 0.35));
+  color: #fdfdfd;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.3);
+}
+
+.circle-pong__overlay-actions button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 42px rgba(56, 189, 248, 0.42);
+}
+
+.circle-pong__overlay-actions button:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.45);
+}
+
+@media (max-width: 640px) {
+  .circle-pong {
+    padding: 1.5rem 0.5rem;
+  }
+
+  .circle-pong__menu {
+    padding: 2rem 1.5rem;
+  }
+
+  .circle-pong__canvas {
+    width: 360px;
+    height: 360px;
+  }
+
+  .circle-pong__hud {
+    padding: 1rem;
+  }
+
+  .circle-pong__overlay {
+    border-radius: 2rem;
+  }
+}

--- a/src/apps/CirclePongApp/CirclePongApp.js
+++ b/src/apps/CirclePongApp/CirclePongApp.js
@@ -1,0 +1,370 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import './CirclePongApp.css';
+import {
+  DEFAULT_OPTIONS,
+  createInitialState,
+  createInputState,
+  stepGame,
+  computeAiInput,
+} from './gameLogic';
+
+const FULL_CIRCLE = Math.PI * 2;
+const CANVAS_SIZE = DEFAULT_OPTIONS.boardSize;
+
+function drawGrid(ctx, size) {
+  ctx.save();
+  ctx.strokeStyle = 'rgba(147, 197, 253, 0.08)';
+  ctx.lineWidth = 1;
+  const spacing = 36;
+  for (let x = spacing; x < size; x += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, size);
+    ctx.stroke();
+  }
+  for (let y = spacing; y < size; y += spacing) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(size, y);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawBoard(ctx, state) {
+  const { options, center } = state;
+  ctx.save();
+  const gradient = ctx.createRadialGradient(
+    center.x,
+    center.y,
+    options.radius * 0.3,
+    center.x,
+    center.y,
+    options.radius
+  );
+  gradient.addColorStop(0, 'rgba(253, 253, 253, 0.18)');
+  gradient.addColorStop(1, 'rgba(209, 213, 219, 0.05)');
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.arc(center.x, center.y, options.radius, 0, FULL_CIRCLE);
+  ctx.fill();
+
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = 'rgba(147, 197, 253, 0.35)';
+  ctx.shadowBlur = 14;
+  ctx.shadowColor = 'rgba(147, 197, 253, 0.35)';
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawPaddle(ctx, state, paddle, color) {
+  const { options, center } = state;
+  const arc = paddle.arc ?? options.paddleArc;
+  const startAngle = paddle.angle - arc / 2;
+  const endAngle = paddle.angle + arc / 2;
+
+  ctx.save();
+  ctx.lineWidth = 16;
+  ctx.lineCap = 'round';
+  ctx.strokeStyle = color;
+  ctx.shadowBlur = 20;
+  ctx.shadowColor = color;
+  ctx.beginPath();
+  ctx.arc(center.x, center.y, options.radius - 10, startAngle, endAngle, false);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawBall(ctx, state) {
+  const { ball, options } = state;
+  if (!ball) {
+    return;
+  }
+
+  ctx.save();
+  const glow = ctx.createRadialGradient(
+    ball.x - options.ballRadius / 2,
+    ball.y - options.ballRadius / 2,
+    options.ballRadius / 4,
+    ball.x,
+    ball.y,
+    options.ballRadius
+  );
+  glow.addColorStop(0, 'rgba(253, 253, 253, 0.92)');
+  glow.addColorStop(1, 'rgba(147, 197, 253, 0.25)');
+  ctx.fillStyle = glow;
+  ctx.shadowBlur = 18;
+  ctx.shadowColor = 'rgba(147, 197, 253, 0.55)';
+  ctx.beginPath();
+  ctx.arc(ball.x, ball.y, options.ballRadius, 0, FULL_CIRCLE);
+  ctx.fill();
+  ctx.restore();
+}
+
+function renderScene(ctx, state) {
+  const size = state.options.boardSize;
+  ctx.clearRect(0, 0, size, size);
+  ctx.save();
+  ctx.fillStyle = '#1f2937';
+  ctx.fillRect(0, 0, size, size);
+  drawGrid(ctx, size);
+  drawBoard(ctx, state);
+  drawPaddle(ctx, state, state.paddles.player1, 'rgba(147, 197, 253, 0.85)');
+  drawPaddle(ctx, state, state.paddles.player2, 'rgba(56, 189, 248, 0.85)');
+  drawBall(ctx, state);
+  ctx.restore();
+}
+
+function useKeyboardControls(active, inputRef) {
+  useEffect(() => {
+    if (!active) {
+      inputRef.current.player1 = 0;
+      inputRef.current.player2 = 0;
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      const key = event.key;
+      if (key === 'ArrowUp' || key === 'ArrowDown') {
+        event.preventDefault();
+      }
+      switch (key) {
+        case 'w':
+        case 'W':
+          inputRef.current.player1 = -1;
+          break;
+        case 's':
+        case 'S':
+          inputRef.current.player1 = 1;
+          break;
+        case 'ArrowUp':
+          inputRef.current.player2 = 1;
+          break;
+        case 'ArrowDown':
+          inputRef.current.player2 = -1;
+          break;
+        default:
+          break;
+      }
+    };
+
+    const handleKeyUp = (event) => {
+      switch (event.key) {
+        case 'w':
+        case 'W':
+        case 's':
+        case 'S':
+          inputRef.current.player1 = 0;
+          break;
+        case 'ArrowUp':
+        case 'ArrowDown':
+          inputRef.current.player2 = 0;
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [active, inputRef]);
+}
+
+const CirclePongApp = () => {
+  const canvasRef = useRef(null);
+  const contextRef = useRef(null);
+  const animationFrameRef = useRef(null);
+  const lastTimestampRef = useRef(null);
+  const gameStateRef = useRef(null);
+  const inputRef = useRef(createInputState());
+
+  const [view, setView] = useState('menu');
+  const [mode, setMode] = useState(null);
+  const [scores, setScores] = useState({ player1: 0, player2: 0 });
+  const [winner, setWinner] = useState(null);
+
+  useKeyboardControls(view === 'game', inputRef);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = CANVAS_SIZE * ratio;
+    canvas.height = CANVAS_SIZE * ratio;
+    canvas.style.width = `${CANVAS_SIZE}px`;
+    canvas.style.height = `${CANVAS_SIZE}px`;
+    const ctx = canvas.getContext('2d');
+    ctx.scale(ratio, ratio);
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    contextRef.current = ctx;
+    ctx.fillStyle = '#1f2937';
+    ctx.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
+  }, []);
+
+  const startGame = useCallback((selectedMode) => {
+    const state = createInitialState({ mode: selectedMode });
+    gameStateRef.current = state;
+    inputRef.current = createInputState();
+    lastTimestampRef.current = null;
+    setScores({ player1: 0, player2: 0 });
+    setWinner(null);
+    setMode(selectedMode);
+    setView('game');
+
+    const ctx = contextRef.current;
+    if (ctx) {
+      renderScene(ctx, state);
+    }
+  }, []);
+
+  const stopAnimation = useCallback(() => {
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+  }, []);
+
+  const returnToMenu = useCallback(() => {
+    stopAnimation();
+    setView('menu');
+    setMode(null);
+    setWinner(null);
+    gameStateRef.current = null;
+    inputRef.current = createInputState();
+  }, [stopAnimation]);
+
+  useEffect(() => {
+    if (view !== 'game') {
+      stopAnimation();
+      return undefined;
+    }
+
+    const ctx = contextRef.current;
+    const state = gameStateRef.current;
+    if (!ctx || !state) {
+      return undefined;
+    }
+
+    const loop = (timestamp) => {
+      const previous = lastTimestampRef.current ?? timestamp;
+      const delta = (timestamp - previous) / 1000;
+      lastTimestampRef.current = timestamp;
+
+      const inputs = { ...inputRef.current };
+      if (state.mode === 'single') {
+        inputs.player2 = computeAiInput(state, delta);
+      }
+
+      const events = stepGame(state, inputs, delta);
+      if (events.length) {
+        events.forEach((event) => {
+          if (event.type === 'score') {
+            setScores(event.scores);
+          }
+          if (event.type === 'win') {
+            setWinner(event.winner);
+            setView('win');
+          }
+        });
+      }
+
+      renderScene(ctx, state);
+
+      if (state.isRunning) {
+        animationFrameRef.current = requestAnimationFrame(loop);
+      }
+    };
+
+    animationFrameRef.current = requestAnimationFrame(loop);
+    return () => {
+      stopAnimation();
+    };
+  }, [view, stopAnimation]);
+
+  const playAgain = useCallback(() => {
+    if (mode) {
+      startGame(mode);
+    } else {
+      returnToMenu();
+    }
+  }, [mode, returnToMenu, startGame]);
+
+  const renderWinnerTitle = () => {
+    if (!winner) {
+      return null;
+    }
+    const label = mode === 'single' && winner === 'player2' ? 'AI' : winner === 'player1' ? 'Player 1' : 'Player 2';
+    return `${label} Wins`;
+  };
+
+  return (
+    <div className="circle-pong" data-view={view}>
+      {view === 'menu' && (
+        <div className="circle-pong__menu">
+          <h1 className="circle-pong__title">CirclePong</h1>
+          <p className="circle-pong__subtitle">Futuristic quartz-bound pong inside a luminous ring.</p>
+          <div className="circle-pong__menu-options">
+            <button type="button" onClick={() => startGame('single')}>
+              1 Player vs AI
+            </button>
+            <button type="button" onClick={() => startGame('versus')}>
+              2 Player Local
+            </button>
+          </div>
+          <div className="circle-pong__tips">
+            <span>Player 1: W / S (clockwise / counterclockwise)</span>
+            <span>Player 2: ↑ / ↓ (clockwise / counterclockwise)</span>
+          </div>
+        </div>
+      )}
+
+      {(view === 'game' || view === 'win') && (
+        <div className="circle-pong__stage">
+          <canvas ref={canvasRef} className="circle-pong__canvas" />
+          <div className="circle-pong__hud">
+            <div className="circle-pong__scoreboard">
+              <div className="circle-pong__score circle-pong__score--p1">
+                <span className="label">Player 1</span>
+                <span className="value">{scores.player1}</span>
+              </div>
+              <div className="circle-pong__mode">{mode === 'single' ? 'vs AI' : 'Local Versus'}</div>
+              <div className="circle-pong__score circle-pong__score--p2">
+                <span className="label">{mode === 'single' ? 'AI' : 'Player 2'}</span>
+                <span className="value">{scores.player2}</span>
+              </div>
+            </div>
+            <div className="circle-pong__controls">
+              <span>W/S</span>
+              <span className="divider" />
+              <span>↑/↓</span>
+            </div>
+          </div>
+
+          {view === 'win' && (
+            <div className="circle-pong__overlay">
+              <h2>{renderWinnerTitle()}</h2>
+              <p>First to three points claims the quartz crown.</p>
+              <div className="circle-pong__overlay-actions">
+                <button type="button" onClick={playAgain}>
+                  Play Again
+                </button>
+                <button type="button" onClick={returnToMenu}>
+                  Back to Menu
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CirclePongApp;

--- a/src/apps/CirclePongApp/__tests__/gameLogic.test.js
+++ b/src/apps/CirclePongApp/__tests__/gameLogic.test.js
@@ -1,0 +1,75 @@
+import {
+  createInitialState,
+  createInputState,
+  stepGame,
+  normalizeAngle,
+} from '../gameLogic';
+
+describe('CirclePong game logic', () => {
+  test('player paddles stay within their half-circle range', () => {
+    const state = createInitialState({ mode: 'versus' });
+    const input = createInputState();
+    input.player1 = 1;
+    for (let i = 0; i < 200; i += 1) {
+      stepGame(state, input, 0.016);
+    }
+    const p1Range = state.ranges.player1;
+    expect(normalizeAngle(state.paddles.player1.angle)).toBeLessThanOrEqual(normalizeAngle(p1Range.end) + 1e-6);
+
+    input.player1 = -1;
+    for (let i = 0; i < 200; i += 1) {
+      stepGame(state, input, 0.016);
+    }
+    expect(normalizeAngle(state.paddles.player1.angle)).toBeGreaterThanOrEqual(normalizeAngle(p1Range.start) - 1e-6);
+  });
+
+  test('ball reflects when striking a paddle arc', () => {
+    const state = createInitialState({ mode: 'versus' });
+    state.paddles.player1.angle = Math.PI; // centered on left side
+    state.ball.x = state.center.x - (state.options.radius - state.options.ballRadius - 1);
+    state.ball.y = state.center.y;
+    state.ball.vx = -state.options.ballSpeed;
+    state.ball.vy = 0;
+
+    stepGame(state, createInputState(), 0.016);
+
+    expect(state.ball.vx).toBeGreaterThan(0);
+    const speed = Math.hypot(state.ball.vx, state.ball.vy);
+    expect(speed).toBeCloseTo(state.options.ballSpeed, 3);
+  });
+
+  test('missing a paddle awards a point to the opponent', () => {
+    const state = createInitialState({ mode: 'versus' });
+    state.paddles.player1.angle = normalizeAngle(state.ranges.player1.end); // bottom of arc
+
+    const missAngle = (Math.PI / 2) + 0.4;
+    const distance = state.options.radius - state.options.ballRadius - 0.5;
+    state.ball.x = state.center.x + Math.cos(missAngle) * distance;
+    state.ball.y = state.center.y + Math.sin(missAngle) * distance;
+    state.ball.vx = Math.cos(missAngle) * state.options.ballSpeed;
+    state.ball.vy = Math.sin(missAngle) * state.options.ballSpeed;
+
+    const events = stepGame(state, createInputState(), 0.016);
+    expect(state.scores.player2).toBe(1);
+    expect(events.some(event => event.type === 'score' && event.scorer === 'player2')).toBe(true);
+  });
+
+  test('reaching three points triggers a win condition', () => {
+    const state = createInitialState({ mode: 'versus' });
+    state.scores.player1 = 2;
+    state.paddles.player2.angle = normalizeAngle(state.ranges.player2.start);
+
+    const missAngle = 0.3;
+    const distance = state.options.radius - state.options.ballRadius - 0.5;
+    state.ball.x = state.center.x + Math.cos(missAngle) * distance;
+    state.ball.y = state.center.y + Math.sin(missAngle) * distance;
+    state.ball.vx = Math.cos(missAngle) * state.options.ballSpeed;
+    state.ball.vy = Math.sin(missAngle) * state.options.ballSpeed;
+
+    const events = stepGame(state, createInputState(), 0.016);
+
+    expect(state.winner).toBe('player1');
+    expect(state.isRunning).toBe(false);
+    expect(events.some(event => event.type === 'win' && event.winner === 'player1')).toBe(true);
+  });
+});

--- a/src/apps/CirclePongApp/gameLogic.js
+++ b/src/apps/CirclePongApp/gameLogic.js
@@ -1,0 +1,257 @@
+const TAU = Math.PI * 2;
+
+export const DEFAULT_OPTIONS = {
+  boardSize: 520,
+  radius: 220,
+  paddleArc: (30 * Math.PI) / 180,
+  paddleAngularSpeed: Math.PI / 1.8, // ~100 deg/sec
+  ballSpeed: 280,
+  ballRadius: 10,
+  winScore: 3,
+  aiReactionDelay: 0.18,
+  aiMaxAngularSpeed: Math.PI / 2.5,
+  serveAngles: [0, Math.PI / 14, -Math.PI / 14],
+};
+
+export function normalizeAngle(angle) {
+  let value = angle % TAU;
+  if (value < 0) {
+    value += TAU;
+  }
+  return value;
+}
+
+export function shortestAngleDiff(a, b) {
+  const diff = normalizeAngle(a) - normalizeAngle(b);
+  return ((diff + Math.PI) % TAU) - Math.PI;
+}
+
+export function isAngleBetween(angle, start, end) {
+  const normStart = normalizeAngle(start);
+  const normEnd = normalizeAngle(end);
+  const normAngle = normalizeAngle(angle);
+  const length = (normEnd - normStart + TAU) % TAU;
+  const relative = (normAngle - normStart + TAU) % TAU;
+  return relative <= length + 1e-6;
+}
+
+export function clampAngleToRange(angle, range) {
+  const normAngle = normalizeAngle(angle);
+  if (isAngleBetween(normAngle, range.start, range.end)) {
+    return normAngle;
+  }
+  const start = normalizeAngle(range.start);
+  const end = normalizeAngle(range.end);
+  const diffStart = Math.abs(shortestAngleDiff(normAngle, start));
+  const diffEnd = Math.abs(shortestAngleDiff(normAngle, end));
+  return diffStart <= diffEnd ? start : end;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function createServeBall(state, toward = 'player2') {
+  const { options, center } = state;
+  const baseAngle = toward === 'player1' ? Math.PI : 0;
+  const offset = options.serveAngles[state.nextServeIndex % options.serveAngles.length];
+  state.nextServeIndex = (state.nextServeIndex + 1) % options.serveAngles.length;
+  const angle = normalizeAngle(baseAngle + offset);
+  const vx = Math.cos(angle) * options.ballSpeed;
+  const vy = Math.sin(angle) * options.ballSpeed;
+  return {
+    x: center.x,
+    y: center.y,
+    vx,
+    vy,
+    speed: options.ballSpeed,
+  };
+}
+
+export function createInitialState(config = {}) {
+  const { mode = 'versus', ...optionOverrides } = config;
+  const options = { ...DEFAULT_OPTIONS, ...optionOverrides };
+  const boardSize = options.boardSize;
+  const center = { x: boardSize / 2, y: boardSize / 2 };
+  const ranges = {
+    player1: {
+      start: Math.PI / 2,
+      end: (3 * Math.PI) / 2,
+    },
+    player2: {
+      start: (3 * Math.PI) / 2,
+      end: Math.PI / 2,
+    },
+  };
+
+  const paddles = {
+    player1: {
+      angle: Math.PI,
+      arc: options.paddleArc,
+      angularVelocity: 0,
+    },
+    player2: {
+      angle: 0,
+      arc: options.paddleArc,
+      angularVelocity: 0,
+    },
+  };
+
+  const state = {
+    options,
+    mode,
+    center,
+    ranges,
+    paddles,
+    ball: null,
+    scores: {
+      player1: 0,
+      player2: 0,
+    },
+    isRunning: true,
+    winner: null,
+    nextServeIndex: 0,
+    ai: {
+      targetAngle: paddles.player2.angle,
+      reactionTimer: 0,
+    },
+  };
+
+  state.ball = createServeBall(state, 'player2');
+  return state;
+}
+
+export function createInputState() {
+  return {
+    player1: 0,
+    player2: 0,
+  };
+}
+
+function updatePaddle(state, playerKey, intent, deltaSeconds) {
+  const { paddles, ranges, options } = state;
+  const paddle = paddles[playerKey];
+  const range = ranges[playerKey];
+  const clampedIntent = clamp(intent, -1, 1);
+  const angleDelta = clampedIntent * options.paddleAngularSpeed * deltaSeconds;
+  const nextAngle = clampAngleToRange(paddle.angle + angleDelta, range);
+  if (deltaSeconds > 0) {
+    paddle.angularVelocity = (nextAngle - paddle.angle) / deltaSeconds;
+  } else {
+    paddle.angularVelocity = 0;
+  }
+  paddle.angle = nextAngle;
+}
+
+function reflectBallFromNormal(ball, normal, targetSpeed) {
+  const dot = ball.vx * normal.x + ball.vy * normal.y;
+  ball.vx -= 2 * dot * normal.x;
+  ball.vy -= 2 * dot * normal.y;
+  const magnitude = Math.hypot(ball.vx, ball.vy) || 1;
+  const speed = targetSpeed ?? ball.speed;
+  ball.vx = (ball.vx / magnitude) * speed;
+  ball.vy = (ball.vy / magnitude) * speed;
+  ball.speed = speed;
+}
+
+function awardPoint(state, scoringPlayer, events) {
+  state.scores[scoringPlayer] += 1;
+  events.push({ type: 'score', scorer: scoringPlayer, scores: { ...state.scores } });
+
+  if (state.scores[scoringPlayer] >= state.options.winScore) {
+    state.isRunning = false;
+    state.winner = scoringPlayer;
+    state.ball = null;
+    events.push({ type: 'win', winner: scoringPlayer, scores: { ...state.scores } });
+    return;
+  }
+
+  const defender = scoringPlayer === 'player1' ? 'player2' : 'player1';
+  state.ball = createServeBall(state, defender);
+}
+
+export function computeAiInput(state, deltaSeconds) {
+  if (state.mode !== 'single' || !state.ball) {
+    return 0;
+  }
+
+  const { paddles, center, options, ranges, ai } = state;
+  ai.reactionTimer += deltaSeconds;
+  if (ai.reactionTimer >= options.aiReactionDelay) {
+    const ballAngle = normalizeAngle(Math.atan2(state.ball.y - center.y, state.ball.x - center.x));
+    ai.targetAngle = clampAngleToRange(ballAngle, ranges.player2);
+    ai.reactionTimer = 0;
+  }
+
+  if (deltaSeconds <= 0) {
+    return 0;
+  }
+
+  const diff = shortestAngleDiff(ai.targetAngle, paddles.player2.angle);
+  const maxStep = options.aiMaxAngularSpeed * deltaSeconds;
+  const limited = clamp(diff, -maxStep, maxStep);
+  if (Math.abs(limited) < 1e-4) {
+    return 0;
+  }
+  const desired = limited / (options.paddleAngularSpeed * deltaSeconds);
+  return clamp(desired, -1, 1);
+}
+
+function handleBall(state, deltaSeconds, events) {
+  const { ball, options, center, ranges, paddles } = state;
+  if (!ball) {
+    return;
+  }
+
+  ball.x += ball.vx * deltaSeconds;
+  ball.y += ball.vy * deltaSeconds;
+
+  const dx = ball.x - center.x;
+  const dy = ball.y - center.y;
+  const distance = Math.hypot(dx, dy);
+  const boundary = options.radius - options.ballRadius;
+
+  if (distance < boundary) {
+    return;
+  }
+
+  const angle = normalizeAngle(Math.atan2(dy, dx));
+  const onPlayer1Side = isAngleBetween(angle, ranges.player1.start, ranges.player1.end);
+  const player = onPlayer1Side ? 'player1' : 'player2';
+  const paddle = paddles[player];
+  const halfArc = (paddle.arc ?? options.paddleArc) / 2;
+  const diff = Math.abs(shortestAngleDiff(angle, paddle.angle));
+
+  const normal = {
+    x: dx / (distance || 1),
+    y: dy / (distance || 1),
+  };
+
+  if (diff <= halfArc + 1e-3) {
+    const dot = ball.vx * normal.x + ball.vy * normal.y;
+    if (dot > 0) {
+      reflectBallFromNormal(ball, normal, options.ballSpeed);
+      const placement = boundary - 1.5;
+      ball.x = center.x + normal.x * placement;
+      ball.y = center.y + normal.y * placement;
+    }
+    return;
+  }
+
+  const scorer = player === 'player1' ? 'player2' : 'player1';
+  awardPoint(state, scorer, events);
+}
+
+export function stepGame(state, input, deltaSeconds) {
+  const events = [];
+  if (!state.isRunning) {
+    return events;
+  }
+
+  const dt = clamp(Number.isFinite(deltaSeconds) ? deltaSeconds : 0, 0, 0.05);
+  updatePaddle(state, 'player1', input?.player1 ?? 0, dt);
+  const p2Intent = input?.player2 ?? 0;
+  updatePaddle(state, 'player2', p2Intent, dt);
+  handleBall(state, dt, events);
+  return events;
+}

--- a/src/apps/CirclePongApp/index.js
+++ b/src/apps/CirclePongApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './CirclePongApp';

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -71,6 +71,20 @@ export const APP_REGISTRY = {
     created: '2024-01-01',
     featured: true
   },
+  'circle-pong': {
+    id: 'circle-pong',
+    title: 'CirclePong',
+    description: 'Circular quartz arena pong with marble glow and solo/versus modes',
+    icon: '🪩',
+    category: 'Games',
+    component: null,
+    path: '/apps/circle-pong',
+    tags: ['game', 'canvas', 'futuristic'],
+    version: '1.0.0',
+    author: 'OpenAI Assistant',
+    created: '2024-05-01',
+    featured: true
+  },
   'sudoku-coffee': {
     id: 'sudoku-coffee',
     title: 'Sudoku Roast',

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -8,6 +8,7 @@ const NPomodoroApp = React.lazy(() => import('../apps/NPomodoroApp'));
 const SnakeApp = React.lazy(() => import('../apps/SnakeApp'));
 const HexaSnakeApp = React.lazy(() => import('../apps/HexaSnakeApp'));
 const PongApp = React.lazy(() => import('../apps/PongApp'));
+const CirclePongApp = React.lazy(() => import('../apps/CirclePongApp'));
 const SudokuApp = React.lazy(() => import('../apps/SudokuApp'));
 
 const AppContainer = () => {
@@ -38,6 +39,8 @@ const AppContainer = () => {
         return <HexaSnakeApp onBack={handleBackToLauncher} />;
       case 'pong':
         return <PongApp onBack={handleBackToLauncher} />;
+      case 'circle-pong':
+        return <CirclePongApp onBack={handleBackToLauncher} />;
       case 'sudoku-coffee':
         return <SudokuApp onBack={handleBackToLauncher} />;
       default:


### PR DESCRIPTION
## Summary
- add the CirclePong sub-app with a futuristic marble-and-quartz canvas presentation, solo/versus modes, AI paddle tracking, and scoring to three
- implement reusable circular pong physics with paddle constraints, reflections, scoring, and win detection plus targeted unit tests
- register CirclePong in the launcher metadata and update documentation to surface the new experience

## Testing
- npm test -- CirclePongApp

------
https://chatgpt.com/codex/tasks/task_e_68cadd51abbc832ba59e2f01fe2d5b95