### PR TITLE
Add Cosmos solar system simulator subapp

### DIFF
--- a/apps/cosmos/bodies.js
+++ b/apps/cosmos/bodies.js
@@ -1,0 +1,122 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.162/build/three.module.js';
+
+const TRAIL_LIMIT = 720;
+const MIN_RENDER_RADIUS = 0.35;
+
+export async function loadBodyData(url = './data/bodies.json') {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load bodies from ${url}: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function createMaterial(color, isSun) {
+  if (isSun) {
+    return new THREE.MeshStandardMaterial({
+      emissive: new THREE.Color('#fff4d3'),
+      emissiveIntensity: 1.6,
+      color: new THREE.Color(color),
+    });
+  }
+
+  return new THREE.MeshStandardMaterial({
+    color: new THREE.Color(color),
+    roughness: 0.6,
+    metalness: 0.1,
+  });
+}
+
+function createTrail(color) {
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(TRAIL_LIMIT * 3);
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setDrawRange(0, 0);
+
+  const tint = new THREE.Color(color).lerp(new THREE.Color('#ffffff'), 0.35);
+
+  const material = new THREE.LineBasicMaterial({
+    color: tint,
+    transparent: true,
+    opacity: 0.45,
+  });
+
+  const line = new THREE.Line(geometry, material);
+  line.visible = false;
+  line.frustumCulled = false;
+
+  return { line, positions, geometry };
+}
+
+export function createBodyMeshes(bodies, { scale }) {
+  const group = new THREE.Group();
+  const visuals = bodies.map((body) => {
+    const renderRadius = Math.max(body.radius * scale, MIN_RENDER_RADIUS);
+    const geometry = new THREE.SphereGeometry(renderRadius, 48, 32);
+    const material = createMaterial(body.color, body.name === 'Sun');
+    const mesh = new THREE.Mesh(geometry, material);
+
+    mesh.castShadow = false;
+    mesh.receiveShadow = false;
+    mesh.name = body.name;
+
+    const { line: trail, positions, geometry: trailGeometry } = createTrail(body.color);
+
+    group.add(mesh);
+    group.add(trail);
+
+    return {
+      name: body.name,
+      mesh,
+      trail,
+      trailPositions: positions,
+      trailGeometry,
+    };
+  });
+
+  return { group, visuals };
+}
+
+export function createSunLight(intensity = 3.5) {
+  const light = new THREE.PointLight('#fff2a3', intensity, 0, 2);
+  light.castShadow = false;
+  light.position.set(0, 0, 0);
+  return light;
+}
+
+export function updateBodyMeshes(visuals, simulationBodies, { scale, showTrails }) {
+  const temp = new THREE.Vector3();
+
+  visuals.forEach((visual, index) => {
+    const body = simulationBodies[index];
+    temp.copy(body.position).multiplyScalar(scale);
+    visual.mesh.position.copy(temp);
+
+    if (visual.mesh.name === 'Sun') {
+      // keep the sun trail hidden for clarity
+      visual.trail.visible = false;
+      visual.trailGeometry.setDrawRange(0, 0);
+    } else if (showTrails) {
+      const history = body.history;
+      const { trailPositions, trailGeometry, trail } = visual;
+
+      for (let i = 0; i < history.length; i += 1) {
+        const entry = history[i];
+        const offset = i * 3;
+        trailPositions[offset] = entry.x * scale;
+        trailPositions[offset + 1] = entry.y * scale;
+        trailPositions[offset + 2] = entry.z * scale;
+      }
+
+      trailGeometry.attributes.position.needsUpdate = true;
+      trailGeometry.setDrawRange(0, history.length);
+      trailGeometry.computeBoundingSphere();
+      trail.visible = history.length > 1;
+    } else {
+      visual.trailGeometry.setDrawRange(0, 0);
+      visual.trail.visible = false;
+    }
+  });
+}

--- a/apps/cosmos/controls.js
+++ b/apps/cosmos/controls.js
@@ -1,0 +1,47 @@
+import GUI from 'https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm';
+
+const DEFAULTS = {
+  timeSpeed: 4000,
+  gravityMultiplier: 1,
+  showTrails: true,
+};
+
+export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
+  const settings = {
+    ...DEFAULTS,
+    ...overrides,
+  };
+
+  const gui = new GUI({ title: 'Cosmos Controls' });
+  gui.domElement.classList.add('cosmos-gui');
+
+  gui
+    .add(settings, 'timeSpeed', 100, 20000, 100)
+    .name('Time speed (×)')
+    .onChange((value) => handlers.onTimeSpeedChange?.(value));
+
+  gui
+    .add(settings, 'gravityMultiplier', 0, 3, 0.05)
+    .name('Gravity (×)')
+    .onChange((value) => handlers.onGravityChange?.(value));
+
+  gui
+    .add(settings, 'showTrails')
+    .name('Show trails')
+    .onChange((value) => handlers.onTrailsToggle?.(value));
+
+  const cameraFolder = gui.addFolder('Camera');
+  bodies.forEach((body) => {
+    const action = { [`teleport${body.name}`]: () => handlers.onTeleport?.(body.name) };
+    cameraFolder.add(action, `teleport${body.name}`).name(body.name);
+  });
+  cameraFolder
+    .add({ reset: () => handlers.onReset?.() }, 'reset')
+    .name('Reset view');
+
+  handlers.onTimeSpeedChange?.(settings.timeSpeed);
+  handlers.onGravityChange?.(settings.gravityMultiplier);
+  handlers.onTrailsToggle?.(settings.showTrails);
+
+  return { gui, settings };
+}

