### PR TITLE
docs: detail cache lab tech stack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,10 @@ g1/
 - React 18
 - Webpack 5 + webpack-dev-server
 - Babel (`@babel/preset-env`, `@babel/preset-react`)
+- SortableJS for drag-and-drop reordering in shared UIs
+- Vite + TypeScript + pnpm toolchain powering `apps/cache-lab`
+
+The Cache Lab workspace also ships with Vitest and Playwright for unit, component, and end-to-end testing flows.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add SortableJS and the Cache Lab build toolchain to the documented tech stack
- mention the Vitest and Playwright setup available in the Cache Lab workspace

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0cc4a2ab4832b90aae63782632119