### PR TITLE
Fix chess.js CDN reference

### DIFF
--- a/src/apps/ChessApp/ChessApp.js
+++ b/src/apps/ChessApp/ChessApp.js
@@ -11,7 +11,7 @@ const CHESSBOARD_STYLE_URL =
 const CHESSBOARD_SCRIPT_URL =
   'https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js';
 const CHESS_RULES_SCRIPT_URL =
-  'https://cdn.jsdelivr.net/npm/chess.js@1.0.0/dist/chess.min.js';
+  'https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js';
 const STOCKFISH_SCRIPT_URL =
   'https://cdn.jsdelivr.net/npm/stockfish@16.1.1/dist/stockfish.js';
 


### PR DESCRIPTION
## Summary
- point the chess rules loader at the stable chess.js 0.13.4 UMD bundle so the script can be fetched correctly

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0978803a8832ba7df2b4d1dbd7250