### PR TITLE
docs: add contributor guidance and git history log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# g1 Agent Handbook
+
+Welcome! This guide captures expectations for future coding agents collaborating on the g1 React micro app collection. The rules in this file apply to the entire repository.
+
+## Quick start
+- Use Node.js 18 or 20 when possible. Install dependencies with `npm install` before running any scripts.
+- Local development happens through `npm start`, which runs webpack-dev-server on port 3000.
+- The production bundle is created with `npm run build`; assets are emitted to `dist/`.
+
+## Required checks
+- When you change any JavaScript, JSX, or CSS that impacts runtime behaviour or visuals, run `npm test`. The suite is powered by Jest and `@testing-library`.
+- If you touch build tooling (webpack, Babel config, deployment setup) also run `npm run build` to ensure the bundle still compiles.
+- Documentation-only updates (Markdown, plain text) do not require automated checks, but state this explicitly in your summary.
+
+## Code conventions
+- Components live in `src/components/` and in `src/apps/<AppName>/`. Prefer functional React components with hooks.
+- Keep presentation and logic separated: shared layout bits belong in `src/components/`, app-specific state lives under each `src/apps/` folder.
+- Styling is managed with plain CSS files colocated with their components. Reuse existing class names when extending styles and favour flexbox utilities already present in the project.
+- Tests sit next to the code they cover, using Jest + Testing Library. Use `renderWithProviders` from `src/testUtils` when global wrappers are needed.
+
+## When adding or changing apps
+- Register the app in `src/apps/registry.js` and verify the launcher entry in `src/components/AppLauncher` renders correctly.
+- Update `APPS.md` with a short blurb and usage tips for the new experience.
+- If chess-related features change, also revise `CHESS.md` accordingly.
+
+## Documentation expectations
+- Keep this `AGENTS.md` file updated when conventions evolve.
+- Maintain a running log of merges and significant decisions in `GITSTORY.md` (one line per event).
+- Reflect user-facing updates in `README.md` so the GitHub page stays accurate.
+
+Happy hacking!

--- a/GITSTORY.md
+++ b/GITSTORY.md
@@ -1,0 +1,5 @@
+# g1 Git History Log
+
+Use this file to track commits, pushes, merges, and noteworthy design choices. Each event should appear on its own single line for quick scanning.
+
+- 2025-09-17 — docs — Added AGENTS.md guidance, refreshed README documentation, and introduced this log for future history tracking.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ A small, modular React playground bundling multiple apps behind a simple launche
 
 - CirclePong has been renamed to Pong Ring with a refreshed canvas setup so the match starts reliably in the browser.
 
+### Project documentation
+
+- [`AGENTS.md`](AGENTS.md) — contributor handbook outlining required checks, code conventions, and documentation expectations.
+- [`APPS.md`](APPS.md) — catalog of bundled micro apps with behaviour notes.
+- [`CHESS.md`](CHESS.md) — reference for chess-specific helpers and utilities.
+- [`GITSTORY.md`](GITSTORY.md) — chronological log of commits, pushes, merges, and key design decisions.
+
 ## Live demo
 
 [Open on GitHub Pages](https://hardik-s.github.io/g1)


### PR DESCRIPTION
## Summary
- add an AGENTS.md handbook with contributor expectations and required checks
- introduce GITSTORY.md to log commits, pushes, merges, and notable decisions
- update README documentation to reference the new guides

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cb141fb78c832ba76b797385301afa