### PR TITLE
Add celebratory and immersive enhancements to Sudoku app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "css-loader": "^6.8.0",
         "gh-pages": "^6.0.0",
         "html-webpack-plugin": "^5.5.0",
+        "import-local": "^3.2.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.1.2",
         "style-loader": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "css-loader": "^6.8.0",
     "gh-pages": "^6.0.0",
     "html-webpack-plugin": "^5.5.0",
+    "import-local": "^3.2.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.1.2",
     "style-loader": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      sortablejs:
+        specifier: ^1.15.6
+        version: 1.15.6
     devDependencies:
       '@babel/core':
         specifier: ^7.22.0
@@ -4118,6 +4121,9 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
+
+  sortablejs@1.15.6:
+    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9222,6 +9228,8 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
+
+  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/apps/SudokuApp/SudokuApp.css
+++ b/src/apps/SudokuApp/SudokuApp.css
@@ -125,3 +125,98 @@
   border: 1px solid rgba(209, 182, 149, 0.45);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
 }
+
+.confetti-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 5;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -12vh;
+  width: 0.5rem;
+  height: 1.2rem;
+  border-radius: 0.35rem;
+  opacity: 0;
+  animation-name: confettiFall;
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-in-out;
+  box-shadow: 0 6px 10px rgba(64, 40, 24, 0.18);
+}
+
+.confetti-piece:nth-child(2n) {
+  transform: rotate(22deg);
+  border-radius: 0.1rem;
+}
+
+.confetti-piece:nth-child(3n) {
+  width: 0.4rem;
+  height: 1.4rem;
+  border-radius: 0.15rem;
+}
+
+@keyframes confettiFall {
+  0% {
+    transform: translate3d(0, -20vh, 0) rotate(0deg);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(var(--confetti-end-x, 0), 110vh, 0)
+      rotate(var(--confetti-rotation, 720deg));
+    opacity: 0;
+  }
+}
+
+.zen-mode .sudoku-coffee-content {
+  min-height: 100vh;
+}
+
+.zen-mode .sudoku-panel {
+  max-width: min(92vw, 640px);
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.34);
+  box-shadow: 0 24px 48px rgba(86, 62, 44, 0.22);
+}
+
+.zen-active-panel {
+  gap: 2.5rem;
+}
+
+.zen-hidden {
+  display: none !important;
+}
+
+.zen-board-only {
+  width: 100%;
+  padding-block: 1.5rem;
+}
+
+.zen-board-only .sudoku-board-surface {
+  max-width: min(92vw, 560px);
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(161, 124, 92, 0.18),
+    0 20px 46px rgba(79, 58, 42, 0.22);
+}
+
+.fullscreen-active .sudoku-panel {
+  box-shadow: 0 26px 52px rgba(58, 39, 26, 0.26);
+}
+
+.screen-reader-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add celebratory confetti animation along with new fill helpers, full screen control, and zen mode to Sudoku Roast
- extend the Sudoku styling for confetti, immersive layouts, and accessibility hints to support the new experiences
- expand the Sudoku test suite and add the `import-local` dev dependency so Jest runs reliably with the enhanced features

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d596ef18832b89bfa21205cd66c9