### PR TITLE
Add focus mode overlay and planner fixes

### DIFF
--- a/src/apps/NPomodoroApp/NPomodoroApp.css
+++ b/src/apps/NPomodoroApp/NPomodoroApp.css
@@ -7,6 +7,10 @@
   font-family: 'Inter', 'Segoe UI', sans-serif;
 }
 
+body.n-pomodoro-focus-active {
+  overflow: hidden;
+}
+
 .cosmic-backdrop {
   position: fixed;
   inset: 0;
@@ -319,6 +323,12 @@
 .session-focus-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 22px 44px rgba(32, 24, 76, 0.55);
+}
+
+.session-focus-btn.active {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 54px rgba(32, 24, 76, 0.6);
+  filter: brightness(1.05);
 }
 
 .session-remove-btn {
@@ -819,6 +829,146 @@
 .timeline-segment.active {
   border-color: var(--segment-accent, #7f5af0);
   box-shadow: 0 24px 60px rgba(127, 90, 240, 0.45);
+}
+
+.focus-mode-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 8vw, 80px);
+  background: radial-gradient(
+      circle at top,
+      rgba(15, 18, 42, 0.8),
+      rgba(5, 8, 24, 0.92)
+    )
+    fixed;
+  backdrop-filter: blur(18px);
+  z-index: 12;
+  animation: focusOverlayFade 0.35s ease;
+}
+
+.focus-mode-shell {
+  width: min(760px, 100%);
+  max-height: min(92vh, 860px);
+  overflow-y: auto;
+  padding: clamp(28px, 5vw, 44px);
+  border-radius: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 14, 36, 0.9);
+  box-shadow: 0 46px 120px rgba(5, 6, 20, 0.65);
+  backdrop-filter: blur(24px);
+  animation: focusOverlayPop 0.35s ease;
+}
+
+.focus-mode-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: clamp(18px, 4vw, 32px);
+}
+
+.focus-mode-subtitle {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.focus-mode-close {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  background: rgba(255, 255, 255, 0.08);
+  color: #f6f8ff;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.focus-mode-close:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 20px 40px rgba(6, 8, 26, 0.4);
+}
+
+.timer-card.focus-mode-card {
+  margin: 0 auto;
+  max-width: min(640px, 100%);
+  box-shadow: 0 34px 90px rgba(5, 6, 24, 0.6);
+}
+
+.timer-card.focus-mode-card .timer-meta h2 {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+}
+
+.timer-card.focus-mode-card .time-display {
+  font-size: clamp(3.4rem, 12vw, 6rem);
+  letter-spacing: 0.12em;
+}
+
+.timer-card.focus-mode-card .quick-stats {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.timer-card.focus-mode-card .completion-banner {
+  margin-top: clamp(28px, 4vw, 40px);
+}
+
+.focus-mode-shell::-webkit-scrollbar {
+  width: 10px;
+}
+
+.focus-mode-shell::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+}
+
+.focus-mode-shell::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@media (max-width: 720px) {
+  .focus-mode-shell {
+    padding: 24px;
+    border-radius: 28px;
+  }
+
+  .timer-card.focus-mode-card {
+    padding: 32px 24px 28px;
+  }
+
+  .timer-card.focus-mode-card .time-display {
+    font-size: clamp(3rem, 16vw, 5.4rem);
+  }
+}
+
+@keyframes focusOverlayFade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes focusOverlayPop {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .planner-overlay {

--- a/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
+++ b/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NPomodoroApp from '../NPomodoroApp';
+
+describe('NPomodoroApp interactions', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1200
+    });
+  });
+
+  it('toggles focus mode when the focus session button is used', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const sessionCards = screen.getAllByTestId('session-card');
+    const focusButton = within(sessionCards[0]).getByRole('button', {
+      name: /focus session/i
+    });
+
+    await user.click(focusButton);
+
+    expect(screen.getByTestId('focus-mode-overlay')).toBeInTheDocument();
+    expect(focusButton).toHaveTextContent(/exit focus/i);
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('focus-mode-overlay')).not.toBeInTheDocument();
+    });
+    expect(focusButton).toHaveTextContent(/focus session/i);
+  });
+
+  it('removes a session when the remove button is pressed', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const sessionCards = screen.getAllByTestId('session-card');
+    const secondSession = sessionCards[1];
+    expect(within(secondSession).getByDisplayValue(/midday flow/i)).toBeInTheDocument();
+
+    const removeButton = within(secondSession).getByRole('button', { name: /remove/i });
+    await user.click(removeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue(/midday flow/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('adds a new block to the selected session', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const initialSessionCard = screen.getAllByTestId('session-card')[0];
+    const initialBlocks = within(initialSessionCard).getAllByTestId('block-row');
+    const addBlockButton = within(initialSessionCard).getByRole('button', {
+      name: /\+ add block/i
+    });
+
+    await user.click(addBlockButton);
+
+    await waitFor(() => {
+      const updatedSessionCard = screen.getAllByTestId('session-card')[0];
+      const updatedBlocks = within(updatedSessionCard).getAllByTestId('block-row');
+      expect(updatedBlocks).toHaveLength(initialBlocks.length + 1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a focus-mode overlay for the timer, wire the Focus session button to toggle it, and show minute-only timer text
- harden planner actions so removing sessions or adding blocks updates the active view and provide stable test hooks
- style the immersive timer experience and cover the key interactions with Jest tests

## Testing
- npm test -- NPomodoroApp

------
https://chatgpt.com/codex/tasks/task_e_68caf373ebb0832babdf83de5d0ee7f8