### PR TITLE
Document new app directories in project structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,12 @@ Your site will be available at the `homepage` URL.
 
 ```
 g1/
+├── apps/
+│   ├── cache-lab/
+│   └── cat-typing-speed-test/
+├── docs/
+│   ├── README.md
+│   └── ... (additional guides)
 ├── public/
 │   └── index.html
 ├── src/
@@ -102,12 +108,23 @@ g1/
 │   │   ├── AppLauncher.js
 │   │   └── AppLauncher.css
 │   └── apps/
-│       ├── ChessApp/
-│       │   ├── ChessApp.js
-│       │   └── index.js
+│       ├── CacheLabApp/
+│       │   ├── index.js
+│       │   └── styles.css
+│       ├── CatNapLeapApp/
+│       │   ├── CatNapLeapApp.js
+│       │   ├── CatNapLeapApp.css
+│       │   └── spawnLogic.js
 │       ├── CatPadApp/
 │       │   ├── CatPadApp.js
 │       │   ├── CatPadApp.css
+│       │   └── index.js
+│       ├── CatTypingSpeedTestApp/
+│       │   ├── CatTypingSpeedTestApp.js
+│       │   ├── CatTypingSpeedTestApp.css
+│       │   └── index.js
+│       ├── ChessApp/
+│       │   ├── ChessApp.js
 │       │   └── index.js
 │       ├── DaySwitcherApp/
 │       │   ├── DaySwitcherApp.js
@@ -137,6 +154,10 @@ g1/
 │       │   ├── SudokuApp.js
 │       │   ├── SudokuApp.css
 │       │   └── index.js
+│       ├── ZenDoApp/
+│       │   ├── ZenDoApp.js
+│       │   ├── ZenDoApp.css
+│       │   └── components/
 │       └── registry.js
 ├── dist/
 │   └── ... (build output)


### PR DESCRIPTION
## Summary
- note the top-level `apps/` and `docs/` directories that newcomers should expect
- document CacheLabApp, CatNapLeapApp, CatTypingSpeedTestApp, and ZenDoApp entries in the `src/apps/` tree snippet

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0cc480760832baf8368a8a8765f36