### PR TITLE
Build Cache Lab assets before webpack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Then open http://localhost:3000.
 npm run build
 ```
 
-Artifacts are emitted to `dist/`.
+This composite step first builds the Cache Lab Vite bundle from `apps/cache-lab`, then runs Webpack to emit launcher assets into `dist/`.
 
 ### Deploy (GitHub Pages)
 
@@ -81,7 +81,8 @@ Your site will be available at the `homepage` URL.
 ## Scripts
 
 - `npm start` — Start webpack dev server at `http://localhost:3000`
-- `npm run build` — Create production build in `dist/`
+- `npm run build:cache-lab` — Build the Cache Lab assets within `apps/cache-lab`
+- `npm run build` — Build Cache Lab and create the launcher production bundle in `dist/`
 - `npm run deploy` — Publish `dist/` to `gh-pages`
 
 ## Project structure

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack serve --mode development",
-    "build": "webpack --mode production",
+    "build:cache-lab": "npm --prefix apps/cache-lab run build",
+    "build": "npm run build:cache-lab && webpack --mode production",
     "test": "jest",
     "deploy": "gh-pages -d dist",
     "test:cache-lab": "pnpm --filter cache-lab test",


### PR DESCRIPTION
## Summary
- add a `build:cache-lab` helper so the launcher can trigger the Vite bundle
- run the cache-lab build before webpack's production build to ensure dist assets exist
- document the composite build flow for contributors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b37686c4832b9ef13f84b9f409e1