### PR TITLE
Add CatPad app with cloud-synced notepad

### DIFF
--- a/APPS.md
+++ b/APPS.md
@@ -6,6 +6,12 @@ Day Switcher transforms the weekly calendar into an interactive playground. Smoo
 - Offer accessibility-focused themes, including high-contrast palettes and reduced-motion options.
 - Introduce keyboard shortcuts and swipe gestures for faster navigation across devices.
 
+## CatPad
+CatPad is a feline-inspired notepad that autosaves to IndexedDB and offers optional GitHub gist syncing so every browser shares the same whisker scribbles. A cat cursor, tiled background, and cozy palette make editing playful while a cloud panel handles credentials, manual pulls, and push-on-demand.
+- Expand sync providers beyond GitHub gists, such as WebDAV or commercial cloud storage adapters.
+- Layer in version history so writers can rewind to an earlier meowment or compare drafts.
+- Provide rich-text flourishes like headings or checklists while keeping the editor lightweight.
+
 ## N-Pomodoro Timer
 N-Pomodoro Timer choreographs customizable work cycles within a cosmic interface. Users pick multi-activity presets, monitor progress through animated rings, and toggle configuration panels without losing context. Timers persist across states, enabling focused sprints, reflective breaks, and celebratory completions through ambient stars, all tailored to evolving productivity rituals and team rhythms.
 - Enable user-defined activity presets with saved profiles synchronized across devices.

--- a/GITSTORY.md
+++ b/GITSTORY.md
@@ -4,3 +4,4 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 
 - 2025-09-17 — docs — Added AGENTS.md guidance, refreshed README documentation, and introduced this log for future history tracking.
 - 2025-09-18 — feature+docs — Surfaced Chessboard Summit in the launcher list, refreshed documentation for every bundled app, and added coverage to guard the registry entry.
+- 2025-09-21 — feature+docs — Added the CatPad notepad with IndexedDB persistence, GitHub gist syncing, and refreshed docs/tests for the new launcher entry.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A small, modular React playground bundling multiple apps behind a simple launche
 ### Included apps
 
 - Day Switcher — flip through the week with animated transitions.
+- CatPad — jot notes with a cat-themed editor that syncs through GitHub gists.
 - N-Pomodoro — orchestrate multi-activity pomodoro sessions.
 - Snake — chase high scores across a responsive grid.
 - Hexa-Snake (Bee Edition) — guide a bee across a honeycomb board.
@@ -98,6 +99,10 @@ g1/
 │   └── apps/
 │       ├── ChessApp/
 │       │   ├── ChessApp.js
+│       │   └── index.js
+│       ├── CatPadApp/
+│       │   ├── CatPadApp.js
+│       │   ├── CatPadApp.css
 │       │   └── index.js
 │       ├── DaySwitcherApp/
 │       │   ├── DaySwitcherApp.js

