### PR TITLE
Add decaf mode and coffee-themed Sudoku difficulties

### DIFF
--- a/src/apps/SudokuApp/SudokuApp.js
+++ b/src/apps/SudokuApp/SudokuApp.js
@@ -1,22 +1,20 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './SudokuApp.css';
 import {
-  DIFFICULTY_LEVELS,
-  GRID_SIZE,
   generateSudoku,
+  getDifficultyConfig,
   getDifficultyLevels,
   isBoardComplete,
   solveSudoku,
 } from './sudokuLogic';
 
 const CANVAS_SIZE = 540;
-const CELL_SIZE = CANVAS_SIZE / GRID_SIZE;
 
 const cloneBoard = (board) => board.map((row) => row.slice());
 
-const createEmptyNotes = () =>
-  Array.from({ length: GRID_SIZE }, () =>
-    Array.from({ length: GRID_SIZE }, () => new Set())
+const createEmptyNotes = (size) =>
+  Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => new Set())
   );
 
 const toBoardSignature = (board) => board.map((row) => row.join('')).join('|');
@@ -35,23 +33,34 @@ const toNotesSignature = (notes) =>
 const SudokuApp = ({ onBack }) => {
   const initialGameRef = useRef(null);
   if (!initialGameRef.current) {
-    initialGameRef.current = generateSudoku('easy');
+    initialGameRef.current = generateSudoku();
   }
 
   const [difficulty, setDifficulty] = useState(
-    initialGameRef.current.difficulty || 'easy'
+    initialGameRef.current.difficulty
   );
   const [gameData, setGameData] = useState(initialGameRef.current);
   const [board, setBoard] = useState(() =>
     cloneBoard(initialGameRef.current.puzzle)
   );
-  const [notes, setNotes] = useState(() => createEmptyNotes());
+  const [notes, setNotes] = useState(() =>
+    createEmptyNotes(initialGameRef.current.gridSize)
+  );
   const [selectedCell, setSelectedCell] = useState({ row: 0, col: 0 });
   const [noteMode, setNoteMode] = useState(false);
   const [isBoardAnimating, setIsBoardAnimating] = useState(false);
   const [lastAction, setLastAction] = useState('Breathe in the aroma and begin.');
   const canvasRef = useRef(null);
   const animationTimeoutRef = useRef(null);
+
+  const gridSize = gameData.gridSize;
+  const subgridSize = gameData.subgridSize;
+  const symbolNames = gameData.symbols || [];
+  const isShapeMode = symbolNames.length > 0;
+  const maxEntryValue = isShapeMode ? symbolNames.length : gridSize;
+  const totalCells = gridSize * gridSize;
+  const difficultyLabel = gameData.label || difficulty;
+  const difficultyOptions = useMemo(() => getDifficultyLevels(), []);
 
   const lockedCells = useMemo(
     () => gameData.puzzle.map((row) => row.map((value) => value !== 0)),
@@ -60,7 +69,7 @@ const SudokuApp = ({ onBack }) => {
 
   useEffect(() => {
     setBoard(cloneBoard(gameData.puzzle));
-    setNotes(createEmptyNotes());
+    setNotes(createEmptyNotes(gameData.gridSize));
     setSelectedCell({ row: 0, col: 0 });
     setNoteMode(false);
     setLastAction('Freshly brewed puzzle, enjoy the calm.');
@@ -80,15 +89,15 @@ const SudokuApp = ({ onBack }) => {
   const boardMatchesSolution = useMemo(() => {
     const { solution } = gameData;
     if (!solution) return false;
-    for (let row = 0; row < GRID_SIZE; row += 1) {
-      for (let col = 0; col < GRID_SIZE; col += 1) {
+    for (let row = 0; row < gridSize; row += 1) {
+      for (let col = 0; col < gridSize; col += 1) {
         if (board[row][col] !== solution[row][col]) {
           return false;
         }
       }
     }
     return true;
-  }, [board, gameData]);
+  }, [board, gameData, gridSize]);
 
   const filledCount = useMemo(
     () => board.reduce((acc, row) => acc + row.filter((value) => value !== 0).length, 0),
@@ -99,11 +108,14 @@ const SudokuApp = ({ onBack }) => {
     if (boardMatchesSolution && isBoardComplete(board)) {
       return 'Complete! Treat yourself to a refill.';
     }
-    if (noteMode) {
+    if (noteMode && !isShapeMode) {
       return 'Note mode: gentle pencil marks for possibilities.';
     }
+    if (isShapeMode) {
+      return 'Decaf mode: tap squares to cycle through cozy shapes.';
+    }
     return 'Final mode: place numbers with a steady hand.';
-  }, [board, boardMatchesSolution, noteMode]);
+  }, [board, boardMatchesSolution, isShapeMode, noteMode]);
 
   const triggerBoardAnimation = useCallback(() => {
     setIsBoardAnimating(true);
@@ -117,9 +129,13 @@ const SudokuApp = ({ onBack }) => {
 
   const startNewPuzzle = useCallback(
     (level) => {
-      const targetLevel = DIFFICULTY_LEVELS[level] ? level : difficulty;
-      const nextGame = generateSudoku(targetLevel);
-      setDifficulty(targetLevel);
+      const requestedConfig = level ? getDifficultyConfig(level) : null;
+      const targetId =
+        level && requestedConfig && requestedConfig.id !== level
+          ? difficulty
+          : (requestedConfig ? requestedConfig.id : difficulty);
+      const nextGame = generateSudoku(targetId);
+      setDifficulty(nextGame.difficulty);
       setGameData(nextGame);
       triggerBoardAnimation();
     },
@@ -147,14 +163,18 @@ const SudokuApp = ({ onBack }) => {
     if (gameData.solution) {
       solvedBoard = cloneBoard(gameData.solution);
     } else if (gameData.puzzle) {
-      const computedFromPuzzle = solveSudoku(gameData.puzzle);
+      const computedFromPuzzle = solveSudoku(
+        gameData.puzzle,
+        gridSize,
+        subgridSize
+      );
       if (computedFromPuzzle) {
         solvedBoard = computedFromPuzzle;
       }
     }
 
     if (!solvedBoard) {
-      const computedFromBoard = solveSudoku(board);
+      const computedFromBoard = solveSudoku(board, gridSize, subgridSize);
       if (computedFromBoard) {
         solvedBoard = computedFromBoard;
       }
@@ -173,31 +193,75 @@ const SudokuApp = ({ onBack }) => {
   }, [board, boardMatchesSolution, gameData, triggerBoardAnimation]);
 
   const handleCanvasSelection = (event) => {
-    if (!canvasRef.current) return;
+    if (!canvasRef.current) return null;
     const rect = canvasRef.current.getBoundingClientRect();
     const scaleX = CANVAS_SIZE / rect.width;
     const scaleY = CANVAS_SIZE / rect.height;
     const x = (event.clientX - rect.left) * scaleX;
     const y = (event.clientY - rect.top) * scaleY;
-    const row = Math.max(0, Math.min(GRID_SIZE - 1, Math.floor(y / CELL_SIZE)));
-    const col = Math.max(0, Math.min(GRID_SIZE - 1, Math.floor(x / CELL_SIZE)));
-    setSelectedCell({ row, col });
+    const cellSize = CANVAS_SIZE / gridSize;
+    const row = Math.max(0, Math.min(gridSize - 1, Math.floor(y / cellSize)));
+    const col = Math.max(0, Math.min(gridSize - 1, Math.floor(x / cellSize)));
+    const coords = { row, col };
+    setSelectedCell(coords);
+    return coords;
   };
 
   const handleCanvasClick = (event) => {
-    handleCanvasSelection(event);
-    setLastAction('Cell selected — sip slowly and decide.');
+    const coords = handleCanvasSelection(event);
+    if (!coords) return;
+
+    const { row, col } = coords;
+
+    if (isShapeMode && !lockedCells[row][col]) {
+      setNoteMode(false);
+      clearNotesAt(row, col);
+      const nextValue = (() => {
+        let updated = 0;
+        setBoard((prev) => {
+          const next = prev.map((r) => r.slice());
+          const current = next[row][col];
+          const candidate = current >= maxEntryValue ? 0 : current + 1;
+          next[row][col] = candidate;
+          updated = candidate;
+          return next;
+        });
+        return updated;
+      })();
+      if (nextValue === 0) {
+        setLastAction('Cleared the cup — back to a blank slate.');
+      } else {
+        const shapeName = symbolNames[nextValue - 1];
+        setLastAction(`Placed ${shapeName} — playful and light.`);
+      }
+    } else {
+      setLastAction('Cell selected — sip slowly and decide.');
+    }
   };
 
   const handleCanvasDoubleClick = (event) => {
-    handleCanvasSelection(event);
+    const coords = handleCanvasSelection(event);
+    if (!coords) return;
+
+    if (isShapeMode) {
+      setLastAction('Decaf mode keeps things simple — notes stay tucked away.');
+      return;
+    }
+
     setNoteMode((prev) => !prev);
     setLastAction('Mode toggled — pencil or pen, your choice.');
   };
 
   const handleCanvasContextMenu = (event) => {
     event.preventDefault();
-    handleCanvasSelection(event);
+    const coords = handleCanvasSelection(event);
+    if (!coords) return;
+
+    if (isShapeMode) {
+      setLastAction('Decaf mode is all intuition — notes are unavailable.');
+      return;
+    }
+
     setNoteMode(true);
     setLastAction('Note mode engaged — jot gentle hints.');
   };
@@ -234,10 +298,10 @@ const SudokuApp = ({ onBack }) => {
   const moveSelection = (direction) => {
     setSelectedCell((prev) => {
       let { row, col } = prev;
-      if (direction === 'up') row = (row + GRID_SIZE - 1) % GRID_SIZE;
-      if (direction === 'down') row = (row + 1) % GRID_SIZE;
-      if (direction === 'left') col = (col + GRID_SIZE - 1) % GRID_SIZE;
-      if (direction === 'right') col = (col + 1) % GRID_SIZE;
+      if (direction === 'up') row = (row + gridSize - 1) % gridSize;
+      if (direction === 'down') row = (row + 1) % gridSize;
+      if (direction === 'left') col = (col + gridSize - 1) % gridSize;
+      if (direction === 'right') col = (col + 1) % gridSize;
       return { row, col };
     });
   };
@@ -271,37 +335,55 @@ const SudokuApp = ({ onBack }) => {
 
       if (locked) return;
 
-      if (/^[1-9]$/.test(event.key)) {
-        const value = parseInt(event.key, 10);
-        if (noteMode) {
-          toggleNoteValue(row, col, value);
-          setLastAction(`Noted ${value} — soft pencil whispers.`);
-        } else {
-          updateBoardValue(row, col, value);
+      const numericValue = Number.parseInt(event.key, 10);
+      if (
+        !Number.isNaN(numericValue) &&
+        numericValue >= 1 &&
+        numericValue <= maxEntryValue
+      ) {
+        if (isShapeMode) {
+          updateBoardValue(row, col, numericValue);
           clearNotesAt(row, col);
-          setLastAction(`Placed ${value} with confidence.`);
+          setNoteMode(false);
+          const shapeName = symbolNames[numericValue - 1];
+          setLastAction(`Placed ${shapeName} — playful and light.`);
+        } else if (noteMode) {
+          toggleNoteValue(row, col, numericValue);
+          setLastAction(`Noted ${numericValue} — soft pencil whispers.`);
+        } else {
+          updateBoardValue(row, col, numericValue);
+          clearNotesAt(row, col);
+          setLastAction(`Placed ${numericValue} with confidence.`);
         }
       } else if (event.key === 'Backspace' || event.key === 'Delete') {
-        if (noteMode) {
+        if (noteMode && !isShapeMode) {
           clearNotesAt(row, col);
           setLastAction('Notes cleared — fresh parchment.');
         } else {
           updateBoardValue(row, col, 0);
           clearNotesAt(row, col);
-          setLastAction('Cell cleared — savor the pause.');
+          setLastAction(
+            isShapeMode
+              ? 'Cleared the cup — back to a blank slate.'
+              : 'Cell cleared — savor the pause.'
+          );
         }
       }
     },
     [
       clearNotesAt,
+      isShapeMode,
       lockedCells,
+      maxEntryValue,
       moveSelection,
       noteMode,
       selectedCell,
+      symbolNames,
       toggleNoteValue,
       updateBoardValue,
     ]
   );
+
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
@@ -315,6 +397,54 @@ const SudokuApp = ({ onBack }) => {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+
+    const cellSize = CANVAS_SIZE / gridSize;
+    const noteGridSize = isShapeMode ? 2 : 3;
+    const noteCellSize = cellSize / noteGridSize;
+
+    const drawShape = (shapeName, centerX, centerY, size, options = {}) => {
+      const {
+        strokeStyle = 'rgba(93, 66, 46, 0.92)',
+        fillStyle = 'transparent',
+        lineWidth = 2,
+      } = options;
+      ctx.save();
+      ctx.lineWidth = lineWidth;
+      ctx.strokeStyle = strokeStyle;
+      ctx.fillStyle = fillStyle;
+      if (shapeName === 'Circle') {
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, size, 0, Math.PI * 2);
+        ctx.stroke();
+      } else if (shapeName === 'Triangle') {
+        ctx.beginPath();
+        ctx.moveTo(centerX, centerY - size);
+        ctx.lineTo(centerX - size, centerY + size);
+        ctx.lineTo(centerX + size, centerY + size);
+        ctx.closePath();
+        ctx.stroke();
+      } else if (shapeName === 'Square') {
+        const half = size;
+        ctx.strokeRect(centerX - half, centerY - half, half * 2, half * 2);
+      } else if (shapeName === 'Star') {
+        ctx.beginPath();
+        const spikes = 5;
+        for (let i = 0; i < spikes * 2; i += 1) {
+          const radius = i % 2 === 0 ? size : size * 0.45;
+          const angle = (Math.PI / spikes) * i - Math.PI / 2;
+          const x = centerX + Math.cos(angle) * radius;
+          const y = centerY + Math.sin(angle) * radius;
+          if (i === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+        ctx.closePath();
+        ctx.stroke();
+      }
+      ctx.restore();
+    };
 
     ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
 
@@ -335,86 +465,130 @@ const SudokuApp = ({ onBack }) => {
 
     if (selectedCell) {
       const { row, col } = selectedCell;
-      // Highlight subgrid
-      const subgridRow = Math.floor(row / 3) * 3;
-      const subgridCol = Math.floor(col / 3) * 3;
+      const subgridRow = Math.floor(row / subgridSize) * subgridSize;
+      const subgridCol = Math.floor(col / subgridSize) * subgridSize;
       ctx.fillStyle = 'rgba(210, 180, 140, 0.18)';
       ctx.fillRect(
-        subgridCol * CELL_SIZE,
-        subgridRow * CELL_SIZE,
-        CELL_SIZE * 3,
-        CELL_SIZE * 3
+        subgridCol * cellSize,
+        subgridRow * cellSize,
+        cellSize * subgridSize,
+        cellSize * subgridSize
       );
 
-      // Highlight row and column
       ctx.fillStyle = 'rgba(201, 168, 132, 0.18)';
-      ctx.fillRect(0, row * CELL_SIZE, CANVAS_SIZE, CELL_SIZE);
-      ctx.fillRect(col * CELL_SIZE, 0, CELL_SIZE, CANVAS_SIZE);
+      ctx.fillRect(0, row * cellSize, CANVAS_SIZE, cellSize);
+      ctx.fillRect(col * cellSize, 0, cellSize, CANVAS_SIZE);
 
-      // Selected cell highlight
       ctx.fillStyle = noteMode
         ? 'rgba(226, 202, 171, 0.6)'
         : 'rgba(202, 174, 139, 0.6)';
-      ctx.fillRect(col * CELL_SIZE, row * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+      ctx.fillRect(col * cellSize, row * cellSize, cellSize, cellSize);
     }
 
-    // Grid lines
-    for (let i = 0; i <= GRID_SIZE; i += 1) {
+    for (let i = 0; i <= gridSize; i += 1) {
       ctx.beginPath();
-      ctx.moveTo(0, i * CELL_SIZE);
-      ctx.lineTo(CANVAS_SIZE, i * CELL_SIZE);
-      ctx.strokeStyle = i % 3 === 0 ? 'rgba(111, 78, 55, 0.55)' : 'rgba(111, 78, 55, 0.25)';
-      ctx.lineWidth = i % 3 === 0 ? 2 : 1;
+      ctx.moveTo(0, i * cellSize);
+      ctx.lineTo(CANVAS_SIZE, i * cellSize);
+      ctx.strokeStyle =
+        i % subgridSize === 0
+          ? 'rgba(111, 78, 55, 0.55)'
+          : 'rgba(111, 78, 55, 0.25)';
+      ctx.lineWidth = i % subgridSize === 0 ? 2 : 1;
       ctx.stroke();
 
       ctx.beginPath();
-      ctx.moveTo(i * CELL_SIZE, 0);
-      ctx.lineTo(i * CELL_SIZE, CANVAS_SIZE);
-      ctx.strokeStyle = i % 3 === 0 ? 'rgba(111, 78, 55, 0.55)' : 'rgba(111, 78, 55, 0.25)';
-      ctx.lineWidth = i % 3 === 0 ? 2 : 1;
+      ctx.moveTo(i * cellSize, 0);
+      ctx.lineTo(i * cellSize, CANVAS_SIZE);
+      ctx.strokeStyle =
+        i % subgridSize === 0
+          ? 'rgba(111, 78, 55, 0.55)'
+          : 'rgba(111, 78, 55, 0.25)';
+      ctx.lineWidth = i % subgridSize === 0 ? 2 : 1;
       ctx.stroke();
     }
 
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
 
-    for (let row = 0; row < GRID_SIZE; row += 1) {
-      for (let col = 0; col < GRID_SIZE; col += 1) {
-        const centerX = col * CELL_SIZE + CELL_SIZE / 2;
-        const centerY = row * CELL_SIZE + CELL_SIZE / 2;
+    for (let row = 0; row < gridSize; row += 1) {
+      for (let col = 0; col < gridSize; col += 1) {
+        const centerX = col * cellSize + cellSize / 2;
+        const centerY = row * cellSize + cellSize / 2;
         const puzzleValue = gameData.puzzle[row][col];
         const value = board[row][col];
 
         if (puzzleValue !== 0) {
-          ctx.fillStyle = 'rgba(101, 77, 57, 0.95)';
-          ctx.font = `600 ${CELL_SIZE * 0.55}px 'Work Sans', 'Segoe UI', sans-serif`;
-          ctx.fillText(puzzleValue, centerX, centerY + 2);
+          if (isShapeMode) {
+            const shapeName = symbolNames[puzzleValue - 1];
+            drawShape(shapeName, centerX, centerY, cellSize * 0.3, {
+              strokeStyle: 'rgba(101, 77, 57, 0.95)',
+              lineWidth: 2.4,
+            });
+          } else {
+            ctx.fillStyle = 'rgba(101, 77, 57, 0.95)';
+            ctx.font = `600 ${cellSize * 0.55}px 'Work Sans', 'Segoe UI', sans-serif`;
+            ctx.fillText(puzzleValue, centerX, centerY + 2);
+          }
         } else if (value !== 0) {
           const isCorrect = gameData.solution[row][col] === value;
-          ctx.fillStyle = isCorrect
-            ? 'rgba(93, 66, 46, 0.92)'
-            : 'rgba(164, 82, 62, 0.85)';
-          ctx.font = `500 ${CELL_SIZE * 0.55}px 'Work Sans', 'Segoe UI', sans-serif`;
-          ctx.fillText(value, centerX, centerY + 2);
+          if (isShapeMode) {
+            const shapeName = symbolNames[value - 1];
+            drawShape(shapeName, centerX, centerY, cellSize * 0.3, {
+              strokeStyle: isCorrect
+                ? 'rgba(93, 66, 46, 0.92)'
+                : 'rgba(164, 82, 62, 0.85)',
+              lineWidth: 2,
+            });
+          } else {
+            ctx.fillStyle = isCorrect
+              ? 'rgba(93, 66, 46, 0.92)'
+              : 'rgba(164, 82, 62, 0.85)';
+            ctx.font = `500 ${cellSize * 0.55}px 'Work Sans', 'Segoe UI', sans-serif`;
+            ctx.fillText(value, centerX, centerY + 2);
+          }
         } else {
           const cellNotes = notes[row][col];
           if (cellNotes && cellNotes.size) {
-            ctx.fillStyle = 'rgba(111, 78, 55, 0.55)';
-            ctx.font = `400 ${CELL_SIZE / 3.2}px 'Work Sans', 'Segoe UI', sans-serif`;
-            const sortedNotes = Array.from(cellNotes).sort((a, b) => a - b);
+            const sortedNotes = Array.from(cellNotes)
+              .filter((note) => note <= maxEntryValue)
+              .sort((a, b) => a - b);
             sortedNotes.forEach((note) => {
               const index = note - 1;
-              const noteRow = Math.floor(index / 3);
-              const noteCol = index % 3;
-              const noteX = col * CELL_SIZE + (noteCol + 0.5) * (CELL_SIZE / 3);
-              const noteY = row * CELL_SIZE + (noteRow + 0.5) * (CELL_SIZE / 3);
-              ctx.fillText(note, noteX, noteY);
+              const noteRow = Math.floor(index / noteGridSize);
+              const noteCol = index % noteGridSize;
+              const noteX =
+                col * cellSize + (noteCol + 0.5) * noteCellSize;
+              const noteY =
+                row * cellSize + (noteRow + 0.5) * noteCellSize;
+
+              if (isShapeMode) {
+                const shapeName = symbolNames[note - 1];
+                drawShape(shapeName, noteX, noteY, noteCellSize * 0.35, {
+                  strokeStyle: 'rgba(111, 78, 55, 0.55)',
+                  lineWidth: 1.2,
+                });
+              } else {
+                ctx.fillStyle = 'rgba(111, 78, 55, 0.55)';
+                ctx.font = `400 ${cellSize / 3.2}px 'Work Sans', 'Segoe UI', sans-serif`;
+                ctx.fillText(note, noteX, noteY);
+              }
             });
           }
         }
       }
     }
-  }, [board, gameData, noteMode, notes, selectedCell]);
+  }, [
+    board,
+    gameData,
+    gridSize,
+    isShapeMode,
+    maxEntryValue,
+    noteMode,
+    notes,
+    selectedCell,
+    subgridSize,
+    symbolNames,
+  ]);
 
   return (
     <div className="sudoku-coffee-shell font-sudoku text-coffee-ink">
@@ -427,37 +601,41 @@ const SudokuApp = ({ onBack }) => {
               </span>
               <h2 className="text-3xl md:text-4xl font-semibold tracking-tight">Sudoku Roast</h2>
               <p className="text-sm text-coffee-hazelnut/80 max-w-md">
-                Gentle numbers steeped in warm hues. Type to place digits, right-click for
-                notes, and double-click to toggle between mindful note-taking and final
-                answers.
+                Gentle puzzles steeped in warm hues. Tap Decaf for shape-based play, type
+                digits in the stronger roasts, right-click for notes, and double-click to
+                toggle between mindful note-taking and final answers.
               </p>
             </div>
 
             <div className="flex flex-wrap gap-2" role="group" aria-label="Select difficulty">
-              {getDifficultyLevels().map((level) => (
+              {difficultyOptions.map(({ id, label }) => (
                 <button
-                  key={level}
+                  key={id}
                   type="button"
                   className={`coffee-chip px-4 py-2 rounded-full text-xs uppercase tracking-[0.25em] transition-all duration-300 hover:translate-y-[-1px] hover:shadow-lg ${
-                    difficulty === level ? 'coffee-chip-active' : 'text-coffee-ink/70'
+                    difficulty === id ? 'coffee-chip-active' : 'text-coffee-ink/70'
                   }`}
-                  onClick={() => handleDifficultyChange(level)}
-                  data-testid={`difficulty-${level}`}
+                  onClick={() => handleDifficultyChange(id)}
+                  data-testid={`difficulty-${id}`}
                 >
-                  {level}
+                  {label}
                 </button>
               ))}
             </div>
 
             <div className="flex flex-wrap items-center gap-3 text-xs md:text-sm">
               <span className="status-badge px-4 py-1 rounded-full uppercase tracking-[0.2em]">
-                {noteMode ? 'Note mode' : 'Final entry'}
+                {noteMode && !isShapeMode
+                  ? 'Note mode'
+                  : isShapeMode
+                  ? 'Shape cycling'
+                  : 'Final entry'}
               </span>
               <span className="status-badge px-4 py-1 rounded-full uppercase tracking-[0.2em]">
-                {difficulty} blend
+                {difficultyLabel} blend
               </span>
               <span className="status-badge px-4 py-1 rounded-full uppercase tracking-[0.2em]">
-                {filledCount} / 81 filled
+                {filledCount} / {totalCells} filled
               </span>
             </div>
 

--- a/src/apps/SudokuApp/__tests__/SudokuApp.test.js
+++ b/src/apps/SudokuApp/__tests__/SudokuApp.test.js
@@ -33,10 +33,14 @@ jest.mock('../sudokuLogic', () => {
   const actual = jest.requireActual('../sudokuLogic');
   return {
     ...actual,
-    generateSudoku: jest.fn((level = 'easy') => ({
+    generateSudoku: jest.fn((level = 'latte') => ({
       puzzle: cloneBoard(basePuzzle),
       solution: cloneBoard(baseSolution),
       difficulty: level,
+      label: level.charAt(0).toUpperCase() + level.slice(1),
+      gridSize: 9,
+      subgridSize: 3,
+      symbols: null,
     })),
   };
 });
@@ -59,6 +63,10 @@ beforeEach(() => {
     fillStyle: '',
     arc: jest.fn(),
     fill: jest.fn(),
+    strokeRect: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    closePath: jest.fn(),
     font: '',
     textAlign: 'center',
     textBaseline: 'middle',
@@ -117,9 +125,9 @@ describe('SudokuApp component', () => {
 
   it('requests new puzzles when difficulty changes', () => {
     render(<SudokuApp onBack={jest.fn()} />);
-    const mediumButton = screen.getByTestId('difficulty-medium');
-    fireEvent.click(mediumButton);
-    expect(generateSudoku).toHaveBeenLastCalledWith('medium');
+    const cappuccinoButton = screen.getByTestId('difficulty-cappuccino');
+    fireEvent.click(cappuccinoButton);
+    expect(generateSudoku).toHaveBeenLastCalledWith('cappuccino');
   });
 
   it('reveals the full solution when the Solution button is clicked', async () => {

--- a/src/apps/SudokuApp/__tests__/sudokuLogic.test.js
+++ b/src/apps/SudokuApp/__tests__/sudokuLogic.test.js
@@ -38,38 +38,47 @@ describe('sudoku logic utilities', () => {
   });
 
   it('generateSudoku returns valid puzzle and solution across difficulties', () => {
-    Object.keys(DIFFICULTY_LEVELS).forEach((level) => {
-      const { puzzle, solution, difficulty } = generateSudoku(level);
-      expect(difficulty).toBe(level);
-      expect(solution).toHaveLength(9);
-      expect(puzzle).toHaveLength(9);
+    Object.values(DIFFICULTY_LEVELS).forEach((config) => {
+      const { puzzle, solution, difficulty, gridSize, subgridSize } =
+        generateSudoku(config.id);
+      expect(difficulty).toBe(config.id);
+      expect(solution).toHaveLength(gridSize);
+      expect(puzzle).toHaveLength(gridSize);
 
       puzzle.forEach((row, rowIndex) => {
-        expect(row).toHaveLength(9);
+        expect(row).toHaveLength(gridSize);
         row.forEach((value, colIndex) => {
           expect(value).toBeGreaterThanOrEqual(0);
-          expect(value).toBeLessThanOrEqual(9);
+          expect(value).toBeLessThanOrEqual(gridSize);
           if (value !== 0) {
-            expect(isValidPlacement(puzzle, rowIndex, colIndex, value)).toBe(true);
+            expect(
+              isValidPlacement(puzzle, rowIndex, colIndex, value, gridSize, subgridSize)
+            ).toBe(true);
           }
         });
       });
 
-      const solved = solveSudoku(puzzle);
+      const solved = solveSudoku(puzzle, gridSize, subgridSize);
       expect(solved).not.toBeNull();
       expect(solved).toEqual(solution);
     });
   });
 
   it('difficulty levels control the number of given clues', () => {
-    Object.entries(DIFFICULTY_LEVELS).forEach(([level, clues]) => {
-      const { puzzle } = generateSudoku(level);
+    Object.values(DIFFICULTY_LEVELS).forEach((config) => {
+      const { puzzle } = generateSudoku(config.id);
       const filled = puzzle.reduce(
         (total, row) => total + row.filter((value) => value !== 0).length,
         0
       );
-      expect(filled).toBeGreaterThanOrEqual(clues - 2); // allow slight variance due to uniqueness enforcement
-      expect(filled).toBeLessThanOrEqual(81);
+
+      if (config.clues) {
+        expect(filled).toBeGreaterThanOrEqual(config.clues - 2);
+        expect(filled).toBeLessThanOrEqual(config.gridSize * config.gridSize);
+      } else {
+        expect(filled).toBeGreaterThan(0);
+        expect(filled).toBeLessThanOrEqual(config.gridSize * config.gridSize);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a coffee-themed difficulty table with a new Decaf 4x4 shape mode and updated generators
- teach the Sudoku UI to adapt to grid size, cycle shapes on tap, and surface the new labels and counters
- refresh Sudoku tests to exercise the renamed difficulties and expanded drawing API

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0cb9c0460832bbb776c8ba0e5dd9e