### PR TITLE
Enable All Tasks drag cloning and iconize focus controls

### DIFF
--- a/src/apps/ZenDoApp/views/FocusView.js
+++ b/src/apps/ZenDoApp/views/FocusView.js
@@ -102,11 +102,15 @@ const FocusView = ({
           <div className="zen-timer-label">{phaseLabel}</div>
           <div className="zen-timer-display">{formattedTime}</div>
           <div className="zen-timer-controls">
-            <button type="button" onClick={handlePauseToggle}>
-              {paused ? 'Resume' : 'Pause'}
+            <button
+              type="button"
+              onClick={handlePauseToggle}
+              aria-label={paused ? 'Resume timer' : 'Pause timer'}
+            >
+              {paused ? '▶️' : '⏸️'}
             </button>
-            <button type="button" onClick={handleSkip}>
-              Skip
+            <button type="button" onClick={handleSkip} aria-label="Skip phase">
+              ⏭️
             </button>
           </div>
         </div>

--- a/src/apps/ZenDoApp/views/LandingView.js
+++ b/src/apps/ZenDoApp/views/LandingView.js
@@ -22,8 +22,9 @@ const LandingView = ({
   const sortablesRef = useRef({});
 
   useEffect(() => {
-    if (!allTasksRef.current) return undefined;
-    const sortable = Sortable.create(allTasksRef.current, {
+    const listElement = allTasksRef.current?.querySelector('.zen-task-tree');
+    if (!listElement) return undefined;
+    const sortable = Sortable.create(listElement, {
       group: { name: 'zen-weekly', pull: 'clone', put: false },
       animation: 150,
       sort: false,
@@ -38,8 +39,14 @@ const LandingView = ({
         }
       },
     });
-    return () => sortable.destroy();
-  }, []);
+    sortablesRef.current.allTasks = sortable;
+    return () => {
+      sortable.destroy();
+      if (sortablesRef.current.allTasks === sortable) {
+        delete sortablesRef.current.allTasks;
+      }
+    };
+  }, [tasks]);
 
   useEffect(() => {
     DAY_ORDER.forEach((day) => {


### PR DESCRIPTION
## Summary
- hook the landing view drag source to the rendered task tree so weekly buckets accept drops while keeping tasks listed
- clean up the all-tasks Sortable instance alongside the existing bucket sortables
- swap the focus mode pause/skip text buttons for accessible icon controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ca5b0dc8832bb2e5615d459c87bb