### PR TITLE
Add routing support to app container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1",
         "sortablejs": "^1.15.6"
       },
       "devDependencies": {
@@ -3863,6 +3864,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -12661,6 +12671,38 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/react-smooth": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1",
     "sortablejs": "^1.15.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       html-webpack-plugin:
         specifier: ^5.5.0
         version: 5.6.4(webpack@5.101.3)
+      import-local:
+        specifier: ^3.2.0
+        version: 3.2.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.17)

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,14 @@
 import React from 'react';
+import { Routes, Route } from 'react-router-dom';
 import AppContainer from './components/AppContainer';
 import './App.css';
 
 function App() {
   return (
     <div className="app">
-      <AppContainer />
+      <Routes>
+        <Route path="/*" element={<AppContainer />} />
+      </Routes>
     </div>
   );
 }

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { APP_CATEGORIES, getAllApps } from '../apps/registry';
 import './AppLauncher.css';
 
-const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
+const AppLauncher = () => {
+  const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState('grid'); // 'grid' or 'list'
@@ -68,7 +70,7 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
 
   const handleAppClick = (app) => {
     if (app.disabled) return;
-    onLaunchApp(app);
+    navigate(app.path);
   };
 
   const renderAppCard = (app) => {
@@ -103,10 +105,6 @@ const AppLauncher = ({ onLaunchApp, currentView, onBackToLauncher }) => {
       </div>
     );
   };
-
-  if (currentView !== 'launcher') {
-    return null;
-  }
 
   return (
     <div className="app-launcher">

--- a/src/components/__tests__/AppContainer.test.js
+++ b/src/components/__tests__/AppContainer.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import App from '../../App';
+
+const renderAtPath = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <App />
+  </MemoryRouter>
+);
+
+describe('App routing', () => {
+  it('loads the Day Switcher app when navigating directly to its route', async () => {
+    renderAtPath('/apps/day-switcher');
+
+    expect(await screen.findByText(/Day 1 of 7/i)).toBeInTheDocument();
+  });
+
+  it('preserves the active app when the page is refreshed', async () => {
+    const appPath = '/apps/day-switcher';
+
+    const firstRender = renderAtPath(appPath);
+    expect(await screen.findByText(/Day 1 of 7/i)).toBeInTheDocument();
+    firstRender.unmount();
+
+    renderAtPath(appPath);
+    expect(await screen.findByText(/Day 1 of 7/i)).toBeInTheDocument();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add react-router-dom and wrap the root app with router primitives
- derive the active app from the current location and navigate home when leaving an app
- update the launcher to push routes on selection and add routing tests for deep-linking

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0ef74d3f0832bb009707576249a11