--- a/apps/cosmos/data/bodies.json
+++ b/apps/cosmos/data/bodies.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "Sun",
+    "mass": 1.989e30,
+    "radius": 6.9634e8,
+    "position": [0, 0, 0],
+    "velocity": [0, 0, 0],
+    "color": "yellow"
+  },
+  {
+    "name": "Mercury",
+    "mass": 3.301e23,
+    "radius": 2.439e6,
+    "position": [5.79e10, 0, 0],
+    "velocity": [0, 47400, 0],
+    "color": "gray"
+  },
+  {
+    "name": "Venus",
+    "mass": 4.867e24,
+    "radius": 6.052e6,
+    "position": [1.082e11, 0, 0],
+    "velocity": [0, 35000, 0],
+    "color": "orange"
+  },
+  {
+    "name": "Earth",
+    "mass": 5.972e24,
+    "radius": 6.371e6,
+    "position": [1.496e11, 0, 0],
+    "velocity": [0, 29780, 0],
+    "color": "blue"
+  },
+  {
+    "name": "Mars",
+    "mass": 6.39e23,
+    "radius": 3.389e6,
+    "position": [2.279e11, 0, 0],
+    "velocity": [0, 24100, 0],
+    "color": "red"
+  },
+  {
+    "name": "Jupiter",
+    "mass": 1.898e27,
+    "radius": 6.9911e7,
+    "position": [7.785e11, 0, 0],
+    "velocity": [0, 13070, 0],
+    "color": "orange"
+  },
+  {
+    "name": "Saturn",
+    "mass": 5.683e26,
+    "radius": 5.8232e7,
+    "position": [1.433e12, 0, 0],
+    "velocity": [0, 9680, 0],
+    "color": "goldenrod"
+  },
+  {
+    "name": "Uranus",
+    "mass": 8.681e25,
+    "radius": 2.5362e7,
+    "position": [2.872e12, 0, 0],
+    "velocity": [0, 6800, 0],
+    "color": "lightblue"
+  },
+  {
+    "name": "Neptune",
+    "mass": 1.024e26,
+    "radius": 2.4622e7,
+    "position": [4.495e12, 0, 0],
+    "velocity": [0, 5430, 0],
+    "color": "darkblue"
+  }
+]

