### PR TITLE
Handle missing Cache Lab dist in webpack copy

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -51,12 +52,20 @@ module.exports = {
       template: './public/index.html',
     }),
     new CopyWebpackPlugin({
-      patterns: [
-        { from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' },
-        { from: path.resolve(__dirname, 'apps/cat-typing-speed-test'), to: 'apps/cat-typing-speed-test' },
-        { from: path.resolve(__dirname, 'apps/zen-go'), to: 'apps/zen-go' },
-        { from: path.resolve(__dirname, 'apps/cache-lab/dist'), to: 'cache-lab' },
-      ],
+      patterns: (() => {
+        const patterns = [
+          { from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' },
+          { from: path.resolve(__dirname, 'apps/cat-typing-speed-test'), to: 'apps/cat-typing-speed-test' },
+          { from: path.resolve(__dirname, 'apps/zen-go'), to: 'apps/zen-go' },
+        ];
+
+        const cacheLabSource = path.resolve(__dirname, 'apps/cache-lab/dist');
+        if (fs.existsSync(cacheLabSource)) {
+          patterns.push({ from: cacheLabSource, to: 'cache-lab' });
+        }
+
+        return patterns;
+      })(),
     }),
   ],
   devServer: {


### PR DESCRIPTION
## Summary
- guard the webpack CopyWebpackPlugin patterns by checking for the Cache Lab dist directory before copying

## Testing
- npm start
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ef741f70832b850f4bae5a026209