### PR TITLE
Add Cat Typing Speed Test micro app

### DIFF
--- a/apps/cat-typing-speed-test/corpus.json
+++ b/apps/cat-typing-speed-test/corpus.json
@@ -1,0 +1,14 @@
+{
+  "sentences": [
+    "Kimchi lounges like royalty on the highest cat tree.",
+    "Rythm bats at shadows, always ready to pounce.",
+    "Siella darts across the bed, tail flicking wildly.",
+    "Kimchi purrs loudly when the wet food arrives.",
+    "Rythm crunches dry food with mischievous satisfaction.",
+    "Siella climbs the playpen walls, testing her speed.",
+    "All three cats sprawl together on the sunny bed.",
+    "Kimchi’s orange fur glows in the afternoon sunlight.",
+    "Rythm steals toys just to watch Siella chase him.",
+    "Siella meows loudly, demanding someone pay attention now."
+  ]
+}

--- a/apps/cat-typing-speed-test/index.html
+++ b/apps/cat-typing-speed-test/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cat Typing Speed Test</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell" aria-live="polite">
+      <header class="app-header">
+        <h1>Cat Typing Speed Test</h1>
+        <p>Warm up your paws and measure typing speed with Kimchi, Rythm, and Siella.</p>
+      </header>
+
+      <section class="card" id="start-screen">
+        <h2>Choose a test duration</h2>
+        <div class="duration-options" role="group" aria-label="Test duration">
+          <button type="button" class="duration-btn" data-duration="15">15 seconds</button>
+          <button type="button" class="duration-btn" data-duration="30">30 seconds</button>
+        </div>
+        <p class="start-hint">Each test pulls fresh sentences from the cat chronicles.</p>
+      </section>
+
+      <section class="card hidden" id="test-screen" aria-hidden="true">
+        <div class="test-meta">
+          <div class="timer" id="timer" aria-live="assertive">00:15</div>
+          <dl class="stat-line" aria-label="Live typing statistics">
+            <div>
+              <dt>WPM</dt>
+              <dd id="wpm">0</dd>
+            </div>
+            <div>
+              <dt>CPM</dt>
+              <dd id="cpm">0</dd>
+            </div>
+            <div>
+              <dt>Accuracy</dt>
+              <dd id="accuracy">100%</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div class="text-panel" id="text-display" aria-label="Typing passage"></div>
+
+        <label class="input-wrapper" for="typing-input">
+          <span class="label">Type the passage exactly as shown</span>
+          <textarea id="typing-input" rows="5" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" placeholder="Start typing here when the timer begins..." aria-describedby="timer"></textarea>
+        </label>
+
+        <div class="actions">
+          <button type="button" class="secondary" id="restart-btn">↺ Restart</button>
+          <button type="button" class="ghost" id="back-btn">← Back to menu</button>
+        </div>
+      </section>
+
+      <section class="card hidden" id="results-screen" aria-hidden="true">
+        <h2>Your results</h2>
+        <div class="results-grid" role="presentation">
+          <div>
+            <span class="result-label">Words per minute</span>
+            <span class="result-value" id="final-wpm">0</span>
+          </div>
+          <div>
+            <span class="result-label">Characters per minute</span>
+            <span class="result-value" id="final-cpm">0</span>
+          </div>
+          <div>
+            <span class="result-label">Accuracy</span>
+            <span class="result-value" id="final-accuracy">0%</span>
+          </div>
+        </div>
+        <p class="results-note" id="results-note"></p>
+        <div class="actions">
+          <button type="button" class="primary" id="results-retry">Try again</button>
+          <button type="button" class="ghost" id="results-menu">Back to menu</button>
+        </div>
+      </section>
+    </main>
+
+    <script src="main.js" defer></script>
+  </body>
+</html>

