### PR TITLE
Ensure Chessboard Summit surfaces in launcher and refresh docs

### DIFF
--- a/APPS.md
+++ b/APPS.md
@@ -18,11 +18,35 @@ Snake Game modernizes the classic grid chase with keyboard-friendly controls, re
 - Publish leaderboards and social sharing to encourage friendly competition.
 - Offer touch controls and haptic feedback for mobile and tablet players.
 
+## Hexa-Snake (Bee Edition)
+Hexa-Snake drops players into a honeycomb arena where a cheerful bee chases nectar across a hexagonal grid. Momentum-based turns, buzzing audio cues, and sticky walls encourage thoughtful routing while staying approachable. The board scales responsively so the experience feels polished on desktop or handheld devices alike.
+- Add seasonal nectar types with different point values to deepen scoring variety.
+- Surface optional guidance overlays to help new players understand hex-grid movement.
+- Experiment with daily challenge seeds to keep the routine buzzing.
+
+## Neon Pong
+Neon Pong channels the retro arcade spirit with crisp paddle controls, a responsive scoreboard, and quick session restarts. Solo players can spar with an AI rival while versus mode keeps local showdowns energetic. Animated trails and reactive colour shifts amplify every rally.
+- Layer achievements that reward shut-outs, comeback wins, and volley streaks.
+- Support keyboard remapping plus touch controls for broader accessibility.
+- Introduce difficulty presets so practice, casual, and competitive modes shine.
+
 ## Pong Ring
 Pong Ring reimagines Pong inside a circular quartz arena with luminous marble flourishes. Paddles glide along arcs of a perfect ring, defending their hemisphere as a glowing sphere rebounds with crisp physicality. Solo pilots can spar with an adaptive AI or battle locally, with rounds racing to three points amid ethereal neon scoring overlays.
 - Layer in dynamic backgrounds with refraction shaders for evolving ambience.
 - Introduce adjustable paddle arcs and experimental power-ups for advanced modes.
 - Extend online multiplayer with latency-friendly predictive inputs and leaderboards.
+
+## Sudoku Roast
+Sudoku Roast brings a cozy café vibe to the classic logic puzzle with parchment-inspired styling, smooth note-taking, and an original puzzle generator. Solvers can pencil in candidates, validate progress, and request handcrafted hints without breaking immersion.
+- Track solve statistics, streaks, and difficulty preferences for returning players.
+- Offer colourblind-friendly palettes and alternate fonts for improved readability.
+- Publish a daily featured puzzle with shareable completion cards.
+
+## Chessboard Summit
+Chessboard Summit bundles a draggable board, polished status panel, and optional Stockfish sparring partner into the launcher. It dynamically loads Chessboard.js, Chess.js, and Stockfish from CDNs so the experience stays lightweight while remaining fully featured for casual study sessions or friendly matches.
+- Add move history with PGN export for study or sharing.
+- Surface clocks and increment options to support blitz and rapid play.
+- Explore online multiplayer via WebRTC or WebSockets for remote matches.
 
 ## Coming Soon
 Coming Soon placeholder reserves space for upcoming experiments within the launcher. It reminds contributors to ideate beyond the initial trio, surfacing metadata hooks, routing, and categories that future experiences will inherit. Documented scaffolding ensures new concepts launch smoothly while signaling a living roadmap to collaborators continuously exploring the ecosystem's potential.