--- a/apps/cosmos/index.html
+++ b/apps/cosmos/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cosmos • Solar System Simulator</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div class="cosmos-app">
+      <header class="cosmos-header">
+        <h1>Cosmos</h1>
+        <p>
+          Navigate a to-scale (×10<sup>-9</sup>) solar system rendered with Three.js and velocity Verlet
+          integration. Adjust time, gravity, and orbital trails to watch planets evolve in real time.
+        </p>
+        <ul class="cosmos-highlights">
+          <li>Newtonian physics with velocity Verlet integration.</li>
+          <li>Teleport the camera to any planet instantly.</li>
+          <li>Adjust gravity strength and orbital trails live.</li>
+        </ul>
+      </header>
+      <section class="cosmos-viewport">
+        <div class="cosmos-loader">Loading solar system…</div>
+      </section>
+      <footer class="cosmos-footer">
+        Data sourced from NASA JPL public records. Distances and radii scaled by 1×10<sup>-9</sup> for a
+        desktop-friendly view. Designed for modern desktop browsers.
+      </footer>
+    </div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/apps/cosmos/main.js
+++ b/apps/cosmos/main.js
@@ -1,0 +1,181 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.162/build/three.module.js';
+import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.162/examples/jsm/controls/OrbitControls.js';
+import { loadBodyData, createBodyMeshes, createSunLight, updateBodyMeshes } from './bodies.js';
+import { SolarSystemSimulation, SCALE } from './simulation.js';
+import { setupControlPanel } from './controls.js';
+
+const viewport = document.querySelector('.cosmos-viewport');
+const statusEl = document.querySelector('.cosmos-loader');
+
+let renderer;
+let camera;
+let controls;
+let sunLight;
+let simulation;
+let visuals;
+let showTrails = true;
+let timeSpeed = 4000;
+let gravityMultiplier = 1;
+
+const initialCameraPosition = new THREE.Vector3(0, 1200, 3200);
+const initialTarget = new THREE.Vector3();
+
+function setStatus(message, isError = false) {
+  if (!statusEl) {
+    return;
+  }
+  statusEl.textContent = message;
+  statusEl.classList.toggle('cosmos-loader--error', isError);
+}
+
+function clearStatus() {
+  if (statusEl) {
+    statusEl.remove();
+  }
+}
+
+function createRenderer() {
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  if ('outputColorSpace' in renderer) {
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+  } else {
+    renderer.outputEncoding = THREE.sRGBEncoding;
+  }
+  renderer.shadowMap.enabled = false;
+  viewport.appendChild(renderer.domElement);
+}
+
+function createCamera() {
+  const { clientWidth, clientHeight } = viewport;
+  camera = new THREE.PerspectiveCamera(50, clientWidth / clientHeight, 0.1, 12000);
+  camera.position.copy(initialCameraPosition);
+}
+
+function createControls() {
+  controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.maxDistance = 7000;
+  controls.minDistance = 0.5;
+  controls.target.copy(initialTarget);
+  controls.update();
+}
+
+function addStars(scene) {
+  const starCount = 1500;
+  const positions = new Float32Array(starCount * 3);
+  for (let i = 0; i < starCount; i += 1) {
+    const index = i * 3;
+    positions[index] = (Math.random() - 0.5) * 10000;
+    positions[index + 1] = (Math.random() - 0.5) * 10000;
+    positions[index + 2] = (Math.random() - 0.5) * 10000;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const material = new THREE.PointsMaterial({
+    color: '#ffffff',
+    size: 1.2,
+    sizeAttenuation: true,
+    transparent: true,
+    opacity: 0.6,
+  });
+  const stars = new THREE.Points(geometry, material);
+  scene.add(stars);
+}
+
+function resizeRenderer() {
+  if (!renderer || !camera) return;
+  const { clientWidth, clientHeight } = viewport;
+  renderer.setSize(clientWidth, clientHeight);
+  camera.aspect = clientWidth / clientHeight;
+  camera.updateProjectionMatrix();
+}
+
+function resetCamera() {
+  camera.position.copy(initialCameraPosition);
+  controls.target.copy(initialTarget);
+  controls.update();
+}
+
+function teleportCameraTo(name) {
+  const targetBody = simulation?.getBodyByName(name);
+  if (!targetBody) {
+    return;
+  }
+
+  const targetPosition = targetBody.position.clone().multiplyScalar(SCALE);
+  const offsetDirection = targetPosition.lengthSq() > 0
+    ? targetPosition.clone().normalize()
+    : new THREE.Vector3(0, 0.4, 1).normalize();
+  const focusOffset = Math.max(targetBody.radius * SCALE * 18, 6);
+  const elevated = targetPosition.clone().addScaledVector(offsetDirection, focusOffset);
+  elevated.y += focusOffset * 0.3;
+
+  camera.position.copy(elevated);
+  controls.target.copy(targetPosition);
+  controls.update();
+}
+
+async function init() {
+  if (!viewport) {
+    return;
+  }
+
+  createRenderer();
+  createCamera();
+  createControls();
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#020614');
+  addStars(scene);
+
+  scene.add(new THREE.AmbientLight('#0e111f', 0.18));
+
+  resizeRenderer();
+
+  window.addEventListener('resize', resizeRenderer);
+
+  try {
+    const bodies = await loadBodyData('./data/bodies.json');
+    simulation = new SolarSystemSimulation(bodies, { historyLimit: 720 });
+    const { group, visuals: createdVisuals } = createBodyMeshes(simulation.bodies, { scale: SCALE });
+    visuals = createdVisuals;
+
+    sunLight = createSunLight();
+    scene.add(group);
+    scene.add(sunLight);
+
+    setupControlPanel(simulation.bodies, {
+      onTimeSpeedChange: (value) => { timeSpeed = value; },
+      onGravityChange: (value) => { gravityMultiplier = value; },
+      onTrailsToggle: (value) => { showTrails = value; },
+      onTeleport: teleportCameraTo,
+      onReset: resetCamera,
+    });
+
+    clearStatus();
+
+    const clock = new THREE.Clock();
+
+    function animate() {
+      requestAnimationFrame(animate);
+      const deltaSeconds = clock.getDelta();
+      simulation.step(deltaSeconds, { timeScale: timeSpeed, gravityMultiplier });
+      updateBodyMeshes(visuals, simulation.bodies, { scale: SCALE, showTrails });
+      const sunVisual = visuals.find((item) => item.name === 'Sun');
+      if (sunVisual && sunLight) {
+        sunLight.position.copy(sunVisual.mesh.position);
+      }
+      controls.update();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+  } catch (error) {
+    console.error(error);
+    setStatus('Failed to load solar system data.', true);
+  }
+}
+
+init();

--- a/apps/cosmos/simulation.js
+++ b/apps/cosmos/simulation.js
@@ -1,0 +1,104 @@
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.162/build/three.module.js';
+
+export const SCALE = 1e-9;
+const G = 6.6743e-11;
+const MIN_DISTANCE_SQ = 1e6; // prevent singularities when bodies get too close
+
+export class SolarSystemSimulation {
+  constructor(bodyDefinitions, options = {}) {
+    this.scale = options.scale ?? SCALE;
+    this.gravityMultiplier = options.gravityMultiplier ?? 1;
+    this.historyLimit = options.historyLimit ?? 720;
+    this.bodies = bodyDefinitions.map((definition) => ({
+      name: definition.name,
+      mass: definition.mass,
+      radius: definition.radius,
+      color: definition.color,
+      position: new THREE.Vector3().fromArray(definition.position),
+      velocity: new THREE.Vector3().fromArray(definition.velocity),
+      acceleration: new THREE.Vector3(),
+      history: [],
+    }));
+    this._accelerations = this.bodies.map(() => new THREE.Vector3());
+    this.updateAccelerations(this.gravityMultiplier);
+  }
+
+  setHistoryLimit(limit) {
+    this.historyLimit = limit;
+    this.bodies.forEach((body) => {
+      if (body.history.length > limit) {
+        body.history.splice(0, body.history.length - limit);
+      }
+    });
+  }
+
+  updateAccelerations(gravityMultiplier = this.gravityMultiplier) {
+    const factor = gravityMultiplier * G;
+    const diff = new THREE.Vector3();
+
+    for (let i = 0; i < this._accelerations.length; i += 1) {
+      this._accelerations[i].set(0, 0, 0);
+    }
+
+    for (let i = 0; i < this.bodies.length; i += 1) {
+      const body = this.bodies[i];
+      for (let j = i + 1; j < this.bodies.length; j += 1) {
+        const other = this.bodies[j];
+        diff.subVectors(other.position, body.position);
+        const distanceSq = Math.max(diff.lengthSq(), MIN_DISTANCE_SQ);
+        const distance = Math.sqrt(distanceSq);
+        const accelMagnitudeI = factor * other.mass / distanceSq;
+        const accelMagnitudeJ = factor * body.mass / distanceSq;
+        const directionScale = 1 / distance;
+
+        this._accelerations[i].addScaledVector(diff, accelMagnitudeI * directionScale);
+        this._accelerations[j].addScaledVector(diff, -accelMagnitudeJ * directionScale);
+      }
+    }
+
+    for (let i = 0; i < this.bodies.length; i += 1) {
+      this.bodies[i].acceleration.copy(this._accelerations[i]);
+    }
+
+    this.gravityMultiplier = gravityMultiplier;
+  }
+
+  step(deltaSeconds, { timeScale = 1, gravityMultiplier = this.gravityMultiplier } = {}) {
+    const dt = deltaSeconds * timeScale;
+
+    if (!Number.isFinite(dt) || dt <= 0) {
+      return;
+    }
+
+    const previousAccelerations = this._accelerations.map((accel) => accel.clone());
+
+    this.bodies.forEach((body, index) => {
+      body.position
+        .addScaledVector(body.velocity, dt)
+        .addScaledVector(previousAccelerations[index], 0.5 * dt * dt);
+    });
+
+    this.updateAccelerations(gravityMultiplier);
+
+    this.bodies.forEach((body, index) => {
+      const newAcceleration = this._accelerations[index];
+      body.velocity.addScaledVector(previousAccelerations[index].add(newAcceleration), 0.5 * dt);
+      this._recordHistory(body);
+    });
+  }
+
+  getBodyByName(name) {
+    return this.bodies.find((body) => body.name === name) ?? null;
+  }
+
+  _recordHistory(body) {
+    if (this.historyLimit <= 0) {
+      return;
+    }
+
+    body.history.push(body.position.clone());
+    if (body.history.length > this.historyLimit) {
+      body.history.shift();
+    }
+  }
+}

--- a/apps/cosmos/styles.css
+++ b/apps/cosmos/styles.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #01030a;
+  color: #e6eeff;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(14, 44, 94, 0.45), transparent 60%), #01030a;
+}
+
+.cosmos-app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 24px clamp(16px, 4vw, 32px);
+  gap: 24px;
+  box-sizing: border-box;
+}
+
+.cosmos-header h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cosmos-header p {
+  margin: 8px 0 16px;
+  max-width: 52ch;
+  line-height: 1.5;
+  color: rgba(220, 231, 255, 0.78);
+}
+
+.cosmos-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.cosmos-highlights li {
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(31, 53, 109, 0.25);
+  border: 1px solid rgba(82, 118, 191, 0.25);
+  backdrop-filter: blur(6px);
+  font-size: 0.95rem;
+}
+
+.cosmos-viewport {
+  position: relative;
+  flex: 1;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(120, 166, 255, 0.15);
+  background: radial-gradient(circle at center, rgba(8, 18, 38, 0.85), #030611 60%);
+  min-height: 480px;
+}
+
+.cosmos-viewport canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.cosmos-loader {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  padding: 14px 22px;
+  border-radius: 999px;
+  background: rgba(19, 36, 73, 0.75);
+  border: 1px solid rgba(121, 165, 255, 0.25);
+  color: #f1f5ff;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.cosmos-loader--error {
+  background: rgba(120, 26, 42, 0.85);
+  border-color: rgba(255, 126, 147, 0.6);
+}
+
+.cosmos-footer {
+  font-size: 0.85rem;
+  color: rgba(197, 212, 255, 0.6);
+  line-height: 1.5;
+}
+
+.cosmos-gui {
+  position: fixed;
+  top: 20px;
+  right: 24px;
+  max-width: 240px;
+  font-size: 0.85rem;
+  z-index: 10;
+}
+
+.cosmos-gui .name {
+  color: #051635 !important;
+}
+
+@media (max-width: 900px) {
+  .cosmos-gui {
+    position: static;
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .cosmos-header p {
+    font-size: 0.95rem;
+  }
+
+  .cosmos-viewport {
+    min-height: 420px;
+  }
+}

--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -84,6 +84,12 @@ Zen Go invites quick 9×9 sparring against a lightweight GNU Go engine compiled 
 - Layer SGF export, move history, and review tools for deeper post-game study.
 - Surface AI insight overlays such as win-rate charts or candidate variation summaries.
 
+## Cosmos Simulator
+Cosmos Simulator shrinks the solar system by 1×10⁻⁹ and renders it with Three.js, a velocity Verlet integrator, and lil-gui control panel. Planets load from JSON metadata, trails showcase orbital history, and buttons teleport the camera to any world for close-up inspections.
+- Add moon and asteroid presets to extend the data-driven catalogue beyond the eight planets.
+- Experiment with post-processing bloom for the sun and motion blur for orbital trails.
+- Persist custom gravity and time-speed presets to revisit favourite slow-motion or accelerated scenarios.
+
 ## Cache Lab
 Cache Lab embeds the dedicated cache-learning subapp that lives under `/cache-lab`. Eight mini-modules cover mapping, replacement, parameter sweeps, locality visualisation, miss classification, hierarchy exploration, pipeline impact, and trace loading. Auxiliary tabs (Learn, Experiment, Assess, Dashboard) guide newcomers, let advanced users tinker, and track quiz progress with localStorage persistence.
 - Ship more visualisations (e.g., animated heatmaps) for large traces while maintaining performance.

--- a/docs/GITSTORY.md
+++ b/docs/GITSTORY.md
@@ -11,3 +11,4 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 - 2025-09-23 — feature+docs — Introduced Cat Typing Speed Test with a vanilla JS typing drill, launcher wiring, and refreshed documentation.
 - 2025-10-05 — feature+docs — Added Zen Do with gist-backed persistence, drag-and-drop planning, and docs updates across the catalog.
 - 2025-10-07 — feature+docs — Added Zen Go with a WebAssembly GNU Go engine, handicap presets, and launcher/documentation updates.
+- 2025-10-12 — feature+docs — Added Cosmos solar system simulator with Three.js physics subapp, launcher integration, and refreshed docs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Gif coming soon
 
 * **Cat Typing Speed Test**: practise timed drills with Kimchi, Rythm, and Siella.
 * **Cache Lab**: explore cache mapping, replacement, hierarchy, and assessments via `/cache-lab`.
+* **Cosmos Simulator**: orbit a scaled solar system with live Newtonian physics and camera fly-to controls.
 
 ---
 

--- a/src/apps/CosmosApp/CosmosApp.css
+++ b/src/apps/CosmosApp/CosmosApp.css
@@ -1,0 +1,94 @@
+.cosmos-embed {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: clamp(24px, 4vw, 40px);
+  color: #f3f8ff;
+  background: radial-gradient(circle at top left, rgba(31, 64, 129, 0.2), transparent 55%), #040713;
+  min-height: 100%;
+}
+
+.cosmos-intro {
+  display: flex;
+  justify-content: center;
+}
+
+.cosmos-intro-copy {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.cosmos-intro-copy h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c4d9ff;
+}
+
+.cosmos-intro-copy p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(213, 225, 255, 0.78);
+}
+
+.cosmos-intro-copy ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  font-size: 0.98rem;
+  color: rgba(221, 230, 255, 0.85);
+}
+
+.cosmos-frame {
+  width: 100%;
+  min-height: clamp(420px, 65vh, 720px);
+  border: 1px solid rgba(88, 140, 214, 0.35);
+  border-radius: 20px;
+  background: #02040a;
+  box-shadow: 0 30px 60px rgba(5, 14, 33, 0.5);
+}
+
+.cosmos-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.cosmos-link {
+  color: #90c2ff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cosmos-link:hover {
+  text-decoration: underline;
+}
+
+.cosmos-back {
+  appearance: none;
+  border: 1px solid rgba(102, 152, 225, 0.6);
+  border-radius: 999px;
+  background: rgba(26, 54, 109, 0.55);
+  color: #e6f1ff;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.cosmos-back:hover {
+  transform: translateY(-1px);
+  background: rgba(26, 54, 109, 0.75);
+}
+
+@media (max-width: 768px) {
+  .cosmos-frame {
+    min-height: clamp(360px, 60vh, 640px);
+  }
+}