--- a/apps/cat-typing-speed-test/main.js
+++ b/apps/cat-typing-speed-test/main.js
@@ -1,0 +1,300 @@
+(() => {
+  const startScreen = document.getElementById('start-screen');
+  const testScreen = document.getElementById('test-screen');
+  const resultsScreen = document.getElementById('results-screen');
+  const timerEl = document.getElementById('timer');
+  const wpmEl = document.getElementById('wpm');
+  const cpmEl = document.getElementById('cpm');
+  const accuracyEl = document.getElementById('accuracy');
+  const textDisplay = document.getElementById('text-display');
+  const typingInput = document.getElementById('typing-input');
+  const restartBtn = document.getElementById('restart-btn');
+  const backBtn = document.getElementById('back-btn');
+  const finalWpm = document.getElementById('final-wpm');
+  const finalCpm = document.getElementById('final-cpm');
+  const finalAccuracy = document.getElementById('final-accuracy');
+  const resultsNote = document.getElementById('results-note');
+  const resultsRetry = document.getElementById('results-retry');
+  const resultsMenu = document.getElementById('results-menu');
+
+  const durationButtons = Array.from(document.querySelectorAll('.duration-btn'));
+
+  let corpusCache = null;
+  let corpusPromise = null;
+  let countdownSeconds = 0;
+  let testDuration = 0;
+  let timerId = null;
+  let startTimestamp = null;
+  let targetText = '';
+  let charSpans = [];
+  let correctChars = 0;
+  let typedChars = 0;
+
+  const formatTime = (seconds) => {
+    const safeSeconds = Math.max(0, Math.floor(seconds));
+    const mins = Math.floor(safeSeconds / 60)
+      .toString()
+      .padStart(2, '0');
+    const secs = (safeSeconds % 60).toString().padStart(2, '0');
+    return `${mins}:${secs}`;
+  };
+
+  const setScreen = (screen) => {
+    const sections = [startScreen, testScreen, resultsScreen];
+    sections.forEach((section) => {
+      const isActive = section === screen;
+      section.classList.toggle('hidden', !isActive);
+      section.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+  };
+
+  const loadCorpus = async () => {
+    if (corpusCache) return corpusCache;
+    if (!corpusPromise) {
+      corpusPromise = fetch('corpus.json')
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Failed to load corpus: ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (!data || !Array.isArray(data.sentences)) {
+            throw new Error('Corpus is malformed. Expected { sentences: [] }');
+          }
+          corpusCache = data.sentences.slice();
+          return corpusCache;
+        })
+        .catch((error) => {
+          console.error(error);
+          corpusPromise = null;
+          throw error;
+        });
+    }
+    return corpusPromise;
+  };
+
+  const pickPassage = (sentences) => {
+    if (!sentences.length) {
+      throw new Error('Corpus is empty.');
+    }
+
+    const targetLength = 200 + Math.floor(Math.random() * 60) - 30; // ~170-230 chars
+    const shuffled = sentences
+      .map((sentence) => ({ sentence, sort: Math.random() }))
+      .sort((a, b) => a.sort - b.sort)
+      .map(({ sentence }) => sentence);
+
+    let passage = '';
+    let index = 0;
+
+    while (passage.length < 150 || (passage.length < targetLength && index < shuffled.length)) {
+      passage += (passage ? ' ' : '') + shuffled[index % shuffled.length];
+      index += 1;
+      if (index >= shuffled.length) {
+        shuffled.push(...shuffled);
+      }
+      if (passage.length >= 300) {
+        break;
+      }
+    }
+
+    return passage.trim();
+  };
+
+  const renderTargetText = (text) => {
+    textDisplay.innerHTML = '';
+    charSpans = [];
+    [...text].forEach((char) => {
+      const span = document.createElement('span');
+      span.textContent = char;
+      textDisplay.appendChild(span);
+      charSpans.push(span);
+    });
+
+    if (charSpans.length) {
+      charSpans[0].classList.add('current');
+    }
+  };
+
+  const resetStats = () => {
+    correctChars = 0;
+    typedChars = 0;
+    wpmEl.textContent = '0';
+    cpmEl.textContent = '0';
+    accuracyEl.textContent = '100%';
+  };
+
+  const updateHighlights = (value) => {
+    correctChars = 0;
+    typedChars = value.length;
+
+    charSpans.forEach((span, index) => {
+      span.classList.remove('correct', 'incorrect', 'current');
+      if (index < value.length) {
+        if (value[index] === targetText[index]) {
+          span.classList.add('correct');
+          correctChars += 1;
+        } else {
+          span.classList.add('incorrect');
+        }
+      }
+    });
+
+    const nextIndex = value.length;
+    if (nextIndex < charSpans.length && charSpans[nextIndex]) {
+      charSpans[nextIndex].classList.add('current');
+    }
+  };
+
+  const updateLiveStats = () => {
+    if (!startTimestamp) return;
+    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
+    const minutes = elapsedSeconds / 60;
+    const words = correctChars / 5;
+    const cpm = (correctChars / elapsedSeconds) * 60;
+    const accuracy = typedChars === 0 ? 100 : (correctChars / typedChars) * 100;
+
+    wpmEl.textContent = Math.round(words / minutes || 0).toString();
+    cpmEl.textContent = Math.round(cpm || 0).toString();
+    accuracyEl.textContent = `${Math.max(0, Math.min(100, accuracy)).toFixed(0)}%`;
+  };
+
+  const handleTick = () => {
+    countdownSeconds -= 1;
+    timerEl.textContent = formatTime(countdownSeconds);
+
+    if (countdownSeconds <= 0) {
+      finishTest('time');
+    }
+  };
+
+  const setupTimer = () => {
+    clearInterval(timerId);
+    timerId = setInterval(handleTick, 1000);
+  };
+
+  const stopTimer = () => {
+    clearInterval(timerId);
+    timerId = null;
+  };
+
+  const finishTest = (reason) => {
+    if (!startTimestamp) return;
+    stopTimer();
+    typingInput.disabled = true;
+    countdownSeconds = 0;
+
+    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
+    const minutes = elapsedSeconds / 60;
+    const words = correctChars / 5;
+    const cpm = (correctChars / elapsedSeconds) * 60;
+    const accuracy = typedChars === 0 ? 0 : (correctChars / typedChars) * 100;
+
+    finalWpm.textContent = (words / minutes || 0).toFixed(1);
+    finalCpm.textContent = (cpm || 0).toFixed(0);
+    finalAccuracy.textContent = `${Math.max(0, Math.min(100, accuracy)).toFixed(1)}%`;
+
+    const summary = reason === 'completed'
+      ? 'Purrfect focus! You finished the story before the timer ran out.'
+      : "Time's up! Scroll back for another lap with the cats.";
+    resultsNote.textContent = summary;
+
+    setScreen(resultsScreen);
+    resultsRetry.focus();
+  };
+
+  const resetTestState = () => {
+    stopTimer();
+    typingInput.value = '';
+    typingInput.disabled = false;
+    startTimestamp = null;
+    targetText = '';
+    charSpans = [];
+    resetStats();
+    countdownSeconds = 0;
+    testDuration = 0;
+  };
+
+  const beginTest = async (duration) => {
+    try {
+      testDuration = Number(duration);
+      const sentences = await loadCorpus();
+      targetText = pickPassage(sentences);
+      renderTargetText(targetText);
+      resetStats();
+      typingInput.value = '';
+      typingInput.disabled = false;
+      typingInput.focus();
+
+      countdownSeconds = testDuration;
+      updateHighlights('');
+      timerEl.textContent = formatTime(countdownSeconds);
+
+      setScreen(testScreen);
+      startTimestamp = performance.now();
+      setupTimer();
+
+      // Align timer display immediately.
+      timerEl.textContent = formatTime(countdownSeconds);
+    } catch (error) {
+      resetTestState();
+      setScreen(startScreen);
+      alert('Unable to load the cat corpus. Please refresh and try again.');
+      console.error(error);
+    }
+  };
+
+  const handleInput = () => {
+    const value = typingInput.value;
+    updateHighlights(value);
+    updateLiveStats();
+
+    if (value.length >= targetText.length) {
+      finishTest('completed');
+    }
+  };
+
+  durationButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const duration = Number(button.dataset.duration);
+      if (!Number.isFinite(duration) || duration <= 0) return;
+      countdownSeconds = duration;
+      beginTest(duration);
+    });
+  });
+
+  restartBtn.addEventListener('click', () => {
+    if (testDuration > 0 && targetText) {
+      beginTest(testDuration);
+    } else {
+      setScreen(startScreen);
+    }
+  });
+
+  backBtn.addEventListener('click', () => {
+    resetTestState();
+    setScreen(startScreen);
+  });
+
+  typingInput.addEventListener('input', handleInput);
+
+  resultsRetry.addEventListener('click', () => {
+    if (!targetText) {
+      setScreen(startScreen);
+      return;
+    }
+    beginTest(testDuration || 15);
+  });
+
+  resultsMenu.addEventListener('click', () => {
+    resetTestState();
+    setScreen(startScreen);
+  });
+
+  setScreen(startScreen);
+
+  window.addEventListener('beforeunload', () => {
+    stopTimer();
+  });
+})();

