### PR TITLE
feat: enrich CatNap Leap with lobby, treats, and safe spawns

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -19,7 +19,7 @@
 
 .scoreboard {
   display: grid;
-  grid-template-columns: repeat(3, minmax(80px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   background: rgba(255, 255, 255, 0.85);
   border-radius: 16px;
   padding: 0.75rem 1rem;
@@ -45,6 +45,45 @@
   font-size: 1.6rem;
   font-weight: 700;
   color: #2f2a45;
+}
+
+.score-item.treats .value {
+  color: #f47c9c;
+}
+
+.start-boost-banner {
+  flex: 1 1 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.5rem 0.9rem;
+  border-radius: 14px;
+  box-shadow: 0 12px 24px rgba(47, 42, 69, 0.08);
+  font-size: 0.8rem;
+  color: #4a3f70;
+}
+
+.start-boost-banner .boost-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6f5fb7;
+}
+
+.start-boost-banner ul {
+  display: flex;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.start-boost-banner li {
+  background: rgba(128, 111, 199, 0.18);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-weight: 600;
 }
 
 .drowsiness-meter {
@@ -168,6 +207,14 @@
   max-width: 540px;
 }
 
+.overlay-card.start {
+  max-width: 580px;
+}
+
+.overlay-card.shop {
+  max-width: 600px;
+}
+
 .overlay-card h2 {
   margin: 0 0 0.5rem;
   font-size: 1.8rem;
@@ -220,6 +267,10 @@
 
 .overlay-actions {
   margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
 }
 
 .cat-selection-grid {
@@ -271,6 +322,170 @@
   width: 100%;
   max-width: 120px;
   display: block;
+}
+
+.start-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.start-preview {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(123, 102, 255, 0.12);
+}
+
+.start-preview-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.start-preview-copy .cat-name {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: #3d3560;
+}
+
+.start-stats {
+  font-weight: 600;
+  color: #6f65a4;
+}
+
+.start-tip {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a096d3;
+}
+
+.queued-boosts {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(123, 102, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.queued-title {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: #6f65a4;
+}
+
+.queued-boosts ul {
+  margin: 0;
+  padding-left: 1rem;
+  color: #4f466f;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.start-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1.25rem;
+}
+
+.shop-inventory {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin: 1.25rem 0 0;
+}
+
+.shop-item {
+  border: 2px solid transparent;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 1rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 12px 24px rgba(47, 42, 69, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.shop-item:hover,
+.shop-item:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 28px rgba(47, 42, 69, 0.14);
+  outline: none;
+}
+
+.shop-item.is-focused {
+  border-color: #7b66ff;
+  box-shadow: 0 16px 32px rgba(123, 102, 255, 0.28);
+}
+
+.shop-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.shop-name {
+  font-weight: 700;
+  color: #3d3560;
+}
+
+.shop-cost {
+  font-weight: 600;
+  color: #f47c9c;
+}
+
+.shop-item p {
+  margin: 0;
+  color: #594f82;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.queued-count {
+  font-weight: 600;
+  color: #6f65a4;
+}
+
+.shop-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-weight: 600;
+  color: #4f466f;
+}
+
+.shop-treats {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.shop-feedback {
+  color: #7b66ff;
+}
+
+.treat-summary {
+  font-weight: 600;
+  color: #6f65a4;
+  margin: 0.5rem 0 0;
 }
 
 .catnap-footer {
@@ -331,5 +546,14 @@
 
   .cat-selection-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .start-preview {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .shop-inventory {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/apps/CatNapLeapApp/spawnLogic.js
+++ b/src/apps/CatNapLeapApp/spawnLogic.js
@@ -1,0 +1,155 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const POWERUP_TYPES = ['coffee', 'yarn', 'catnip'];
+
+const uniqueLanes = (lanes, minGap) => {
+  const sorted = [...lanes]
+    .filter((lane) => Number.isFinite(lane))
+    .sort((a, b) => a - b);
+  const result = [];
+  sorted.forEach((lane) => {
+    if (result.every((existing) => Math.abs(existing - lane) >= minGap)) {
+      result.push(lane);
+    }
+  });
+  return result;
+};
+
+const computeCandidateLanes = (state) => {
+  const { canvasHeight, pillows = [] } = state;
+  const lanes = [];
+
+  if (!pillows.length) {
+    lanes.push(canvasHeight * 0.5);
+  } else {
+    const recent = pillows.slice(-4);
+    recent.forEach((pillow) => {
+      const { gapCenter, gapHeight } = pillow;
+      const top = gapCenter - gapHeight / 2;
+      const bottom = gapCenter + gapHeight / 2;
+      const band = gapHeight * 0.22;
+      lanes.push(gapCenter);
+      lanes.push(clamp(gapCenter + band, top + band * 0.5, bottom - band * 0.5));
+      lanes.push(clamp(gapCenter - band, top + band * 0.5, bottom - band * 0.5));
+    });
+  }
+
+  // add gentle fallback lanes to keep variety
+  lanes.push(canvasHeight * 0.35, canvasHeight * 0.65);
+
+  return uniqueLanes(lanes, canvasHeight * 0.08);
+};
+
+const laneIsClear = (lane, radius, state, options = {}) => {
+  const { pillows = [], powerups = [], birds = [], canvasHeight, cat } = state;
+  const margin = options.margin ?? 18;
+  const catStartY = options.catStartY ?? (state.canvasHeight * 0.5);
+  const time = options.time ?? 0;
+
+  if (lane < radius + 60 || lane > canvasHeight - radius - 60) {
+    return false;
+  }
+
+  for (let i = 0; i < pillows.length; i += 1) {
+    const pillow = pillows[i];
+    const gapTop = pillow.gapCenter - pillow.gapHeight / 2;
+    const gapBottom = pillow.gapCenter + pillow.gapHeight / 2;
+    if (lane < gapTop + radius + margin || lane > gapBottom - radius - margin) {
+      return false;
+    }
+  }
+
+  for (let i = 0; i < powerups.length; i += 1) {
+    const other = powerups[i];
+    if (Math.abs(other.y - lane) < other.radius + radius + margin) {
+      return false;
+    }
+  }
+
+  for (let i = 0; i < birds.length; i += 1) {
+    const bird = birds[i];
+    if (Math.abs(bird.y - lane) < (bird.radius || 0) + radius + margin) {
+      return false;
+    }
+  }
+
+  if (time < 2600) {
+    const catRadius = cat?.radius ?? 0;
+    if (Math.abs(lane - catStartY) < catRadius * 1.6 + radius) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const getNextPowerupType = () => {
+  const index = Math.floor(Math.random() * POWERUP_TYPES.length);
+  return POWERUP_TYPES[index];
+};
+
+export const createPowerupSpawn = (state, preferredType) => {
+  const radius = Math.max(12, state.canvasWidth * 0.025);
+  const spawnXBase = state.canvasWidth + radius * 3;
+  let spawnX = spawnXBase;
+
+  if (state.pillows?.length) {
+    const last = state.pillows[state.pillows.length - 1];
+    if (last) {
+      spawnX = Math.max(spawnX, last.x + last.width + radius * 4);
+    }
+  }
+
+  const lanes = computeCandidateLanes(state);
+  const shuffled = [...lanes].sort(() => Math.random() - 0.5);
+  const type = preferredType || getNextPowerupType();
+
+  for (let i = 0; i < shuffled.length; i += 1) {
+    const lane = shuffled[i];
+    if (laneIsClear(lane, radius, state, { catStartY: state.canvasHeight * 0.5, time: state.time })) {
+      return {
+        type,
+        x: spawnX,
+        y: lane,
+        radius,
+      };
+    }
+  }
+
+  return null;
+};
+
+export const createBirdSpawn = (state) => {
+  const radius = Math.max(14, state.canvasWidth * 0.03);
+  const lanes = computeCandidateLanes(state);
+  const shuffled = [...lanes].sort(() => Math.random() - 0.5);
+
+  for (let i = 0; i < shuffled.length; i += 1) {
+    const lane = shuffled[i];
+    if (!laneIsClear(lane, radius, state, { margin: 22, catStartY: state.canvasHeight * 0.5, time: state.time })) {
+      // lane isn't safe for a bird; try next option
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const direction = Math.random() > 0.5 ? 1 : -1;
+    const x = direction === 1 ? -radius * 2 - 40 : state.canvasWidth + radius * 2 + 40;
+    const speed = 110 + Math.random() * 60;
+    return {
+      x,
+      y: lane,
+      radius,
+      direction,
+      speed,
+      flapOffset: Math.random() * Math.PI * 2,
+    };
+  }
+
+  return null;
+};
+
+export const summarizeLoadout = (loadout) =>
+  Object.entries(loadout)
+    .filter(([, count]) => count > 0)
+    .map(([type, count]) => ({ type, count }));
+


### PR DESCRIPTION
## Summary
- add a spawn helper to position power-ups and birds away from obstacles and the cat’s launch path
- track session treats, spawn collectible birds, and apply shop boosts when a run begins in CatNap Leap
- introduce a lobby with cat selection, treat shop, updated HUD, and responsive styling cues

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0ade44a44832b8f6eaf8e28909e2c