--- a/CHESS.md
+++ b/CHESS.md
@@ -10,9 +10,9 @@ Pages alongside the existing catalog of mini apps.
 1. Install dependencies if you have not already: `npm install`.
 2. Run `npm start` and open `http://localhost:3000`, or visit the published site at
    [`https://hardik-s.github.io/g1`](https://hardik-s.github.io/g1).
-3. In the launcher, open the **Chessboard Summit** tile to load the chess experience. The component dynamically loads
-   Chessboard.js, Chess.js, and Stockfish.js from their CDNs and shares styling with the standalone build so the look and feel
-   matches the rest of the suite.
+3. In the launcher, open the **Chessboard Summit** tile—featured on the home view and listed under the **Games** category—to
+   load the chess experience. The component dynamically loads Chessboard.js, Chess.js, and Stockfish.js from their CDNs and
+   shares styling with the standalone build so the look and feel matches the rest of the suite.
 
 ### Standalone fallback
 - Open `html/chess.html` directly in a browser. It loads the exact same board and engine modules via CDN and is useful for

--- a/GITSTORY.md
+++ b/GITSTORY.md
@@ -3,3 +3,4 @@
 Use this file to track commits, pushes, merges, and noteworthy design choices. Each event should appear on its own single line for quick scanning.
 
 - 2025-09-17 — docs — Added AGENTS.md guidance, refreshed README documentation, and introduced this log for future history tracking.
+- 2025-09-18 — feature+docs — Surfaced Chessboard Summit in the launcher list, refreshed documentation for every bundled app, and added coverage to guard the registry entry.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ A small, modular React playground bundling multiple apps behind a simple launche
 
 ### Included apps
 
-- Day Switcher (switch between days of the week)
-- NPomodoro (Pomodoro timer)
-- Snake (classic snake game)
-- Pong Ring (futuristic circular pong arena)
+- Day Switcher — flip through the week with animated transitions.
+- N-Pomodoro — orchestrate multi-activity pomodoro sessions.
+- Snake — chase high scores across a responsive grid.
+- Hexa-Snake (Bee Edition) — guide a bee across a honeycomb board.
+- Neon Pong — duel classic paddles with a neon glow.
+- Pong Ring — rally inside a circular quartz arena.
+- Sudoku Roast — solve handcrafted puzzles in a café setting.
+- Chessboard Summit — play local chess or spar with Stockfish.
 
 ### Notes
 
@@ -92,17 +96,36 @@ g1/
 │   │   ├── AppLauncher.js
 │   │   └── AppLauncher.css
 │   └── apps/
+│       ├── ChessApp/
+│       │   ├── ChessApp.js
+│       │   └── index.js
 │       ├── DaySwitcherApp/
 │       │   ├── DaySwitcherApp.js
 │       │   ├── DaySwitcherApp.css
+│       │   └── index.js
+│       ├── HexaSnakeApp/
+│       │   ├── HexaSnakeApp.js
+│       │   ├── HexaSnakeApp.css
 │       │   └── index.js
 │       ├── NPomodoroApp/
 │       │   ├── NPomodoroApp.js
 │       │   ├── NPomodoroApp.css
 │       │   └── index.js
+│       ├── PongApp/
+│       │   ├── PongApp.js
+│       │   ├── PongApp.css
+│       │   └── index.js
+│       ├── PongRingApp/
+│       │   ├── PongRingApp.js
+│       │   ├── PongRingApp.css
+│       │   └── index.js
 │       ├── SnakeApp/
 │       │   ├── SnakeApp.js
 │       │   ├── SnakeApp.css
+│       │   └── index.js
+│       ├── SudokuApp/
+│       │   ├── SudokuApp.js
+│       │   ├── SudokuApp.css
 │       │   └── index.js
 │       └── registry.js
 ├── dist/

--- a/js/boardManager.js
+++ b/js/boardManager.js
@@ -187,7 +187,10 @@
       this.board = null;
       this.afterMoveCallbacks = [];
     }
+  }
 
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = BoardManager;
   } else {
     global.BoardManager = BoardManager;
   }

--- a/src/apps/__tests__/registry.test.js
+++ b/src/apps/__tests__/registry.test.js
@@ -1,0 +1,19 @@
+import { getAllApps, getAppById } from '../registry';
+
+describe('app registry', () => {
+  it('includes the chess app metadata', () => {
+    const chessApp = getAppById('chess');
+
+    expect(chessApp).toBeTruthy();
+    expect(chessApp.title).toBe('Chessboard Summit');
+    expect(chessApp.category).toBe('Games');
+    expect(chessApp.icon).toBe('♟️');
+    expect(chessApp.path).toBe('/apps/chess');
+  });
+
+  it('lists chess among all apps', () => {
+    const allAppIds = getAllApps().map((app) => app.id);
+
+    expect(allAppIds).toContain('chess');
+  });
+});

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { APP_REGISTRY, APP_CATEGORIES, getAppsByCategory, getFeaturedApps, getAllApps } from '../apps/registry';
+import React, { useEffect, useMemo, useState } from 'react';
+import { APP_CATEGORIES, getAllApps } from '../apps/registry';
 import './AppLauncher.css';
 
 const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
@@ -35,16 +35,22 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
   }, []);
 
   const categories = ['All', ...Object.keys(APP_CATEGORIES)];
-  
-  const filteredApps = getAllApps().filter(app => {
-    const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
-    const matchesSearch = app.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+
+  const allApps = useMemo(() => getAllApps(), []);
+
+  const filteredApps = useMemo(() => allApps
+    .filter(app => {
+      const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
+      const matchesSearch = app.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          app.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          app.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
-    return matchesCategory && matchesSearch && !app.disabled;
-  });
+      return matchesCategory && matchesSearch && !app.disabled;
+    })
+    .sort((a, b) => a.title.localeCompare(b.title)), [allApps, selectedCategory, searchQuery]);
 
-  const featuredApps = getFeaturedApps();
+  const featuredApps = useMemo(() => allApps
+    .filter(app => app.featured && !app.disabled)
+    .sort((a, b) => a.title.localeCompare(b.title)), [allApps]);
 
   const isFavorited = (appId) => favoriteIds.includes(appId);
 
@@ -109,7 +115,7 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
           <h1 className="launcher-title">
             <span className="title-icon">📱</span>
             App Container
-            <span className="app-count">({getAllApps().length} apps)</span>
+            <span className="app-count">({allApps.length} apps)</span>
           </h1>
 
           <div className="toronto-clock" aria-label="Current time">


### PR DESCRIPTION
## Summary
- memoize the launcher catalog, sort the featured/all lists, and count the total apps so Chessboard Summit always appears in the grid
- expose BoardManager through CommonJS when available and add a registry test that guards the chess entry
- refresh the README, APPS catalog, chess guide, and Git history to document every bundled experience

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cb1805f6a0832ba17e71e48ccf1d5b