### PR TITLE
Fix standalone chess board chess.js import

### DIFF
--- a/html/chess.html
+++ b/html/chess.html
@@ -40,7 +40,7 @@
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chess.js@1.0.0/dist/chess.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js"></script>
     <script src="../js/boardManager.js"></script>
     <script src="../js/stockfishEngine.js"></script>


### PR DESCRIPTION
## Summary
- point the standalone chess page at the 0.13.4 UMD build of chess.js so it loads as a classic script

## Testing
- npm test -- --watch=false *(fails: missing optional dependency import-local in provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d6bb5598832b89170a9adb9018ff