--- a/apps/cat-typing-speed-test/styles.css
+++ b/apps/cat-typing-speed-test/styles.css
@@ -1,0 +1,302 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f3f4f6;
+  --card: #ffffff;
+  --accent: #ec4899;
+  --accent-dark: #db2777;
+  --text: #1f2933;
+  --muted: #6b7280;
+  --border: #d1d5db;
+  --success: #10b981;
+  --error: #ef4444;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #f9fafb 0%, #e0f2fe 45%, #fce7f3 100%);
+  color: var(--text);
+}
+
+.app-shell {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header {
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0;
+}
+
+.app-header p {
+  margin: 0 auto;
+  max-width: 48ch;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1.5rem;
+  padding: 2rem clamp(1.5rem, 5vw, 2.5rem);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.duration-options {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.duration-btn {
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1.05rem;
+  font-weight: 600;
+  padding: 0.85rem 1.75rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.duration-btn:hover,
+.duration-btn:focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(236, 72, 153, 0.35);
+}
+
+.duration-btn:focus-visible {
+  outline: 3px solid rgba(236, 72, 153, 0.4);
+  outline-offset: 3px;
+}
+
+.start-hint {
+  margin: 0;
+  text-align: center;
+  color: var(--muted);
+}
+
+.test-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.timer {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent-dark);
+}
+
+.stat-line {
+  display: flex;
+  gap: 1.75rem;
+  margin: 0;
+}
+
+.stat-line div {
+  display: grid;
+  gap: 0.2rem;
+  text-align: center;
+}
+
+.stat-line dt {
+  font-size: 0.85rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stat-line dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.text-panel {
+  border: 2px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: rgba(248, 250, 252, 0.75);
+  font-size: 1.15rem;
+  line-height: 1.7;
+  min-height: 120px;
+  letter-spacing: 0.01em;
+  word-break: break-word;
+}
+
+.text-panel span {
+  position: relative;
+  padding: 0 1px;
+}
+
+.text-panel .correct {
+  color: var(--success);
+}
+
+.text-panel .incorrect {
+  color: var(--error);
+  text-decoration: underline wavy var(--error);
+}
+
+.text-panel .current::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+.input-wrapper {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.input-wrapper .label {
+  font-weight: 600;
+}
+
+textarea {
+  width: 100%;
+  border-radius: 1rem;
+  border: 2px solid transparent;
+  padding: 1rem 1.1rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  resize: vertical;
+  min-height: 140px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.25);
+  outline: none;
+}
+
+textarea:disabled {
+  opacity: 0.6;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.actions .primary,
+.actions .secondary,
+.actions .ghost {
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 0.9rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions .primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.actions .primary:hover,
+.actions .primary:focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(219, 39, 119, 0.3);
+}
+
+.actions .secondary {
+  background: #fff;
+  color: var(--accent-dark);
+  border: 2px solid rgba(219, 39, 119, 0.2);
+}
+
+.actions .secondary:hover,
+.actions .secondary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(219, 39, 119, 0.25);
+}
+
+.actions .ghost {
+  background: transparent;
+  color: var(--muted);
+}
+
+.actions button:focus-visible {
+  outline: 3px solid rgba(236, 72, 153, 0.45);
+  outline-offset: 3px;
+}
+
+.results-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.result-label {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.result-value {
+  font-size: 2rem;
+  font-weight: 700;
+  display: block;
+}
+
+.results-note {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.75rem;
+    border-radius: 1.25rem;
+  }
+
+  .test-meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actions {
+    justify-content: stretch;
+  }
+
+  .actions button {
+    flex: 1;
+  }
+}

--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -12,6 +12,12 @@ CatPad is a feline-inspired notepad that autosaves to IndexedDB and offers optio
 - Layer in version history so writers can rewind to an earlier meowment or compare drafts.
 - Provide rich-text flourishes like headings or checklists while keeping the editor lightweight.
 
+## Cat Typing Speed Test
+Cat Typing Speed Test launches a focused browser-based drill for measuring WPM, CPM, and accuracy across 15 or 30 second sprints. Sentences are assembled on the fly from Kimchi, Rythm, and Siella’s daily antics, while inline highlighting tracks perfect keystrokes versus mischievous typos. A responsive layout, cached corpus fetch, and shareable iframe make it easy to practise in the launcher or pop the experience into a dedicated tab.
+- Offer selectable corpus themes so typists can swap between cats, cosmic voyages, or custom uploads.
+- Surface progress charts that compare recent runs and highlight improvements over time.
+- Add keyboard shortcuts for restarting, toggling durations, and switching to a zen full-screen mode.
+
 ## N-Pomodoro Timer
 N-Pomodoro Timer choreographs customizable work cycles within a cosmic interface. Users pick multi-activity presets, monitor progress through animated rings, and toggle configuration panels without losing context. Timers persist across states, enabling focused sprints, reflective breaks, and celebratory completions through ambient stars, all tailored to evolving productivity rituals and team rhythms.
 - Enable user-defined activity presets with saved profiles synchronized across devices.

--- a/docs/GITSTORY.md
+++ b/docs/GITSTORY.md
@@ -7,4 +7,5 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 - 2025-09-19 — feature+docs — Introduced CatNap Leap with a dreamy canvas game loop, registry wiring, and documentation updates across the catalog.
 - 2025-09-21 — feature+docs — Added the CatPad notepad with IndexedDB persistence, GitHub gist syncing, and refreshed docs/tests for the new launcher entry.
 
-2025-09-22 – Added Cache Lab Vite subapp with interactive cache modules, assessments, and dashboard.
+- 2025-09-22 — feature+docs — Added Cache Lab Vite subapp with interactive cache modules, assessments, and dashboard.
+- 2025-09-23 — feature+docs — Introduced Cat Typing Speed Test with a vanilla JS typing drill, launcher wiring, and refreshed documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ A small, modular React playground bundling multiple apps behind a simple launche
 
 - Day Switcher — flip through the week with animated transitions.
 - CatPad — jot notes with a cat-themed editor that syncs through GitHub gists.
+- Cat Typing Speed Test — practise timed typing drills with Kimchi, Rythm, and Siella.
 - N-Pomodoro — orchestrate multi-activity pomodoro sessions.
 - Snake — chase high scores across a responsive grid.
 - Hexa-Snake (Bee Edition) — guide a bee across a honeycomb board.

--- a/src/apps/CatTypingSpeedTestApp/CatTypingSpeedTestApp.css
+++ b/src/apps/CatTypingSpeedTestApp/CatTypingSpeedTestApp.css
@@ -1,0 +1,89 @@
+.cat-typing-wrapper {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: linear-gradient(145deg, rgba(255, 248, 252, 0.75), rgba(230, 242, 255, 0.75));
+  border-radius: 1.25rem;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
+}
+
+.cat-typing-intro p {
+  margin: 0;
+  color: #475569;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.cat-typing-frame {
+  width: 100%;
+  border: none;
+  min-height: 640px;
+  border-radius: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  background: #fff;
+}
+
+.cat-typing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cat-typing-link,
+.cat-typing-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cat-typing-link {
+  background: #ec4899;
+  color: #fff;
+  box-shadow: 0 12px 22px rgba(236, 72, 153, 0.35);
+}
+
+.cat-typing-link:hover,
+.cat-typing-link:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(236, 72, 153, 0.4);
+}
+
+.cat-typing-link:focus-visible,
+.cat-typing-back:focus-visible {
+  outline: 3px solid rgba(236, 72, 153, 0.45);
+  outline-offset: 3px;
+}
+
+.cat-typing-back {
+  border: none;
+  background: #fff;
+  color: #ec4899;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 2px rgba(236, 72, 153, 0.2);
+}
+
+.cat-typing-back:hover,
+.cat-typing-back:focus-visible {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 640px) {
+  .cat-typing-frame {
+    min-height: 520px;
+  }
+
+  .cat-typing-actions {
+    flex-direction: column;
+  }
+
+  .cat-typing-link,
+  .cat-typing-back {
+    justify-content: center;
+  }
+}

--- a/src/apps/CatTypingSpeedTestApp/CatTypingSpeedTestApp.js
+++ b/src/apps/CatTypingSpeedTestApp/CatTypingSpeedTestApp.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import './CatTypingSpeedTestApp.css';
+
+const CatTypingSpeedTestApp = ({ onBack }) => {
+  const base = process.env.PUBLIC_URL || '';
+  const appUrl = `${base}/apps/cat-typing-speed-test/`;
+
+  return (
+    <div className="cat-typing-wrapper">
+      <div className="cat-typing-intro">
+        <p>
+          Test your typing skills with a 15 or 30 second sprint featuring Kimchi, Rythm, and Siella.
+          The standalone experience loads below and can be opened in a new tab for a larger view.
+        </p>
+      </div>
+
+      <iframe
+        src={appUrl}
+        title="Cat Typing Speed Test"
+        className="cat-typing-frame"
+        loading="lazy"
+      />
+
+      <div className="cat-typing-actions">
+        <a className="cat-typing-link" href={appUrl} target="_blank" rel="noreferrer">
+          Open full window ↗
+        </a>
+        <button type="button" className="cat-typing-back" onClick={onBack}>
+          ← Back to Apps
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CatTypingSpeedTestApp;

--- a/src/apps/CatTypingSpeedTestApp/index.js
+++ b/src/apps/CatTypingSpeedTestApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './CatTypingSpeedTestApp';

--- a/src/apps/__tests__/registry.test.js
+++ b/src/apps/__tests__/registry.test.js
@@ -26,4 +26,14 @@ describe('app registry', () => {
     expect(catpad.icon).toBe('😺');
     expect(catpad.path).toBe('/apps/catpad');
   });
+
+  it('registers the Cat Typing Speed Test metadata', () => {
+    const typingTest = getAppById('cat-typing-speed-test');
+
+    expect(typingTest).toBeTruthy();
+    expect(typingTest.title).toBe('Cat Typing Speed Test');
+    expect(typingTest.category).toBe('Education');
+    expect(typingTest.icon).toBe('⌨️');
+    expect(typingTest.path).toBe('/apps/cat-typing-speed-test');
+  });
 });

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -28,6 +28,20 @@ export const APP_REGISTRY = {
     created: '2024-06-01',
     featured: true,
   },
+  'cat-typing-speed-test': {
+    id: 'cat-typing-speed-test',
+    title: 'Cat Typing Speed Test',
+    description: 'Sprint through cat-themed sentences to measure WPM, CPM, and accuracy.',
+    icon: '⌨️',
+    category: 'Education',
+    component: null,
+    path: '/apps/cat-typing-speed-test',
+    tags: ['typing', 'speed', 'practice', 'cats'],
+    version: '1.0.0',
+    author: 'OpenAI Assistant',
+    created: '2024-09-23',
+    featured: true,
+  },
   // Placeholder for future apps
   'n-pomodoro': {
     id: 'n-pomodoro',

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -18,6 +18,8 @@ const CatPadApp = React.lazy(() => import('../apps/CatPadApp'));
 
 const CacheLabApp = React.lazy(() => import('../apps/CacheLabApp'));
 
+const CatTypingSpeedTestApp = React.lazy(() => import('../apps/CatTypingSpeedTestApp'));
+
 
 const AppContainer = () => {
   const [currentView, setCurrentView] = useState('launcher'); // 'launcher' or 'app'
@@ -62,6 +64,9 @@ const AppContainer = () => {
 
       case 'cache-lab':
         return <CacheLabApp onBack={handleBackToLauncher} />;
+
+      case 'cat-typing-speed-test':
+        return <CatTypingSpeedTestApp onBack={handleBackToLauncher} />;
 
       default:
         return (

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,13 +51,21 @@ module.exports = {
       template: './public/index.html',
     }),
     new CopyWebpackPlugin({
-      patterns: [{ from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' }],
+      patterns: [
+        { from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' },
+        { from: path.resolve(__dirname, 'apps/cat-typing-speed-test'), to: 'apps/cat-typing-speed-test' },
+      ],
     }),
   ],
   devServer: {
-    static: {
-      directory: path.join(__dirname, 'public'),
-    },
+    static: [
+      {
+        directory: path.join(__dirname, 'public'),
+      },
+      {
+        directory: path.join(__dirname, 'apps'),
+      },
+    ],
     compress: true,
     port: 3000,
     open: true,


### PR DESCRIPTION
## Summary
- add a standalone Cat Typing Speed Test sub-app with timed runs, accuracy tracking, and cached cat corpus content
- embed the typing test in the React launcher, update registry coverage, and document the new experience
- copy the static assets during builds and expose the apps directory to the dev server

## Testing
- npm test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d097a58b3c832b82456b3a58d5abe3