### PR TITLE
chore(cache-lab): use build-only tsconfig

### DIFF
--- a/apps/cache-lab/package.json
+++ b/apps/cache-lab/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -p tsconfig.build.json && vite build",
     "preview": "vite preview",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/cache-lab/tsconfig.build.json
+++ b/apps/cache-lab/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src"]
+}

--- a/apps/cache-lab/vite.config.ts
+++ b/apps/cache-lab/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       lines: 0.9,
       branches: 0.9
+    },
+    typecheck: {
+      tsconfig: './tsconfig.json'
     }
   }
 });


### PR DESCRIPTION
## Summary
- add a dedicated tsconfig.build.json that only covers production sources
- point the build script at the new config before running the Vite bundle
- configure Vitest to type check with the existing tsconfig that contains its globals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b65cb990832b9ee0be7d62f10f5b