### PR TITLE
Bundle cache lab in deploy

### DIFF
--- a/apps/cache-lab/src/lib/cacheSimulator.ts
+++ b/apps/cache-lab/src/lib/cacheSimulator.ts
@@ -145,7 +145,10 @@ export function simulateCache(
     amat,
   };
 
-  const perAccess = internal.perAccess.map((item) => ({ ...item, missType: undefined }));
+  const perAccess: CacheSimulationResult['perAccess'] = internal.perAccess.map((item) => ({
+    ...item,
+    missType: undefined,
+  }));
 
   if (options.classifyMisses) {
     const classification = classifyMisses(trace, config);

--- a/apps/cache-lab/src/lib/traces.ts
+++ b/apps/cache-lab/src/lib/traces.ts
@@ -2,16 +2,16 @@ import { Access, Trace } from './types';
 import { SeededRNG } from './prng';
 
 function makeSequentialTrace(length: number): Access[] {
-  return Array.from({ length }, (_, i) => ({ address: i, type: 'R' }));
+  return Array.from({ length }, (_, i): Access => ({ address: i, type: 'R' }));
 }
 
 function makeStrideTrace(length: number, stride: number): Access[] {
-  return Array.from({ length }, (_, i) => ({ address: (i * stride) % length, type: 'R' }));
+  return Array.from({ length }, (_, i): Access => ({ address: (i * stride) % length, type: 'R' }));
 }
 
 function makeRandomTrace(length: number, seed = 42): Access[] {
   const rng = new SeededRNG(seed);
-  return Array.from({ length }, () => ({ address: Math.floor(rng.next() * length), type: 'R' }));
+  return Array.from({ length }, (): Access => ({ address: Math.floor(rng.next() * length), type: 'R' }));
 }
 
 export const builtInTraces: Trace[] = [
@@ -29,7 +29,10 @@ export function generateCustomTrace(expression: string, limit = 1024): Trace {
     }
     const start = Number(match[1]);
     const end = Number(match[2]);
-    const accesses = Array.from({ length: end - start + 1 }, (_, i) => ({ address: start + i, type: 'R' }));
+    const accesses: Access[] = Array.from({ length: end - start + 1 }, (_, i): Access => ({
+      address: start + i,
+      type: 'R',
+    }));
     return { name: `seq(${start}..${end})`, accesses };
   }
   if (trimmed.startsWith('stride(')) {
@@ -41,7 +44,10 @@ export function generateCustomTrace(expression: string, limit = 1024): Trace {
     const end = Number(match[2]);
     const stride = Number(match[3]);
     const length = Math.min(limit, Math.max(1, Math.floor((end - start + stride) / stride)));
-    const accesses = Array.from({ length }, (_, i) => ({ address: start + i * stride, type: 'R' }));
+    const accesses: Access[] = Array.from({ length }, (_, i): Access => ({
+      address: start + i * stride,
+      type: 'R',
+    }));
     return { name: `stride(${start}..${end},${stride})`, accesses };
   }
   if (trimmed.startsWith('random(')) {

--- a/apps/cache-lab/src/lib/types.ts
+++ b/apps/cache-lab/src/lib/types.ts
@@ -53,8 +53,13 @@ export interface CacheSimulationOptions {
 
 export interface CacheSimulationResult {
   metrics: ResultMetrics;
-  perAccess: { hit: boolean; missType?: 'compulsory' | 'conflict' | 'capacity'; setIndex: number; tag: number; }[];
-  perSet?: number[][];
+  perAccess: {
+    hit: boolean;
+    missType?: 'compulsory' | 'conflict' | 'capacity';
+    setIndex: number;
+    tag: number;
+  }[];
+  perSet?: number[][][];
 }
 
 export interface HierarchyLevelConfig {

--- a/apps/cache-lab/src/modules/ReplacementSimulator.tsx
+++ b/apps/cache-lab/src/modules/ReplacementSimulator.tsx
@@ -2,11 +2,11 @@ import { useEffect, useMemo } from 'react';
 import styles from './ModuleCard.module.css';
 import { useCacheLabStore } from '../state/useCacheLabStore';
 import { simulateCache } from '../lib/cacheSimulator';
-import { CacheConfig, ReplacementPolicy } from '../lib/types';
+import { Access, CacheConfig, ReplacementPolicy } from '../lib/types';
 
 const policies: ReplacementPolicy[] = ['LRU', 'FIFO', 'Random'];
 
-function runPolicy(config: CacheConfig, policy: ReplacementPolicy, accesses = config ? [] : []) {
+function runPolicy(config: CacheConfig, policy: ReplacementPolicy, accesses: Access[] = []) {
   const nextConfig = { ...config, replacementPolicy: policy } as CacheConfig;
   return simulateCache(accesses, nextConfig, { trackSets: true });
 }

--- a/apps/cache-lab/src/vite-env.d.ts
+++ b/apps/cache-lab/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/apps/cache-lab/vite.config.ts
+++ b/apps/cache-lab/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   build: {
     sourcemap: true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
       patterns: [
         { from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' },
         { from: path.resolve(__dirname, 'apps/cat-typing-speed-test'), to: 'apps/cat-typing-speed-test' },
+        { from: path.resolve(__dirname, 'apps/cache-lab/dist'), to: 'cache-lab' },
       ],
     }),
   ],


### PR DESCRIPTION
## Summary
- add Vite client type declarations and tighten Cache Lab typings so the TypeScript build succeeds
- configure the Cache Lab Vite build for relative asset paths and copy the generated bundle into the webpack dist
- ensure the GitHub Pages bundle includes the Cache Lab static site alongside existing sub-apps

## Testing
- pnpm --filter cache-lab build
- npm run build
- npm run deploy *(fails: missing git remote for gh-pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aa2ffcd8832b90c86bf70d1b2f31