--- a/src/apps/CosmosApp/CosmosApp.js
+++ b/src/apps/CosmosApp/CosmosApp.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import './CosmosApp.css';
+
+const CosmosApp = ({ onBack }) => {
+  const base = process.env.PUBLIC_URL || '';
+  const appUrl = `${base}/apps/cosmos/`;
+
+  return (
+    <div className="cosmos-embed">
+      <section className="cosmos-intro">
+        <div className="cosmos-intro-copy">
+          <h1>Cosmos Simulator</h1>
+          <p>
+            A modular Three.js playground that renders the solar system with velocity Verlet physics,
+            true-to-scale distances, and lil-gui controls. Adjust time, gravity, and orbital trails to see how
+            planets dance around the sun.
+          </p>
+          <ul>
+            <li>Newtonian gravity + velocity Verlet integrator for stable orbits.</li>
+            <li>Camera teleport shortcuts to inspect each planet instantly.</li>
+            <li>Toggle orbital trails and tweak gravity multiplier on the fly.</li>
+          </ul>
+        </div>
+      </section>
+
+      <iframe
+        src={appUrl}
+        title="Cosmos Solar System"
+        className="cosmos-frame"
+        loading="lazy"
+        allowFullScreen
+      />
+
+      <footer className="cosmos-actions">
+        <a className="cosmos-link" href={appUrl} target="_blank" rel="noreferrer">
+          Open full window ↗
+        </a>
+        <button type="button" className="cosmos-back" onClick={onBack}>
+          ← Back to Apps
+        </button>
+      </footer>
+    </div>
+  );
+};
+
+export default CosmosApp;

