### PR TITLE
Fix Chess Stockfish CDN URL

### DIFF
--- a/html/chess.html
+++ b/html/chess.html
@@ -41,7 +41,7 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chess.js@1.0.0/dist/chess.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/stockfish@16.1.1/dist/stockfish.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js"></script>
     <script src="../js/boardManager.js"></script>
     <script src="../js/stockfishEngine.js"></script>
     <script src="../js/chess.js"></script>

--- a/src/apps/ChessApp/ChessApp.js
+++ b/src/apps/ChessApp/ChessApp.js
@@ -13,7 +13,7 @@ const CHESSBOARD_SCRIPT_URL =
 const CHESS_RULES_SCRIPT_URL =
   'https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js';
 const STOCKFISH_SCRIPT_URL =
-  'https://cdn.jsdelivr.net/npm/stockfish@16.1.1/dist/stockfish.js';
+  'https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js';
 
 const resourcePromises = new Map();
 


### PR DESCRIPTION
## Summary
- point the Chess React app to the Stockfish 16.0 NNUE script on jsDelivr
- align the standalone chess.html page to the same working engine bundle

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0b14700fc832b95d376af089a6f2e