### PR TITLE
Use registry metadata for lazy app loading

### DIFF
--- a/src/apps/__tests__/registry.test.js
+++ b/src/apps/__tests__/registry.test.js
@@ -1,4 +1,6 @@
-import { getAllApps, getAppById } from '../registry';
+import React, { Suspense } from 'react';
+import { render, screen } from '@testing-library/react';
+import { APP_REGISTRY, getAllApps, getAppById, getAppLoader } from '../registry';
 
 describe('app registry', () => {
   it('includes the chess app metadata', () => {
@@ -35,5 +37,59 @@ describe('app registry', () => {
     expect(typingTest.category).toBe('Education');
     expect(typingTest.icon).toBe('⌨️');
     expect(typingTest.path).toBe('/apps/cat-typing-speed-test');
+  });
+});
+
+describe('getAppLoader', () => {
+  it('memoizes lazy loader instances for known apps', () => {
+    const firstLoader = getAppLoader('chess');
+    const secondLoader = getAppLoader('chess');
+
+    expect(firstLoader).toBeDefined();
+    expect(secondLoader).toBe(firstLoader);
+  });
+
+  it('returns null when no loader metadata exists', () => {
+    expect(getAppLoader('app-3')).toBeNull();
+    expect(getAppLoader('definitely-not-an-app')).toBeNull();
+  });
+
+  it('supports dynamically registered apps end-to-end', async () => {
+    const testId = '__test-app__';
+    const TestApp = () => <div data-testid="test-app">Hello from test</div>;
+    const loader = jest.fn(() => Promise.resolve({ default: TestApp }));
+
+    APP_REGISTRY[testId] = {
+      id: testId,
+      title: 'Test App',
+      description: 'Temporary test app',
+      icon: '🧪',
+      category: 'Development',
+      component: null,
+      loader,
+      path: '/apps/test-app',
+      tags: ['test'],
+      version: '0.0.1',
+      author: 'Test Suite',
+      created: '2024-01-01',
+      featured: false,
+    };
+
+    try {
+      const LazyTestApp = getAppLoader(testId);
+      expect(LazyTestApp).toBeDefined();
+      expect(getAppLoader(testId)).toBe(LazyTestApp);
+
+      render(
+        <Suspense fallback={<div>loading</div>}>
+          <LazyTestApp />
+        </Suspense>
+      );
+
+      expect(await screen.findByTestId('test-app')).toHaveTextContent('Hello from test');
+      expect(loader).toHaveBeenCalledTimes(1);
+    } finally {
+      delete APP_REGISTRY[testId];
+    }
   });
 });

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -1,26 +1,7 @@
 import React, { useState, Suspense } from 'react';
 import AppLauncher from './AppLauncher';
 import './AppContainer.css';
-
-// Lazy load individual apps
-const DaySwitcherApp = React.lazy(() => import('../apps/DaySwitcherApp'));
-const NPomodoroApp = React.lazy(() => import('../apps/NPomodoroApp'));
-const SnakeApp = React.lazy(() => import('../apps/SnakeApp'));
-const HexaSnakeApp = React.lazy(() => import('../apps/HexaSnakeApp'));
-const PongApp = React.lazy(() => import('../apps/PongApp'));
-const PongRingApp = React.lazy(() => import('../apps/PongRingApp'));
-const SudokuApp = React.lazy(() => import('../apps/SudokuApp'));
-const ChessApp = React.lazy(() => import('../apps/ChessApp'));
-
-const CatNapLeapApp = React.lazy(() => import('../apps/CatNapLeapApp'));
-
-const CatPadApp = React.lazy(() => import('../apps/CatPadApp'));
-
-const CacheLabApp = React.lazy(() => import('../apps/CacheLabApp'));
-
-const CatTypingSpeedTestApp = React.lazy(() => import('../apps/CatTypingSpeedTestApp'));
-
-const ZenDoApp = React.lazy(() => import('../apps/ZenDoApp'));
+import { getAppLoader } from '../apps/registry';
 
 
 const AppContainer = () => {
@@ -40,56 +21,27 @@ const AppContainer = () => {
   const renderCurrentApp = () => {
     if (!currentApp) return null;
 
-    switch (currentApp.id) {
-      case 'day-switcher':
-        return <DaySwitcherApp onBack={handleBackToLauncher} />;
-      case 'n-pomodoro':
-        return <NPomodoroApp onBack={handleBackToLauncher} />;
-      case 'snake':
-        return <SnakeApp onBack={handleBackToLauncher} />;
-      case 'hexa-snake-bee':
-        return <HexaSnakeApp onBack={handleBackToLauncher} />;
-      case 'pong':
-        return <PongApp onBack={handleBackToLauncher} />;
-      case 'pong-ring':
-        return <PongRingApp onBack={handleBackToLauncher} />;
-      case 'sudoku-coffee':
-        return <SudokuApp onBack={handleBackToLauncher} />;
-      case 'chess':
-        return <ChessApp onBack={handleBackToLauncher} />;
+    const LazyAppComponent = getAppLoader(currentApp.id);
 
-      case 'catnap-leap':
-        return <CatNapLeapApp onBack={handleBackToLauncher} />;
-
-      case 'catpad':
-        return <CatPadApp onBack={handleBackToLauncher} />;
-
-      case 'cache-lab':
-        return <CacheLabApp onBack={handleBackToLauncher} />;
-
-      case 'cat-typing-speed-test':
-        return <CatTypingSpeedTestApp onBack={handleBackToLauncher} />;
-
-      case 'zen-do':
-        return <ZenDoApp onBack={handleBackToLauncher} />;
-
-      default:
-        return (
-          <div className="app-placeholder">
-            <div className="placeholder-content">
-              <div className="placeholder-icon">🚧</div>
-              <h2>App Coming Soon</h2>
-              <p>This app is under development and will be available soon!</p>
-              <button 
-                className="back-btn"
-                onClick={handleBackToLauncher}
-              >
-                ← Back to Apps
-              </button>
-            </div>
+    if (!LazyAppComponent) {
+      return (
+        <div className="app-placeholder">
+          <div className="placeholder-content">
+            <div className="placeholder-icon">🚧</div>
+            <h2>App Coming Soon</h2>
+            <p>This app is under development and will be available soon!</p>
+            <button
+              className="back-btn"
+              onClick={handleBackToLauncher}
+            >
+              ← Back to Apps
+            </button>
           </div>
-        );
+        </div>
+      );
     }
+
+    return <LazyAppComponent onBack={handleBackToLauncher} />;
   };
 
   return (


### PR DESCRIPTION
## Summary
- add loader metadata to each app in the registry and memoize lazy components via a new `getAppLoader` helper
- resolve the active app in `AppContainer` through the registry instead of a hard-coded switch statement
- extend the registry tests to cover loader memoization and dynamically added entries

## Testing
- npm test -- --runTestsByPath src/apps/__tests__/registry.test.js
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0cc6cdc80832bb3f9e3d36617cd65