### PR TITLE
Add global gist settings utilities and tests

### DIFF
--- a/src/utils/__tests__/globalGistSettings.test.js
+++ b/src/utils/__tests__/globalGistSettings.test.js
@@ -1,0 +1,139 @@
+import {
+  readGlobalGistSettings,
+  writeGlobalGistSettings,
+  subscribeToGlobalGistSettings,
+  clearGlobalGistSettings,
+} from '../globalGistSettings';
+
+const COOKIE_NAME = 'g1_gist_settings';
+
+class MockBroadcastChannel {
+  static channels = new Map();
+
+  constructor(name) {
+    this.name = name;
+    this.listeners = new Set();
+    this.onmessage = null;
+
+    if (!MockBroadcastChannel.channels.has(name)) {
+      MockBroadcastChannel.channels.set(name, new Set());
+    }
+
+    MockBroadcastChannel.channels.get(name).add(this);
+  }
+
+  postMessage(data) {
+    const peers = MockBroadcastChannel.channels.get(this.name) || new Set();
+    for (const channel of peers) {
+      channel.dispatchMessage(data);
+    }
+  }
+
+  dispatchMessage(data) {
+    const event = { data };
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+
+    if (typeof this.onmessage === 'function') {
+      this.onmessage(event);
+    }
+  }
+
+  addEventListener(type, handler) {
+    if (type === 'message') {
+      this.listeners.add(handler);
+    }
+  }
+
+  removeEventListener(type, handler) {
+    if (type === 'message') {
+      this.listeners.delete(handler);
+    }
+  }
+
+  close() {
+    const peers = MockBroadcastChannel.channels.get(this.name);
+    if (peers) {
+      peers.delete(this);
+      if (!peers.size) {
+        MockBroadcastChannel.channels.delete(this.name);
+      }
+    }
+
+    this.listeners.clear();
+    this.onmessage = null;
+  }
+}
+
+describe('globalGistSettings utilities', () => {
+  const originalBroadcastChannel = global.BroadcastChannel;
+
+  beforeAll(() => {
+    global.BroadcastChannel = MockBroadcastChannel;
+  });
+
+  afterAll(() => {
+    global.BroadcastChannel = originalBroadcastChannel;
+  });
+
+  beforeEach(() => {
+    clearCookie();
+    MockBroadcastChannel.channels.clear();
+  });
+
+  function clearCookie() {
+    document.cookie = `${COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  }
+
+  function setCookie(value) {
+    document.cookie = `${COOKIE_NAME}=${value}; path=/`;
+  }
+
+  test('readGlobalGistSettings returns defaults when cookie is missing', () => {
+    expect(readGlobalGistSettings()).toEqual({ gistId: '', gistToken: '' });
+  });
+
+  test('readGlobalGistSettings gracefully handles invalid JSON', () => {
+    setCookie(encodeURIComponent('not-json'));
+    expect(readGlobalGistSettings()).toEqual({ gistId: '', gistToken: '' });
+  });
+
+  test('readGlobalGistSettings trims values from the cookie payload', () => {
+    const payload = {
+      gistId: '  abc123  ',
+      gistToken: '  token-value  ',
+    };
+    setCookie(encodeURIComponent(JSON.stringify(payload)));
+
+    expect(readGlobalGistSettings()).toEqual({ gistId: 'abc123', gistToken: 'token-value' });
+  });
+
+  test('writeGlobalGistSettings persists cookies and broadcasts updates', () => {
+    const callback = jest.fn();
+    const unsubscribe = subscribeToGlobalGistSettings(callback);
+
+    const detail = { gistId: ' my-id ', gistToken: ' my-token ' };
+    writeGlobalGistSettings(detail);
+
+    expect(readGlobalGistSettings()).toEqual({ gistId: 'my-id', gistToken: 'my-token' });
+    expect(callback).toHaveBeenCalledWith({ gistId: 'my-id', gistToken: 'my-token' });
+    const callsAfterWrite = callback.mock.calls.length;
+    expect(callsAfterWrite).toBeGreaterThanOrEqual(1);
+
+    unsubscribe();
+    clearGlobalGistSettings();
+    expect(callback.mock.calls.length).toBe(callsAfterWrite);
+  });
+
+  test('writeGlobalGistSettings does not throw when document is unavailable', () => {
+    const originalDocument = global.document;
+    // eslint-disable-next-line no-global-assign
+    global.document = undefined;
+
+    expect(() => writeGlobalGistSettings({ gistId: '1', gistToken: '2' })).not.toThrow();
+
+    global.document = originalDocument;
+  });
+});
+

--- a/src/utils/globalGistSettings.js
+++ b/src/utils/globalGistSettings.js
@@ -1,0 +1,174 @@
+const COOKIE_NAME = 'g1_gist_settings';
+const BROADCAST_CHANNEL_NAME = 'g1-gist-settings';
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+const defaultSettings = Object.freeze({ gistId: '', gistToken: '' });
+
+function getDocument() {
+  return typeof document !== 'undefined' ? document : null;
+}
+
+function getWindow() {
+  return typeof window !== 'undefined' ? window : null;
+}
+
+function normalizeSettings(input = {}) {
+  const gistId = typeof input.gistId === 'string' ? input.gistId.trim() : '';
+  const gistToken = typeof input.gistToken === 'string' ? input.gistToken.trim() : '';
+
+  return { gistId, gistToken };
+}
+
+function getCustomEventConstructor() {
+  const win = getWindow();
+  if (win && typeof win.CustomEvent === 'function') {
+    return win.CustomEvent;
+  }
+
+  if (typeof CustomEvent === 'function') {
+    return CustomEvent;
+  }
+
+  return null;
+}
+
+function getBroadcastChannelConstructor() {
+  const win = getWindow();
+  if (win && typeof win.BroadcastChannel === 'function') {
+    return win.BroadcastChannel;
+  }
+
+  if (typeof BroadcastChannel === 'function') {
+    return BroadcastChannel;
+  }
+
+  return null;
+}
+
+export function readGlobalGistSettings() {
+  const doc = getDocument();
+  if (!doc || !doc.cookie) {
+    return { ...defaultSettings };
+  }
+
+  const cookieEntries = doc.cookie.split(';');
+  let rawValue = '';
+
+  for (const entry of cookieEntries) {
+    const [name, ...valueParts] = entry.split('=');
+    if (name && name.trim() === COOKIE_NAME) {
+      rawValue = valueParts.join('=');
+      break;
+    }
+  }
+
+  if (!rawValue) {
+    return { ...defaultSettings };
+  }
+
+  try {
+    const decoded = decodeURIComponent(rawValue);
+    const parsed = JSON.parse(decoded);
+    return normalizeSettings(parsed);
+  } catch (error) {
+    return { ...defaultSettings };
+  }
+}
+
+export function writeGlobalGistSettings(settings) {
+  const detail = normalizeSettings(settings);
+  const doc = getDocument();
+
+  if (doc) {
+    const encoded = encodeURIComponent(JSON.stringify(detail));
+    const cookieString = `${COOKIE_NAME}=${encoded}; path=/; SameSite=Lax; max-age=${ONE_YEAR_IN_SECONDS}`;
+    doc.cookie = cookieString;
+  }
+
+  const win = getWindow();
+  const CustomEventConstructor = getCustomEventConstructor();
+  if (win && typeof win.dispatchEvent === 'function' && CustomEventConstructor) {
+    const event = new CustomEventConstructor('g1:gist-settings-changed', { detail });
+    win.dispatchEvent(event);
+  }
+
+  const BroadcastChannelConstructor = getBroadcastChannelConstructor();
+  if (BroadcastChannelConstructor) {
+    const channel = new BroadcastChannelConstructor(BROADCAST_CHANNEL_NAME);
+    try {
+      channel.postMessage(detail);
+    } finally {
+      if (typeof channel.close === 'function') {
+        channel.close();
+      }
+    }
+  }
+
+  return detail;
+}
+
+export function subscribeToGlobalGistSettings(callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('Expected callback to be a function');
+  }
+
+  const cleanups = [];
+  const win = getWindow();
+
+  if (win && typeof win.addEventListener === 'function') {
+    const handler = (event) => {
+      callback(normalizeSettings(event && event.detail));
+    };
+    win.addEventListener('g1:gist-settings-changed', handler);
+    cleanups.push(() => win.removeEventListener('g1:gist-settings-changed', handler));
+  }
+
+  const BroadcastChannelConstructor = getBroadcastChannelConstructor();
+  let broadcastChannel;
+  let broadcastHandler;
+
+  if (BroadcastChannelConstructor) {
+    broadcastChannel = new BroadcastChannelConstructor(BROADCAST_CHANNEL_NAME);
+    broadcastHandler = (event) => {
+      callback(normalizeSettings(event && event.data));
+    };
+
+    if (typeof broadcastChannel.addEventListener === 'function') {
+      broadcastChannel.addEventListener('message', broadcastHandler);
+      cleanups.push(() => broadcastChannel.removeEventListener('message', broadcastHandler));
+    } else {
+      broadcastChannel.onmessage = broadcastHandler;
+      cleanups.push(() => {
+        if (broadcastChannel.onmessage === broadcastHandler) {
+          broadcastChannel.onmessage = null;
+        }
+      });
+    }
+  }
+
+  return () => {
+    cleanups.forEach((cleanup) => {
+      try {
+        cleanup();
+      } catch (error) {
+        // ignore cleanup errors
+      }
+    });
+
+    if (broadcastChannel && typeof broadcastChannel.close === 'function') {
+      broadcastChannel.close();
+    }
+  };
+}
+
+export function clearGlobalGistSettings() {
+  return writeGlobalGistSettings({ gistId: '', gistToken: '' });
+}
+
+export default {
+  readGlobalGistSettings,
+  writeGlobalGistSettings,
+  subscribeToGlobalGistSettings,
+  clearGlobalGistSettings,
+};
+

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,7 @@
+export {
+  readGlobalGistSettings,
+  writeGlobalGistSettings,
+  subscribeToGlobalGistSettings,
+  clearGlobalGistSettings,
+} from './globalGistSettings';
+


### PR DESCRIPTION
## Summary
- add utilities for reading and writing shared gist settings cookies with event and broadcast notifications
- cover cookie parsing and broadcast fallbacks with unit tests
- expose the new helpers through the utils barrel export

## Testing
- npm test -- globalGistSettings

------
https://chatgpt.com/codex/tasks/task_e_68d18bf9cfe4832b881908735dbae505