### PR TITLE
Add Quantum Playground to app registry

### DIFF
--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -91,6 +91,19 @@ export const APP_REGISTRY = {
     created: '2024-09-23',
     featured: true,
   }),
+  'quantum-playground': withDefaults({
+    id: 'quantum-playground',
+    title: 'Quantum Playground',
+    description: 'Experiment with quantum circuits, visualize qubits, and explore superposition.',
+    icon: '⚛️',
+    category: 'Education',
+    component: null,
+    loader: () => import('./quantum-playground'),
+    path: '/apps/quantum-playground',
+    tags: ['quantum', 'physics', 'circuits', 'visualization'],
+    created: '2025-01-15',
+    featured: true,
+  }),
   // Placeholder for future apps
   'n-pomodoro': withDefaults({
     id: 'n-pomodoro',


### PR DESCRIPTION
## Summary
- register the Quantum Playground app with metadata, category, and lazy loader
- ensure the new registry entry will appear in the launcher through existing sorting

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d18e957840832b85fc5d4579fe97a9