--- a/src/apps/CosmosApp/index.js
+++ b/src/apps/CosmosApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './CosmosApp';

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -207,6 +207,19 @@ export const APP_REGISTRY = {
     created: '2025-09-22',
     featured: true,
   }),
+  cosmos: withDefaults({
+    id: 'cosmos',
+    title: 'Cosmos Simulator',
+    description: 'Navigate a scaled solar system with Newtonian physics, trails, and teleport controls.',
+    icon: '🪐',
+    category: 'Exploration',
+    component: null,
+    loader: () => import('./CosmosApp'),
+    path: '/apps/cosmos',
+    tags: ['three.js', 'simulation', 'space', 'physics'],
+    created: '2024-11-19',
+    featured: true,
+  }),
   'catnap-leap': withDefaults({
 
     id: 'catnap-leap',
@@ -258,6 +271,7 @@ export const APP_CATEGORIES = {
   'Tools': { icon: '🛠️', color: '#4ecdc4' },
   'Creative': { icon: '🎨', color: '#45b7d1' },
   'Education': { icon: '📚', color: '#96ceb4' },
+  'Exploration': { icon: '🪐', color: '#7f9cff' },
   'Productivity': { icon: '⚡', color: '#feca57' },
   'Development': { icon: '💻', color: '#ff9ff3' },
   'Entertainment': { icon: '🎭', color: '#54a0ff' }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ module.exports = {
         { from: path.resolve(__dirname, 'public/hexa-snake'), to: 'hexa-snake' },
         { from: path.resolve(__dirname, 'apps/cat-typing-speed-test'), to: 'apps/cat-typing-speed-test' },
         { from: path.resolve(__dirname, 'apps/zen-go'), to: 'apps/zen-go' },
+        { from: path.resolve(__dirname, 'apps/cosmos'), to: 'apps/cosmos' },
         { from: path.resolve(__dirname, 'apps/cache-lab/dist'), to: 'cache-lab' },
       ],
     }),


### PR DESCRIPTION
## Summary
- add a Cosmos static subapp that renders a scaled solar system with velocity Verlet physics, GUI controls, and camera teleports
- expose the simulator through a React wrapper, registry entry, and webpack copy target so it appears inside the launcher
- document the new experience in the app catalog, README, and git history log

## Testing
- npm test -- --watch=false
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ee45a11c832b839d32aa9e26812d