### PR TITLE
Spawn Stockfish worker dynamically for chess

### DIFF
--- a/html/chess.html
+++ b/html/chess.html
@@ -41,7 +41,6 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js"></script>
     <script src="../js/boardManager.js"></script>
     <script src="../js/stockfishEngine.js"></script>
     <script src="../js/chess.js"></script>

--- a/js/chess.js
+++ b/js/chess.js
@@ -1,4 +1,6 @@
 (function (global) {
+  const STOCKFISH_WORKER_URL =
+    'https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js';
   function ready(callback) {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', callback, { once: true });
@@ -54,7 +56,9 @@
         if (!global.StockfishEngine) {
           throw new Error('StockfishEngine must be loaded before enabling single player mode');
         }
-        engineInstance = new global.StockfishEngine();
+        engineInstance = new global.StockfishEngine({
+          workerUrl: STOCKFISH_WORKER_URL,
+        });
       }
       return engineInstance;
     }

--- a/js/stockfishEngine.js
+++ b/js/stockfishEngine.js
@@ -19,11 +19,18 @@
         thinkTime = DEFAULT_THINK_TIME,
         skillLevel = DEFAULT_SKILL,
         stockfishFactory,
+        workerUrl,
       } = options;
 
       const factory =
         stockfishFactory ||
         (() => {
+          if (workerUrl) {
+            if (typeof Worker === 'undefined') {
+              throw new Error('Web Workers are not supported in this environment');
+            }
+            return new Worker(workerUrl);
+          }
           if (typeof global.Stockfish === 'function') {
             return global.Stockfish();
           }

--- a/src/apps/ChessApp/ChessApp.js
+++ b/src/apps/ChessApp/ChessApp.js
@@ -12,7 +12,7 @@ const CHESSBOARD_SCRIPT_URL =
   'https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js';
 const CHESS_RULES_SCRIPT_URL =
   'https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js';
-const STOCKFISH_SCRIPT_URL =
+const STOCKFISH_WORKER_URL =
   'https://cdn.jsdelivr.net/npm/stockfish@16.0.0/src/stockfish-nnue-16.js';
 
 const resourcePromises = new Map();
@@ -136,7 +136,6 @@ function loadChessResources() {
     loadStylesheet('chessboard-style', CHESSBOARD_STYLE_URL),
     loadScript('chessboard-script', CHESSBOARD_SCRIPT_URL),
     loadScript('chess-rules-script', CHESS_RULES_SCRIPT_URL),
-    loadScript('stockfish-script', STOCKFISH_SCRIPT_URL),
   ]);
 }
 
@@ -220,11 +219,11 @@ const ChessApp = () => {
     setStatusInfo(describeStatus(manager.game));
   }, []);
 
-  const ensureEngine = useCallback(() => {
+  const ensureEngine = useCallback((options = {}) => {
     if (engineRef.current) {
       return engineRef.current;
     }
-    const engineInstance = new StockfishEngine();
+    const engineInstance = new StockfishEngine(options);
     engineRef.current = engineInstance;
     return engineInstance;
   }, []);
@@ -242,7 +241,7 @@ const ChessApp = () => {
     const requestId = ++engineRequestIdRef.current;
 
     try {
-      const engine = ensureEngine();
+      const engine = ensureEngine({ workerUrl: STOCKFISH_WORKER_URL });
       const fen = manager.getFen();
       const move = await engine.requestMove(fen);
 
@@ -316,7 +315,7 @@ const ChessApp = () => {
     }
 
     if (mode === 'single') {
-      const engine = ensureEngine();
+      const engine = ensureEngine({ workerUrl: STOCKFISH_WORKER_URL });
       engine.setSkillLevel(skill);
       manager.setPlayers({ white: 'human', black: 'engine' });
       triggerEngineMoveRef.current();
@@ -338,7 +337,7 @@ const ChessApp = () => {
       return;
     }
 
-    const engine = ensureEngine();
+    const engine = ensureEngine({ workerUrl: STOCKFISH_WORKER_URL });
     engine.setSkillLevel(skill);
   }, [mode, resourcesReady, skill, ensureEngine]);
 
@@ -369,7 +368,7 @@ const ChessApp = () => {
 
     manager.reset();
     if (mode === 'single') {
-      const engineInstance = ensureEngine();
+      const engineInstance = ensureEngine({ workerUrl: STOCKFISH_WORKER_URL });
       engineInstance.setSkillLevel(skill);
       manager.setPlayers({ white: 'human', black: 'engine' });
       triggerEngineMoveRef.current();

--- a/src/chess/__tests__/chess.test.js
+++ b/src/chess/__tests__/chess.test.js
@@ -106,9 +106,9 @@ describe('StockfishEngine', () => {
 });
 
 describe('Chess HTML integration', () => {
-  test('references the CDN hosted Stockfish script', () => {
+  test('omits the CDN hosted Stockfish script tag', () => {
     const htmlPath = path.resolve(__dirname, '../../../html/chess.html');
     const html = fs.readFileSync(htmlPath, 'utf8');
-    expect(html).toMatch(/cdn.jsdelivr.net\/npm\/stockfish/);
+    expect(html).not.toMatch(/cdn.jsdelivr.net\/npm\/stockfish/);
   });
 });


### PR DESCRIPTION
## Summary
- load the chess app resources without eagerly injecting the Stockfish script
- spin up Stockfish workers on demand via new options in the shared engine helper
- drop the Stockfish script tag from the standalone HTML build and adjust tests accordingly

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d101c36174832ba350ef16dca1b746