--- a/src/apps/CatPadApp/CatPadApp.css
+++ b/src/apps/CatPadApp/CatPadApp.css
@@ -1,0 +1,390 @@
+
+.catpad-app {
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  display: flex;
+  justify-content: center;
+  background-color: #fff5ec;
+  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27140%27%20height%3D%27140%27%20viewBox%3D%270%200%20140%20140%27%3E%0A%3Crect%20width%3D%27140%27%20height%3D%27140%27%20fill%3D%27%23fffaf5%27/%3E%0A%3Cg%20fill%3D%27%23f2d3bd%27%20stroke%3D%27%23e0bfa0%27%20stroke-width%3D%271.5%27%3E%0A%3Ccircle%20cx%3D%2730%27%20cy%3D%2730%27%20r%3D%2718%27/%3E%0A%3Ccircle%20cx%3D%27110%27%20cy%3D%2730%27%20r%3D%2718%27/%3E%0A%3Ccircle%20cx%3D%2770%27%20cy%3D%2770%27%20r%3D%2718%27/%3E%0A%3Ccircle%20cx%3D%2730%27%20cy%3D%27110%27%20r%3D%2718%27/%3E%0A%3Ccircle%20cx%3D%27110%27%20cy%3D%27110%27%20r%3D%2718%27/%3E%0A%3C/g%3E%0A%3Cg%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20fill%3D%27none%27%20stroke-linecap%3D%27round%27%3E%0A%3Cpath%20d%3D%27M24%2024%20l-6%20-10%27/%3E%0A%3Cpath%20d%3D%27M36%2024%20l6%20-10%27/%3E%0A%3Cpath%20d%3D%27M104%2024%20l-6%20-10%27/%3E%0A%3Cpath%20d%3D%27M116%2024%20l6%20-10%27/%3E%0A%3Cpath%20d%3D%27M64%2064%20l-6%20-10%27/%3E%0A%3Cpath%20d%3D%27M76%2064%20l6%20-10%27/%3E%0A%3Cpath%20d%3D%27M24%20104%20l-6%20-10%27/%3E%0A%3Cpath%20d%3D%27M36%20104%20l6%20-10%27/%3E%0A%3Cpath%20d%3D%27M104%20104%20l-6%20-10%27/%3E%0A%3Cpath%20d%3D%27M116%20104%20l6%20-10%27/%3E%0A%3C/g%3E%0A%3Cg%20fill%3D%27%23392b28%27%3E%0A%3Ccircle%20cx%3D%2730%27%20cy%3D%2730%27%20r%3D%272.5%27/%3E%0A%3Ccircle%20cx%3D%27110%27%20cy%3D%2730%27%20r%3D%272.5%27/%3E%0A%3Ccircle%20cx%3D%2770%27%20cy%3D%2770%27%20r%3D%272.5%27/%3E%0A%3Ccircle%20cx%3D%2730%27%20cy%3D%27110%27%20r%3D%272.5%27/%3E%0A%3Ccircle%20cx%3D%27110%27%20cy%3D%27110%27%20r%3D%272.5%27/%3E%0A%3C/g%3E%0A%3C/svg%3E');
+  background-size: 140px 140px;
+  color: #3a2723;
+  font-family: 'Nunito', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  box-sizing: border-box;
+  cursor: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%20viewBox%3D%270%200%2032%2032%27%3E%0A%3Cpath%20d%3D%27M8%206%20L4%202%20L4%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Cpath%20d%3D%27M24%206%20L28%202%20L28%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Ccircle%20cx%3D%2716%27%20cy%3D%2718%27%20r%3D%2712%27%20fill%3D%27%23ffe7d8%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27/%3E%0A%3Ccircle%20cx%3D%2712%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Ccircle%20cx%3D%2720%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Cpath%20d%3D%27M12%2022%20Q16%2025%2020%2022%27%20fill%3D%27none%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%0A%3Cpath%20d%3D%27M16%2018%20l0%203%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27/%3E%0A%3C/svg%3E') 2 2, auto;
+}
+
+.catpad-app * {
+  box-sizing: border-box;
+  cursor: inherit;
+}
+
+.catpad-loading {
+  align-items: center;
+  padding: 3rem;
+}
+
+.catpad-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  font-size: 1.1rem;
+  color: #50322d;
+}
+
+.catpad-paw-spinner {
+  width: 48px;
+  height: 48px;
+  border: 6px solid rgba(255, 199, 171, 0.4);
+  border-top-color: #f28f7b;
+  border-radius: 50%;
+  animation: catpad-spin 1s linear infinite;
+}
+
+@keyframes catpad-spin {
+  to { transform: rotate(360deg); }
+}
+
+.catpad-layout {
+  flex: 1;
+  width: 100%;
+  padding: 2rem;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 320px;
+  gap: 1.5rem;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.catpad-sidebar,
+.catpad-editor,
+.catpad-settings {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(226, 181, 148, 0.6);
+  box-shadow: 0 18px 32px rgba(117, 76, 64, 0.12);
+  padding: 1.25rem;
+}
+
+.catpad-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catpad-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.catpad-sidebar-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #2c1a18;
+}
+
+.catpad-note-list {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.catpad-note-item {
+  border: none;
+  text-align: left;
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 246, 239, 0.85);
+  color: inherit;
+  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(230, 184, 147, 0.35);
+}
+
+.catpad-note-item:hover {
+  background: rgba(255, 229, 210, 0.95);
+  transform: translateY(-1px);
+}
+
+.catpad-note-item.active {
+  background: linear-gradient(135deg, rgba(255, 206, 173, 0.95), rgba(255, 230, 214, 0.95));
+  box-shadow: inset 0 0 0 2px rgba(222, 148, 115, 0.6);
+}
+
+.catpad-note-title {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-bottom: 0.35rem;
+  color: #3a241f;
+}
+
+.catpad-note-meta {
+  font-size: 0.85rem;
+  color: #7f655c;
+}
+
+.catpad-empty {
+  text-align: center;
+  color: #8a6f66;
+  padding: 1.5rem 1rem;
+  border-radius: 12px;
+  background: rgba(255, 239, 227, 0.7);
+}
+
+.catpad-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catpad-editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.catpad-title-input {
+  flex: 1;
+  min-width: 180px;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(224, 170, 138, 0.7);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 1.05rem;
+  color: #2b1a17;
+  cursor: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%20viewBox%3D%270%200%2032%2032%27%3E%0A%3Cpath%20d%3D%27M8%206%20L4%202%20L4%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Cpath%20d%3D%27M24%206%20L28%202%20L28%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Ccircle%20cx%3D%2716%27%20cy%3D%2718%27%20r%3D%2712%27%20fill%3D%27%23ffe7d8%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27/%3E%0A%3Ccircle%20cx%3D%2712%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Ccircle%20cx%3D%2720%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Cpath%20d%3D%27M12%2022%20Q16%2025%2020%2022%27%20fill%3D%27none%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%0A%3Cpath%20d%3D%27M16%2018%20l0%203%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27/%3E%0A%3C/svg%3E') 2 2, text;
+}
+
+.catpad-title-input:focus {
+  outline: none;
+  border-color: #f08c73;
+  box-shadow: 0 0 0 3px rgba(240, 140, 115, 0.2);
+}
+
+.catpad-toolbar-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.catpad-textarea {
+  width: 100%;
+  flex: 1;
+  min-height: 340px;
+  resize: none;
+  padding: 1.1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(222, 168, 138, 0.65);
+  background: rgba(255, 255, 255, 0.92);
+  font-size: 1rem;
+  line-height: 1.65;
+  color: #2b1a17;
+  caret-color: #f08c73;
+  cursor: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%20viewBox%3D%270%200%2032%2032%27%3E%0A%3Cpath%20d%3D%27M8%206%20L4%202%20L4%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Cpath%20d%3D%27M24%206%20L28%202%20L28%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Ccircle%20cx%3D%2716%27%20cy%3D%2718%27%20r%3D%2712%27%20fill%3D%27%23ffe7d8%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27/%3E%0A%3Ccircle%20cx%3D%2712%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Ccircle%20cx%3D%2720%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Cpath%20d%3D%27M12%2022%20Q16%2025%2020%2022%27%20fill%3D%27none%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%0A%3Cpath%20d%3D%27M16%2018%20l0%203%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27/%3E%0A%3C/svg%3E') 2 2, text;
+}
+
+.catpad-textarea:focus {
+  outline: none;
+  border-color: #f08c73;
+  box-shadow: 0 0 0 3px rgba(240, 140, 115, 0.2);
+}
+
+.catpad-status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.catpad-sync-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 239, 227, 0.7);
+  color: #78483d;
+}
+
+.catpad-sync-status.syncing {
+  background: rgba(240, 140, 115, 0.15);
+  color: #b35a48;
+}
+
+.catpad-sync-status.success {
+  background: rgba(166, 211, 182, 0.25);
+  color: #2d7a48;
+}
+
+.catpad-sync-status.error {
+  background: rgba(255, 180, 180, 0.25);
+  color: #c03a2f;
+}
+
+.catpad-sync-icon {
+  font-size: 1.1rem;
+}
+
+.catpad-save-meta {
+  color: #7f655c;
+}
+
+.catpad-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.catpad-settings h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #2c1a18;
+}
+
+.catpad-settings-blurb {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #6c5147;
+  line-height: 1.5;
+}
+
+.catpad-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: #50322d;
+}
+
+.catpad-field input[type="text"],
+.catpad-field input[type="password"] {
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(220, 172, 140, 0.7);
+  background: rgba(255, 255, 255, 0.92);
+  font-size: 0.95rem;
+  color: #2c1a18;
+  cursor: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%20viewBox%3D%270%200%2032%2032%27%3E%0A%3Cpath%20d%3D%27M8%206%20L4%202%20L4%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Cpath%20d%3D%27M24%206%20L28%202%20L28%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Ccircle%20cx%3D%2716%27%20cy%3D%2718%27%20r%3D%2712%27%20fill%3D%27%23ffe7d8%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27/%3E%0A%3Ccircle%20cx%3D%2712%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Ccircle%20cx%3D%2720%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Cpath%20d%3D%27M12%2022%20Q16%2025%2020%2022%27%20fill%3D%27none%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%0A%3Cpath%20d%3D%27M16%2018%20l0%203%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27/%3E%0A%3C/svg%3E') 2 2, text;
+}
+
+.catpad-field input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  accent-color: #f08c73;
+}
+
+.catpad-remember {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.catpad-sync-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.catpad-primary,
+.catpad-secondary,
+.catpad-danger {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%20viewBox%3D%270%200%2032%2032%27%3E%0A%3Cpath%20d%3D%27M8%206%20L4%202%20L4%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Cpath%20d%3D%27M24%206%20L28%202%20L28%2012%20Z%27%20fill%3D%27%23f7cbaa%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27/%3E%0A%3Ccircle%20cx%3D%2716%27%20cy%3D%2718%27%20r%3D%2712%27%20fill%3D%27%23ffe7d8%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27/%3E%0A%3Ccircle%20cx%3D%2712%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Ccircle%20cx%3D%2720%27%20cy%3D%2716%27%20r%3D%272.2%27%20fill%3D%27%23392b28%27/%3E%0A%3Cpath%20d%3D%27M12%2022%20Q16%2025%2020%2022%27%20fill%3D%27none%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%272%27%20stroke-linecap%3D%27round%27/%3E%0A%3Cpath%20d%3D%27M16%2018%20l0%203%27%20stroke%3D%27%23392b28%27%20stroke-width%3D%271.5%27%20stroke-linecap%3D%27round%27/%3E%0A%3C/svg%3E') 2 2, pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.catpad-primary {
+  background: linear-gradient(135deg, #ffb996, #f08c73);
+  color: #3a1f1b;
+  box-shadow: 0 10px 18px rgba(240, 140, 115, 0.3);
+}
+
+.catpad-secondary {
+  background: rgba(255, 213, 190, 0.65);
+  color: #4d2c26;
+  box-shadow: 0 8px 16px rgba(232, 175, 147, 0.25);
+}
+
+.catpad-danger {
+  background: rgba(219, 103, 87, 0.85);
+  color: #fff9f6;
+  box-shadow: 0 10px 18px rgba(219, 103, 87, 0.35);
+}
+
+.catpad-primary:hover,
+.catpad-secondary:hover,
+.catpad-danger:hover {
+  transform: translateY(-1px);
+}
+
+.catpad-primary:disabled,
+.catpad-secondary:disabled,
+.catpad-danger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.catpad-tip {
+  margin-top: auto;
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(255, 235, 220, 0.7);
+  color: #6c5147;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  font-size: 0.95rem;
+}
+
+.catpad-tip-icon {
+  font-size: 1.5rem;
+}
+
+@media (max-width: 1200px) {
+  .catpad-layout {
+    grid-template-columns: 230px minmax(0, 1fr);
+    grid-template-areas: 'sidebar editor' 'settings settings';
+  }
+  .catpad-settings {
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (max-width: 860px) {
+  .catpad-layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto auto;
+  }
+  .catpad-sidebar,
+  .catpad-editor,
+  .catpad-settings {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .catpad-layout {
+    padding: 1.25rem;
+  }
+  .catpad-editor-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .catpad-toolbar-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/src/apps/CatPadApp/CatPadApp.js
+++ b/src/apps/CatPadApp/CatPadApp.js
@@ -1,0 +1,766 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import './CatPadApp.css';
+import {
+  DEFAULT_SETTINGS,
+  deleteNote as deleteNoteFromStore,
+  getAllNotes,
+  getSettings,
+  getStoredToken,
+  replaceAllNotes,
+  saveNote,
+  saveSettings,
+  setStoredToken,
+} from './storage';
+import {
+  DEFAULT_SYNC_FILENAME,
+  mergeNoteCollections,
+  pullFromGist,
+  pushToGist,
+} from './sync';
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `cat-${Math.random().toString(16).slice(2)}-${Date.now()}`;
+};
+
+const normalizeNote = (note) => {
+  if (!note) return null;
+  const now = new Date().toISOString();
+  return {
+    id: note.id || generateId(),
+    title: note.title || 'Untitled Cat',
+    content: note.content || '',
+    createdAt: note.createdAt || now,
+    updatedAt: note.updatedAt || note.createdAt || now,
+  };
+};
+
+const createWelcomeNote = () => {
+  const now = new Date().toISOString();
+  return {
+    id: generateId(),
+    title: 'Welcome to CatPad',
+    content: `Welcome to CatPad! 🐾
+
+• Use the sidebar to create, open, and delete notes.
+• CatPad autosaves locally and can sync through a GitHub Gist.
+• Head to the Cloud Sync panel to plug in your gist ID and token so every browser stays in purr-fect sync.
+
+Happy typing!`,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+const sortNotes = (notes) => {
+  const safe = Array.isArray(notes) ? [...notes] : [];
+  safe.sort((a, b) => {
+    const aTime = Date.parse(a.updatedAt || a.createdAt || 0) || 0;
+    const bTime = Date.parse(b.updatedAt || b.createdAt || 0) || 0;
+    if (bTime !== aTime) {
+      return bTime - aTime;
+    }
+    return (a.title || '').localeCompare(b.title || '');
+  });
+  return safe;
+};
+
+const formatRelativeTime = (timestamp) => {
+  if (!timestamp) return 'never';
+  const time = Date.parse(timestamp);
+  if (Number.isNaN(time)) {
+    return 'unknown';
+  }
+  const diffSeconds = Math.round((Date.now() - time) / 1000);
+  if (diffSeconds < 45) {
+    return 'just now';
+  }
+  if (diffSeconds < 90) {
+    return 'a meowment ago';
+  }
+  const diffMinutes = Math.round(diffSeconds / 60);
+  if (diffMinutes < 60) {
+    return `${diffMinutes} min ago`;
+  }
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `${diffHours} hr${diffHours === 1 ? '' : 's'} ago`;
+  }
+  const diffDays = Math.round(diffHours / 24);
+  if (diffDays < 7) {
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(time);
+};
+
+const formatTimestamp = (timestamp) => {
+  if (!timestamp) return 'Never synced';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'Never synced';
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date);
+};
+
+const statusIconMap = {
+  idle: '☁️',
+  syncing: '🐾',
+  success: '😺',
+  error: '⚠️',
+};
+
+const catTips = [
+  'Public gists work great for read-only sync. Add a token to update from any device.',
+  'Create a fine-grained GitHub token with only the “gist” scope for extra safety.',
+  'Tap “Pull latest” after switching devices to be sure you have the newest whisker scribbles.',
+  'Auto-sync keeps notes aligned every time CatPad saves a change.',
+];
+
+const hasNotesChanged = (previous, next) => {
+  if (previous.length !== next.length) {
+    return true;
+  }
+  const sortById = (list) => [...list].sort((a, b) => a.id.localeCompare(b.id));
+  const aSorted = sortById(previous);
+  const bSorted = sortById(next);
+  for (let index = 0; index < aSorted.length; index += 1) {
+    const aNote = aSorted[index];
+    const bNote = bSorted[index];
+    if (aNote.id !== bNote.id) return true;
+    if (aNote.title !== bNote.title) return true;
+    if (aNote.content !== bNote.content) return true;
+    if (aNote.updatedAt !== bNote.updatedAt) return true;
+  }
+  return false;
+};
+
+const CatPadApp = () => {
+  const [notes, setNotes] = useState([]);
+  const [activeNoteId, setActiveNoteId] = useState(null);
+  const [draftTitle, setDraftTitle] = useState('');
+  const [draftContent, setDraftContent] = useState('');
+  const [lastLocalSaveAt, setLastLocalSaveAt] = useState(null);
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [gistToken, setGistTokenState] = useState('');
+  const [syncStatus, setSyncStatus] = useState({ type: 'idle', message: 'Cloud sync disabled' });
+  const [isLoading, setIsLoading] = useState(true);
+  const [tipIndex, setTipIndex] = useState(0);
+
+  const notesRef = useRef([]);
+  const settingsRef = useRef(DEFAULT_SETTINGS);
+  const gistTokenRef = useRef('');
+  const draftRef = useRef({ title: '', content: '' });
+  const autoSaveTimerRef = useRef(null);
+  const pushTimerRef = useRef(null);
+  const pushInFlightRef = useRef(false);
+  const initialSyncAttemptedRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+      }
+      if (pushTimerRef.current) {
+        clearTimeout(pushTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    draftRef.current = { title: draftTitle, content: draftContent };
+  }, [draftTitle, draftContent]);
+
+  const updateNotesState = useCallback((updater) => {
+    setNotes((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      const sanitized = Array.isArray(next) ? next : [];
+      notesRef.current = sanitized;
+      return sanitized;
+    });
+  }, []);
+
+  const persistSettings = useCallback(async (updater) => {
+    let nextSettingsValue = settingsRef.current;
+    setSettings((prev) => {
+      const computed = typeof updater === 'function' ? updater(prev) : updater;
+      nextSettingsValue = { ...DEFAULT_SETTINGS, ...computed };
+      settingsRef.current = nextSettingsValue;
+      return nextSettingsValue;
+    });
+    await saveSettings(nextSettingsValue);
+    return nextSettingsValue;
+  }, []);
+
+  const applyToken = useCallback(async (token, persist) => {
+    const normalized = typeof token === 'string' ? token : '';
+    gistTokenRef.current = normalized;
+    setGistTokenState(normalized);
+    if (persist) {
+      await setStoredToken(normalized);
+    }
+  }, []);
+
+  const getSyncConfig = useCallback(() => {
+    const current = settingsRef.current || DEFAULT_SETTINGS;
+    return {
+      gistId: (current.gistId || '').trim(),
+      filename: (current.gistFilename || DEFAULT_SYNC_FILENAME).trim() || DEFAULT_SYNC_FILENAME,
+      token: (gistTokenRef.current || '').trim(),
+    };
+  }, []);
+
+  const pushToRemote = useCallback(async (reason = 'manual') => {
+    const currentSettings = settingsRef.current;
+    if (!currentSettings.syncEnabled) {
+      return;
+    }
+    const config = getSyncConfig();
+    if (!config.gistId) {
+      setSyncStatus({ type: 'error', message: 'Add a GitHub gist ID to sync.' });
+      return;
+    }
+    if (!config.token) {
+      setSyncStatus({ type: 'error', message: 'Add a gist token to push changes.' });
+      return;
+    }
+    if (pushInFlightRef.current) {
+      return;
+    }
+
+    pushInFlightRef.current = true;
+    setSyncStatus({
+      type: 'syncing',
+      message: reason === 'manual' ? 'Syncing with Cat Cloud…' : 'Auto-syncing with Cat Cloud…',
+    });
+
+    try {
+      const result = await pushToGist({
+        gistId: config.gistId,
+        token: config.token,
+        filename: config.filename,
+        notes: notesRef.current,
+      });
+      await persistSettings((prev) => ({
+        ...prev,
+        lastRemoteExportedAt: result.exportedAt,
+        lastSyncedAt: result.exportedAt,
+      }));
+      setSyncStatus({ type: 'success', message: `Synced at ${formatTimestamp(result.exportedAt)}` });
+    } catch (error) {
+      console.error('[CatPad] push failed', error);
+      setSyncStatus({ type: 'error', message: error.message || 'Cloud sync failed' });
+    } finally {
+      pushInFlightRef.current = false;
+    }
+  }, [getSyncConfig, persistSettings]);
+
+  const scheduleRemotePush = useCallback((reason = 'auto') => {
+    if (pushTimerRef.current) {
+      clearTimeout(pushTimerRef.current);
+    }
+
+    const currentSettings = settingsRef.current;
+    if (!currentSettings.syncEnabled) {
+      return;
+    }
+    if (reason !== 'manual' && !currentSettings.autoSync) {
+      return;
+    }
+
+    const config = getSyncConfig();
+    if (!config.gistId || !config.token) {
+      return;
+    }
+
+    const delay = reason === 'manual' ? 0 : 1200;
+    pushTimerRef.current = setTimeout(() => {
+      pushToRemote(reason);
+    }, delay);
+  }, [getSyncConfig, pushToRemote]);
+
+  const pullFromRemote = useCallback(async (reason = 'manual') => {
+    const currentSettings = settingsRef.current;
+    if (!currentSettings.syncEnabled) {
+      return;
+    }
+
+    const config = getSyncConfig();
+    if (!config.gistId) {
+      setSyncStatus({ type: 'error', message: 'Add a GitHub gist ID to sync.' });
+      return;
+    }
+
+    setSyncStatus({
+      type: 'syncing',
+      message: reason === 'initial' ? 'Connecting to Cat Cloud…' : 'Fetching latest from Cat Cloud…',
+    });
+
+    try {
+      const result = await pullFromGist({
+        gistId: config.gistId,
+        token: config.token,
+        filename: config.filename,
+      });
+      const merged = sortNotes(
+        mergeNoteCollections(
+          notesRef.current,
+          result.notes,
+          result.exportedAt,
+          currentSettings.lastRemoteExportedAt,
+        ),
+      );
+      if (hasNotesChanged(notesRef.current, merged)) {
+        await replaceAllNotes(merged);
+        updateNotesState(merged);
+        if (merged.length > 0) {
+          const stillActive = merged.find((note) => note.id === activeNoteId);
+          if (!stillActive) {
+            setActiveNoteId(merged[0].id);
+          }
+        } else {
+          const fallback = createWelcomeNote();
+          await replaceAllNotes([fallback]);
+          updateNotesState([fallback]);
+          setActiveNoteId(fallback.id);
+        }
+      }
+      await persistSettings((prev) => ({
+        ...prev,
+        lastRemoteExportedAt: result.exportedAt ?? prev.lastRemoteExportedAt,
+        lastSyncedAt: result.exportedAt ?? prev.lastSyncedAt,
+      }));
+      setSyncStatus({ type: 'success', message: 'Cloud copy synced' });
+    } catch (error) {
+      console.error('[CatPad] pull failed', error);
+      setSyncStatus({ type: 'error', message: error.message || 'Failed to fetch from cloud' });
+    }
+  }, [activeNoteId, getSyncConfig, persistSettings, updateNotesState]);
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const [storedNotes, storedSettings, storedToken] = await Promise.all([
+          getAllNotes(),
+          getSettings(),
+          getStoredToken(),
+        ]);
+        const normalizedNotes = sortNotes(
+          (storedNotes && storedNotes.length > 0
+            ? storedNotes.map(normalizeNote)
+            : [createWelcomeNote()]),
+        );
+        updateNotesState(normalizedNotes);
+        const firstNote = normalizedNotes[0] || null;
+        setActiveNoteId(firstNote ? firstNote.id : null);
+        setDraftTitle(firstNote ? firstNote.title : '');
+        setDraftContent(firstNote ? firstNote.content : '');
+        setLastLocalSaveAt(firstNote ? firstNote.updatedAt : null);
+        draftRef.current = {
+          title: firstNote ? firstNote.title : '',
+          content: firstNote ? firstNote.content : '',
+        };
+        const nextSettings = { ...DEFAULT_SETTINGS, ...storedSettings };
+        settingsRef.current = nextSettings;
+        setSettings(nextSettings);
+        const rememberedToken = nextSettings.rememberToken ? storedToken : '';
+        await applyToken(rememberedToken, nextSettings.rememberToken);
+        if (nextSettings.lastSyncedAt) {
+          setSyncStatus({ type: 'success', message: `Last synced ${formatTimestamp(nextSettings.lastSyncedAt)}` });
+        } else if (!nextSettings.syncEnabled) {
+          setSyncStatus({ type: 'idle', message: 'Cloud sync disabled' });
+        }
+      } catch (error) {
+        console.error('[CatPad] Failed to load saved data', error);
+        const fallbackNote = createWelcomeNote();
+        updateNotesState([fallbackNote]);
+        setActiveNoteId(fallbackNote.id);
+        setDraftTitle(fallbackNote.title);
+        setDraftContent(fallbackNote.content);
+        setLastLocalSaveAt(fallbackNote.updatedAt);
+        draftRef.current = { title: fallbackNote.title, content: fallbackNote.content };
+        setSyncStatus({ type: 'error', message: 'Failed to load saved notes, starting fresh.' });
+      } finally {
+        setIsLoading(false);
+        setTipIndex(Math.floor(Math.random() * catTips.length));
+      }
+    };
+
+    load();
+  }, [applyToken, updateNotesState]);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!settings.syncEnabled) return;
+    if (!settings.gistId) return;
+    if (initialSyncAttemptedRef.current) return;
+    initialSyncAttemptedRef.current = true;
+    pullFromRemote('initial');
+  }, [isLoading, pullFromRemote, settings.gistId, settings.syncEnabled]);
+
+  useEffect(() => {
+    if (!settings.syncEnabled) {
+      setSyncStatus({ type: 'idle', message: 'Cloud sync disabled' });
+      return;
+    }
+    if (!settings.gistId) {
+      setSyncStatus({ type: 'idle', message: 'Add a gist ID to enable Cat Cloud sync' });
+    }
+  }, [settings.gistId, settings.syncEnabled]);
+
+  useEffect(() => {
+    const note = notesRef.current.find((item) => item.id === activeNoteId);
+    if (!note) {
+      if (draftRef.current.title !== '' || draftRef.current.content !== '') {
+        setDraftTitle('');
+        setDraftContent('');
+      }
+      return;
+    }
+    if (note.title !== draftRef.current.title) {
+      setDraftTitle(note.title);
+    }
+    if (note.content !== draftRef.current.content) {
+      setDraftContent(note.content);
+    }
+  }, [activeNoteId, notes]);
+
+  useEffect(() => {
+    const current = notesRef.current.find((item) => item.id === activeNoteId);
+    setLastLocalSaveAt(current ? current.updatedAt : null);
+  }, [activeNoteId, notes]);
+
+  const persistDraft = useCallback(async (reason = 'auto') => {
+    const note = notesRef.current.find((item) => item.id === activeNoteId);
+    if (!note) {
+      return;
+    }
+    const trimmedTitle = draftRef.current.title.trim() || 'Untitled Cat';
+    const content = draftRef.current.content;
+    if (note.title === trimmedTitle && note.content === content) {
+      return;
+    }
+    const timestamp = new Date().toISOString();
+    const updatedNote = {
+      ...note,
+      title: trimmedTitle,
+      content,
+      updatedAt: timestamp,
+    };
+    updateNotesState((prev) => sortNotes(prev.map((item) => (item.id === note.id ? updatedNote : item))));
+    try {
+      await saveNote(updatedNote);
+      setLastLocalSaveAt(timestamp);
+      if (draftRef.current.title !== trimmedTitle) {
+        setDraftTitle(trimmedTitle);
+      }
+      if (reason !== 'remote') {
+        scheduleRemotePush('auto');
+      }
+    } catch (error) {
+      console.error('[CatPad] Failed to save note', error);
+      setSyncStatus({ type: 'error', message: 'Local save failed. Check storage permissions.' });
+    }
+  }, [activeNoteId, scheduleRemotePush, updateNotesState]);
+
+  useEffect(() => {
+    if (!activeNoteId) return;
+    const note = notesRef.current.find((item) => item.id === activeNoteId);
+    if (!note) return;
+    if (note.title === draftRef.current.title && note.content === draftRef.current.content) {
+      return;
+    }
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+    }
+    autoSaveTimerRef.current = setTimeout(() => {
+      persistDraft('auto');
+    }, 600);
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+      }
+    };
+  }, [activeNoteId, draftTitle, draftContent, persistDraft]);
+
+  const handleSelectNote = useCallback(async (noteId) => {
+    if (noteId === activeNoteId) {
+      return;
+    }
+    await persistDraft('auto');
+    setActiveNoteId(noteId);
+  }, [activeNoteId, persistDraft]);
+
+  const createNote = useCallback(async () => {
+    const now = new Date().toISOString();
+    const existingTitles = new Set(notesRef.current.map((item) => item.title));
+    let baseTitle = 'New Cat Note';
+    let counter = 1;
+    while (existingTitles.has(baseTitle)) {
+      counter += 1;
+      baseTitle = `New Cat Note ${counter}`;
+    }
+    const newNote = {
+      id: generateId(),
+      title: baseTitle,
+      content: '',
+      createdAt: now,
+      updatedAt: now,
+    };
+    updateNotesState((prev) => sortNotes([newNote, ...prev]));
+    await saveNote(newNote);
+    setLastLocalSaveAt(now);
+    scheduleRemotePush('auto');
+    return newNote;
+  }, [scheduleRemotePush, updateNotesState]);
+
+  const handleNewNote = useCallback(async () => {
+    await persistDraft('auto');
+    const note = await createNote();
+    setActiveNoteId(note.id);
+  }, [createNote, persistDraft]);
+
+  const handleDeleteNote = useCallback(async (noteId) => {
+    const note = notesRef.current.find((item) => item.id === noteId);
+    if (!note) return;
+    const confirmed = typeof window !== 'undefined'
+      ? window.confirm(`Send "${note.title}" to the catnap bin? This cannot be undone.`)
+      : true;
+    if (!confirmed) {
+      return;
+    }
+    let nextNotes = [];
+    updateNotesState((prev) => {
+      nextNotes = prev.filter((item) => item.id !== noteId);
+      return nextNotes;
+    });
+    await deleteNoteFromStore(noteId);
+    if (nextNotes.length === 0) {
+      const newNote = await createNote();
+      setActiveNoteId(newNote.id);
+    } else if (activeNoteId === noteId) {
+      setActiveNoteId(nextNotes[0].id);
+    }
+    scheduleRemotePush('manual');
+  }, [activeNoteId, createNote, scheduleRemotePush, updateNotesState]);
+
+  const handleManualSave = useCallback(async () => {
+    await persistDraft('manual');
+    scheduleRemotePush('manual');
+  }, [persistDraft, scheduleRemotePush]);
+
+  const handleSettingsChange = useCallback((field, value) => {
+    if (field === 'syncEnabled' || field === 'gistId') {
+      initialSyncAttemptedRef.current = false;
+    }
+    persistSettings((prev) => ({
+      ...prev,
+      [field]: field === 'gistId' ? value.trim() : value,
+    }));
+  }, [persistSettings]);
+
+  const syncStateIcon = statusIconMap[syncStatus.type] || statusIconMap.idle;
+  const activeNote = useMemo(
+    () => notes.find((note) => note.id === activeNoteId) || null,
+    [notes, activeNoteId],
+  );
+  const canPush = settings.syncEnabled && Boolean(getSyncConfig().gistId) && Boolean(getSyncConfig().token);
+
+  if (isLoading) {
+    return (
+      <div className="catpad-app catpad-loading">
+        <div className="catpad-loader" role="status" aria-live="polite">
+          <div className="catpad-paw-spinner" />
+          <p>Stretching whiskers…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="catpad-app">
+      <div className="catpad-layout">
+        <aside className="catpad-sidebar">
+          <div className="catpad-sidebar-header">
+            <h2>Cat Files</h2>
+            <button type="button" className="catpad-primary" onClick={handleNewNote}>
+              + New note
+            </button>
+          </div>
+          <div className="catpad-note-list" role="list">
+            {notes.length === 0 && (
+              <div className="catpad-empty">No notes yet — start a new cat tale!</div>
+            )}
+            {notes.map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                role="listitem"
+                className={`catpad-note-item ${note.id === activeNoteId ? 'active' : ''}`}
+                onClick={() => handleSelectNote(note.id)}
+              >
+                <div className="catpad-note-title">{note.title || 'Untitled Cat'}</div>
+                <div className="catpad-note-meta">Updated {formatRelativeTime(note.updatedAt)}</div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <section className="catpad-editor" aria-label="CatPad editor">
+          <div className="catpad-editor-toolbar">
+            <input
+              className="catpad-title-input"
+              type="text"
+              value={draftTitle}
+              onChange={(event) => setDraftTitle(event.target.value)}
+              placeholder="Name your cat note"
+            />
+            <div className="catpad-toolbar-actions">
+              <button type="button" className="catpad-secondary" onClick={handleManualSave}>
+                Save
+              </button>
+              <button
+                type="button"
+                className="catpad-danger"
+                onClick={() => activeNote && handleDeleteNote(activeNote.id)}
+                disabled={!activeNote}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+          <textarea
+            className="catpad-textarea"
+            value={draftContent}
+            onChange={(event) => setDraftContent(event.target.value)}
+            placeholder="Write something delightful for your feline friends…"
+          />
+          <div className="catpad-status-row">
+            <div className={`catpad-sync-status ${syncStatus.type}`}>
+              <span className="catpad-sync-icon" aria-hidden="true">{syncStateIcon}</span>
+              <span>{syncStatus.message}</span>
+            </div>
+            <div className="catpad-save-meta">
+              <span>Last local save: {formatRelativeTime(lastLocalSaveAt)}</span>
+            </div>
+          </div>
+        </section>
+
+        <aside className="catpad-settings" aria-label="Cloud sync settings">
+          <h2>Cloud Sync</h2>
+          <p className="catpad-settings-blurb">
+            CatPad syncs through a GitHub gist so every browser shares the same scratchpad. Enter a gist ID and a
+            GitHub token with the <code>gist</code> scope. Your token never leaves this device.
+          </p>
+
+          <label className="catpad-field">
+            <span>Enable cloud sync</span>
+            <input
+              type="checkbox"
+              checked={settings.syncEnabled}
+              onChange={(event) => handleSettingsChange('syncEnabled', event.target.checked)}
+            />
+          </label>
+
+          <label className="catpad-field">
+            <span>Gist ID</span>
+            <input
+              type="text"
+              value={settings.gistId}
+              onChange={(event) => handleSettingsChange('gistId', event.target.value)}
+              placeholder="e.g. a1b2c3d4e5f6"
+            />
+          </label>
+
+          <label className="catpad-field">
+            <span>Filename</span>
+            <input
+              type="text"
+              value={settings.gistFilename}
+              onChange={(event) => handleSettingsChange('gistFilename', event.target.value || DEFAULT_SYNC_FILENAME)}
+              placeholder={DEFAULT_SYNC_FILENAME}
+            />
+          </label>
+
+          <label className="catpad-field">
+            <span>GitHub token</span>
+            <input
+              type="password"
+              value={gistToken}
+              onChange={async (event) => {
+                const value = event.target.value;
+                await applyToken(value, settings.rememberToken);
+              }}
+              placeholder="ghp_…"
+            />
+          </label>
+
+          <label className="catpad-field catpad-remember">
+            <input
+              type="checkbox"
+              checked={settings.rememberToken}
+              onChange={async (event) => {
+                const remember = event.target.checked;
+                await persistSettings((prev) => ({ ...prev, rememberToken: remember }));
+                if (remember) {
+                  await applyToken(gistTokenRef.current, true);
+                } else {
+                  await setStoredToken('');
+                }
+              }}
+            />
+            <span>Remember token on this device</span>
+          </label>
+
+          <label className="catpad-field">
+            <span>Auto-sync after edits</span>
+            <input
+              type="checkbox"
+              checked={settings.autoSync}
+              onChange={(event) => handleSettingsChange('autoSync', event.target.checked)}
+              disabled={!settings.syncEnabled}
+            />
+          </label>
+
+          <div className="catpad-sync-actions">
+            <button
+              type="button"
+              className="catpad-secondary"
+              onClick={() => pullFromRemote('manual')}
+              disabled={!settings.syncEnabled || !settings.gistId}
+            >
+              Pull latest
+            </button>
+            <button
+              type="button"
+              className="catpad-primary"
+              onClick={() => pushToRemote('manual')}
+              disabled={!canPush}
+            >
+              Push changes
+            </button>
+          </div>
+
+          <div className="catpad-tip">
+            <span className="catpad-tip-icon" aria-hidden="true">🐈</span>
+            <p>{catTips[tipIndex]}</p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default CatPadApp;

--- a/src/apps/CatPadApp/index.js
+++ b/src/apps/CatPadApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './CatPadApp';

--- a/src/apps/CatPadApp/storage.js
+++ b/src/apps/CatPadApp/storage.js
@@ -1,0 +1,319 @@
+const DB_NAME = 'catpad-db';
+const DB_VERSION = 1;
+const NOTES_STORE = 'notes';
+const SETTINGS_STORE = 'settings';
+const SETTINGS_KEY = 'preferences';
+const TOKEN_KEY = 'gistToken';
+const FALLBACK_NOTES_KEY = 'catpad:notes';
+const FALLBACK_SETTINGS_KEY = 'catpad:settings';
+const FALLBACK_TOKEN_KEY = 'catpad:gistToken';
+
+const hasIndexedDB = () => typeof indexedDB !== 'undefined';
+
+const openDatabase = () => new Promise((resolve, reject) => {
+  if (!hasIndexedDB()) {
+    reject(new Error('IndexedDB is not available'));
+    return;
+  }
+
+  const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+  request.onupgradeneeded = (event) => {
+    const db = event.target.result;
+
+    if (!db.objectStoreNames.contains(NOTES_STORE)) {
+      db.createObjectStore(NOTES_STORE, { keyPath: 'id' });
+    }
+
+    if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
+      db.createObjectStore(SETTINGS_STORE);
+    }
+  };
+
+  request.onsuccess = () => {
+    resolve(request.result);
+  };
+
+  request.onerror = () => {
+    reject(request.error);
+  };
+});
+
+const withStore = async (storeName, mode, executor) => {
+  const db = await openDatabase();
+
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(storeName, mode);
+    const store = transaction.objectStore(storeName);
+
+    let result;
+    let request;
+    try {
+      result = executor(store, transaction);
+      if (result && typeof result === 'object' && 'onsuccess' in result) {
+        request = result;
+      }
+    } catch (error) {
+      db.close();
+      reject(error);
+      return;
+    }
+
+    transaction.oncomplete = () => {
+      db.close();
+      if (request && 'result' in request) {
+        resolve(request.result);
+      } else {
+        resolve(result);
+      }
+    };
+
+    transaction.onabort = () => {
+      const error = transaction.error || new Error('Transaction aborted');
+      db.close();
+      reject(error);
+    };
+
+    transaction.onerror = () => {
+      const error = transaction.error || new Error('Transaction failed');
+      db.close();
+      reject(error);
+    };
+  });
+};
+
+const readAllFromStore = async (storeName) => {
+  try {
+    return await withStore(storeName, 'readonly', (store) => store.getAll());
+  } catch (error) {
+    if (!hasIndexedDB()) {
+      return [];
+    }
+    throw error;
+  }
+};
+
+const readValueFromStore = async (storeName, key) => {
+  try {
+    return await withStore(storeName, 'readonly', (store) => store.get(key));
+  } catch (error) {
+    if (!hasIndexedDB()) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+const writeToStore = async (storeName, key, value) => {
+  return withStore(storeName, 'readwrite', (store) => store.put(value, key));
+};
+
+const deleteFromStore = async (storeName, key) => {
+  return withStore(storeName, 'readwrite', (store) => store.delete(key));
+};
+
+const clearStore = async (storeName) => {
+  return withStore(storeName, 'readwrite', (store) => store.clear());
+};
+
+const getFallbackStorage = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+};
+
+const readFallback = (key, defaultValue) => {
+  try {
+    const storage = getFallbackStorage();
+    if (!storage) {
+      return defaultValue;
+    }
+    const raw = storage.getItem(key);
+    if (!raw) {
+      return defaultValue;
+    }
+    return JSON.parse(raw);
+  } catch (_error) {
+    return defaultValue;
+  }
+};
+
+const writeFallback = (key, value) => {
+  try {
+    const storage = getFallbackStorage();
+    if (!storage) {
+      return;
+    }
+    storage.setItem(key, JSON.stringify(value));
+  } catch (_error) {
+    // Ignore quota or serialization issues
+  }
+};
+
+export const getAllNotes = async () => {
+  if (!hasIndexedDB()) {
+    return readFallback(FALLBACK_NOTES_KEY, []);
+  }
+
+  try {
+    const notes = await readAllFromStore(NOTES_STORE);
+    return Array.isArray(notes) ? notes : [];
+  } catch (error) {
+    console.warn('[CatPad] Falling back to localStorage for notes', error);
+    return readFallback(FALLBACK_NOTES_KEY, []);
+  }
+};
+
+export const saveNote = async (note) => {
+  if (!note || !note.id) return;
+
+  if (!hasIndexedDB()) {
+    const notes = await getAllNotes();
+    const nextNotes = notes.filter((item) => item.id !== note.id);
+    nextNotes.push(note);
+    writeFallback(FALLBACK_NOTES_KEY, nextNotes);
+    return;
+  }
+
+  try {
+    await withStore(NOTES_STORE, 'readwrite', (store) => store.put(note));
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB save failed, using localStorage', error);
+    const notes = await getAllNotes();
+    const nextNotes = notes.filter((item) => item.id !== note.id);
+    nextNotes.push(note);
+    writeFallback(FALLBACK_NOTES_KEY, nextNotes);
+  }
+};
+
+export const deleteNote = async (noteId) => {
+  if (!noteId) return;
+
+  if (!hasIndexedDB()) {
+    const notes = await getAllNotes();
+    const nextNotes = notes.filter((item) => item.id !== noteId);
+    writeFallback(FALLBACK_NOTES_KEY, nextNotes);
+    return;
+  }
+
+  try {
+    await deleteFromStore(NOTES_STORE, noteId);
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB delete failed, using localStorage', error);
+    const notes = await getAllNotes();
+    const nextNotes = notes.filter((item) => item.id !== noteId);
+    writeFallback(FALLBACK_NOTES_KEY, nextNotes);
+  }
+};
+
+export const replaceAllNotes = async (notes) => {
+  const sanitized = Array.isArray(notes) ? notes : [];
+
+  if (!hasIndexedDB()) {
+    writeFallback(FALLBACK_NOTES_KEY, sanitized);
+    return;
+  }
+
+  try {
+    await clearStore(NOTES_STORE);
+    await withStore(NOTES_STORE, 'readwrite', (store) => {
+      sanitized.forEach((note) => {
+        store.put(note);
+      });
+    });
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB replace failed, using localStorage', error);
+    writeFallback(FALLBACK_NOTES_KEY, sanitized);
+  }
+};
+
+export const DEFAULT_SETTINGS = {
+  syncEnabled: false,
+  autoSync: true,
+  gistId: '',
+  gistFilename: 'catpad-notes.json',
+  rememberToken: true,
+  lastRemoteExportedAt: null,
+  lastSyncedAt: null,
+};
+
+export const getSettings = async () => {
+  if (!hasIndexedDB()) {
+    const settings = readFallback(FALLBACK_SETTINGS_KEY, DEFAULT_SETTINGS);
+    return { ...DEFAULT_SETTINGS, ...settings };
+  }
+
+  try {
+    const stored = await readValueFromStore(SETTINGS_STORE, SETTINGS_KEY);
+    return { ...DEFAULT_SETTINGS, ...(stored || {}) };
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB settings read failed, using localStorage', error);
+    const settings = readFallback(FALLBACK_SETTINGS_KEY, DEFAULT_SETTINGS);
+    return { ...DEFAULT_SETTINGS, ...settings };
+  }
+};
+
+export const saveSettings = async (settings) => {
+  const payload = { ...DEFAULT_SETTINGS, ...(settings || {}) };
+
+  if (!hasIndexedDB()) {
+    writeFallback(FALLBACK_SETTINGS_KEY, payload);
+    return payload;
+  }
+
+  try {
+    await writeToStore(SETTINGS_STORE, SETTINGS_KEY, payload);
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB settings save failed, using localStorage', error);
+    writeFallback(FALLBACK_SETTINGS_KEY, payload);
+  }
+
+  return payload;
+};
+
+export const getStoredToken = async () => {
+  if (!hasIndexedDB()) {
+    return readFallback(FALLBACK_TOKEN_KEY, '');
+  }
+
+  try {
+    const token = await readValueFromStore(SETTINGS_STORE, TOKEN_KEY);
+    return typeof token === 'string' ? token : '';
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB token read failed, using localStorage', error);
+    return readFallback(FALLBACK_TOKEN_KEY, '');
+  }
+};
+
+export const setStoredToken = async (token) => {
+  const normalized = typeof token === 'string' ? token : '';
+
+  if (!hasIndexedDB()) {
+    writeFallback(FALLBACK_TOKEN_KEY, normalized);
+    return normalized;
+  }
+
+  try {
+    await writeToStore(SETTINGS_STORE, TOKEN_KEY, normalized);
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB token write failed, using localStorage', error);
+    writeFallback(FALLBACK_TOKEN_KEY, normalized);
+  }
+
+  return normalized;
+};
+
+export const clearStoredToken = async () => {
+  if (!hasIndexedDB()) {
+    writeFallback(FALLBACK_TOKEN_KEY, '');
+    return;
+  }
+
+  try {
+    await deleteFromStore(SETTINGS_STORE, TOKEN_KEY);
+  } catch (error) {
+    console.warn('[CatPad] IndexedDB token delete failed, using localStorage', error);
+    writeFallback(FALLBACK_TOKEN_KEY, '');
+  }
+};

--- a/src/apps/CatPadApp/sync.js
+++ b/src/apps/CatPadApp/sync.js
@@ -1,0 +1,169 @@
+export const DEFAULT_SYNC_FILENAME = 'catpad-notes.json';
+
+const parseIsoDate = (value) => {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? null : new Date(time);
+};
+
+export const mergeNoteCollections = (localNotes, remoteNotes, remoteExportedAt, lastRemoteExportedAt) => {
+  const safeLocal = Array.isArray(localNotes) ? localNotes : [];
+  const safeRemote = Array.isArray(remoteNotes) ? remoteNotes : [];
+  const remoteIds = new Set(safeRemote.map((note) => note.id));
+  const remoteExportedTime = parseIsoDate(remoteExportedAt)?.getTime() ?? null;
+  const lastRemoteTime = parseIsoDate(lastRemoteExportedAt)?.getTime() ?? null;
+  const mergedMap = new Map();
+
+  const selectLatest = (existing, incoming) => {
+    if (!existing) return incoming;
+    const existingTime = parseIsoDate(existing.updatedAt)?.getTime() ?? parseIsoDate(existing.createdAt)?.getTime() ?? 0;
+    const incomingTime = parseIsoDate(incoming.updatedAt)?.getTime() ?? parseIsoDate(incoming.createdAt)?.getTime() ?? 0;
+
+    return incomingTime >= existingTime ? incoming : existing;
+  };
+
+  safeRemote.forEach((note) => {
+    if (!note || !note.id) return;
+    mergedMap.set(note.id, note);
+  });
+
+  safeLocal.forEach((note) => {
+    if (!note || !note.id) return;
+    if (remoteIds.has(note.id)) {
+      const existing = mergedMap.get(note.id);
+      mergedMap.set(note.id, selectLatest(existing, note));
+    } else {
+      if (remoteExportedTime === null) {
+        mergedMap.set(note.id, note);
+      } else {
+        const noteTime = parseIsoDate(note.updatedAt)?.getTime() ?? parseIsoDate(note.createdAt)?.getTime() ?? 0;
+        if (noteTime > remoteExportedTime) {
+          mergedMap.set(note.id, note);
+        } else if (lastRemoteTime !== null && noteTime > lastRemoteTime) {
+          mergedMap.set(note.id, note);
+        }
+      }
+    }
+  });
+
+  const merged = Array.from(mergedMap.values()).map((note) => ({
+    ...note,
+    createdAt: note.createdAt ?? new Date().toISOString(),
+    updatedAt: note.updatedAt ?? note.createdAt ?? new Date().toISOString(),
+  }));
+
+  merged.sort((a, b) => {
+    const aTime = parseIsoDate(a.updatedAt)?.getTime() ?? 0;
+    const bTime = parseIsoDate(b.updatedAt)?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+
+  return merged;
+};
+
+const buildHeaders = (token) => {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+const normalizeFilename = (filename) => {
+  if (!filename) return DEFAULT_SYNC_FILENAME;
+  return filename.trim() || DEFAULT_SYNC_FILENAME;
+};
+
+export const pullFromGist = async ({ gistId, token, filename }) => {
+  if (!gistId) {
+    throw new Error('Gist ID is required for sync.');
+  }
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available in this environment.');
+  }
+
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'GET',
+    headers: buildHeaders(token),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Unable to read gist (${response.status}): ${errorText || 'Unknown error'}`);
+  }
+
+  const data = await response.json();
+  const effectiveFilename = normalizeFilename(filename);
+  const file = data.files?.[effectiveFilename];
+
+  if (!file || typeof file.content !== 'string') {
+    return {
+      notes: [],
+      exportedAt: null,
+      gistUpdatedAt: data.updated_at,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(file.content);
+    const notes = Array.isArray(parsed.notes) ? parsed.notes : [];
+    return {
+      notes,
+      exportedAt: parsed.exportedAt ?? parsed.syncedAt ?? null,
+      gistUpdatedAt: data.updated_at,
+    };
+  } catch (error) {
+    throw new Error('Failed to parse CatPad data in gist.');
+  }
+};
+
+export const pushToGist = async ({ gistId, token, filename, notes }) => {
+  if (!gistId) {
+    throw new Error('Gist ID is required for sync.');
+  }
+
+  if (!token) {
+    throw new Error('A GitHub token with gist scope is required to push notes.');
+  }
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available in this environment.');
+  }
+
+  const payload = {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    notes: Array.isArray(notes) ? notes : [],
+  };
+
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'PATCH',
+    headers: {
+      ...buildHeaders(token),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      files: {
+        [normalizeFilename(filename)]: {
+          content: JSON.stringify(payload, null, 2),
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Unable to update gist (${response.status}): ${errorText || 'Unknown error'}`);
+  }
+
+  const data = await response.json();
+  return {
+    exportedAt: payload.exportedAt,
+    gistUpdatedAt: data.updated_at,
+  };
+};

--- a/src/apps/__tests__/registry.test.js
+++ b/src/apps/__tests__/registry.test.js
@@ -16,4 +16,14 @@ describe('app registry', () => {
 
     expect(allAppIds).toContain('chess');
   });
+
+  it('registers the CatPad app metadata', () => {
+    const catpad = getAppById('catpad');
+
+    expect(catpad).toBeTruthy();
+    expect(catpad.title).toBe('CatPad');
+    expect(catpad.category).toBe('Productivity');
+    expect(catpad.icon).toBe('😺');
+    expect(catpad.path).toBe('/apps/catpad');
+  });
 });

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -14,6 +14,20 @@ export const APP_REGISTRY = {
     created: '2024-01-01',
     featured: true
   },
