### PR TITLE
Use PUBLIC_URL for Cat Connect Four background

### DIFF
--- a/src/apps/CatConnectFourApp/CatConnectFourApp.css
+++ b/src/apps/CatConnectFourApp/CatConnectFourApp.css
@@ -2,7 +2,10 @@
   position: relative;
   min-height: 100%;
   padding: 2rem 1rem 3rem;
-  background: url('/cat-connect-four/cat-cafe-illustration.svg') center/cover no-repeat fixed;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   display: flex;
   justify-content: center;
   align-items: stretch;

--- a/src/apps/CatConnectFourApp/CatConnectFourApp.js
+++ b/src/apps/CatConnectFourApp/CatConnectFourApp.js
@@ -482,8 +482,14 @@ const CatConnectFourApp = () => {
     </div>
   );
 
+  const publicUrl = (process.env.PUBLIC_URL || '').replace(/\/$/, '');
+  const backgroundImagePath = `${publicUrl}/cat-connect-four/cat-cafe-illustration.svg`;
+
   return (
-    <div className="cat-connect-four-app">
+    <div
+      className="cat-connect-four-app"
+      style={{ backgroundImage: `url(${backgroundImagePath})` }}
+    >
       <div className="cafe-overlay" />
       <div className="app-shell">
         <header className="app-header">


### PR DESCRIPTION
## Summary
- set the Cat Connect Four app shell background image via PUBLIC_URL so the asset path matches the deployed base URL
- keep the existing layout styling by moving background positioning rules into CSS without a hard-coded image

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0edca172c832bb72e2a553e7aa6b9