### PR TITLE
Ensure chess constructors use module defaults

### DIFF
--- a/js/chess.js
+++ b/js/chess.js
@@ -36,11 +36,13 @@
     const skillInput = document.getElementById('skill-level');
     const skillValue = document.getElementById('skill-value');
 
-    if (!global.BoardManager) {
+    const BoardManagerCtor = global.BoardManager?.default ?? global.BoardManager;
+
+    if (!BoardManagerCtor) {
       throw new Error('BoardManager must be loaded before chess.js');
     }
 
-    const boardManager = new global.BoardManager({
+    const boardManager = new BoardManagerCtor({
       elementId: boardElementId,
     });
 
@@ -51,10 +53,13 @@
 
     function ensureEngine() {
       if (!engineInstance) {
-        if (!global.StockfishEngine) {
+        const StockfishEngineCtor =
+          global.StockfishEngine?.default ?? global.StockfishEngine;
+
+        if (!StockfishEngineCtor) {
           throw new Error('StockfishEngine must be loaded before enabling single player mode');
         }
-        engineInstance = new global.StockfishEngine();
+        engineInstance = new StockfishEngineCtor();
       }
       return engineInstance;
     }

--- a/src/apps/ChessApp/ChessApp.js
+++ b/src/apps/ChessApp/ChessApp.js
@@ -3,8 +3,8 @@ import '../../../css/chess.css';
 import BoardManagerModule from '../../../js/boardManager';
 import StockfishEngineModule from '../../../js/stockfishEngine';
 
-const BoardManager = BoardManagerModule.default || BoardManagerModule;
-const StockfishEngine = StockfishEngineModule.default || StockfishEngineModule;
+const BoardManager = BoardManagerModule?.default ?? BoardManagerModule;
+const StockfishEngine = StockfishEngineModule?.default ?? StockfishEngineModule;
 
 const CHESSBOARD_STYLE_URL =
   'https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.css';


### PR DESCRIPTION
## Summary
- ensure the chess React app grabs constructors from the imported modules via optional chaining so styles and instances come from webpack builds
- detect default-exported constructors in the standalone chess script before instantiating the board manager or Stockfish engine

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d101c453d0832b999711c099c887d5