+  catpad: {
+    id: 'catpad',
+    title: 'CatPad',
+    description: 'Feline-themed notepad with cloud sync across every browser.',
+    icon: '😺',
+    category: 'Productivity',
+    component: null,
+    path: '/apps/catpad',
+    tags: ['notes', 'editor', 'sync', 'cats'],
+    version: '1.0.0',
+    author: 'OpenAI Assistant',
+    created: '2024-06-01',
+    featured: true,
+  },
   // Placeholder for future apps
   'n-pomodoro': {
     id: 'n-pomodoro',

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -11,6 +11,7 @@ const PongApp = React.lazy(() => import('../apps/PongApp'));
 const PongRingApp = React.lazy(() => import('../apps/PongRingApp'));
 const SudokuApp = React.lazy(() => import('../apps/SudokuApp'));
 const ChessApp = React.lazy(() => import('../apps/ChessApp'));
+const CatPadApp = React.lazy(() => import('../apps/CatPadApp'));
 
 const AppContainer = () => {
   const [currentView, setCurrentView] = useState('launcher'); // 'launcher' or 'app'
@@ -46,6 +47,8 @@ const AppContainer = () => {
         return <SudokuApp onBack={handleBackToLauncher} />;
       case 'chess':
         return <ChessApp onBack={handleBackToLauncher} />;
+      case 'catpad':
+        return <CatPadApp onBack={handleBackToLauncher} />;
       default:
         return (
           <div className="app-placeholder">


### PR DESCRIPTION
## Summary
- introduce the CatPad notepad app with feline styling, offline IndexedDB storage, and optional GitHub gist syncing controls
- register CatPad in the launcher, documentation, and registry tests so it appears across the experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d081e65090832b84a0decf3ddd712b