### PR TITLE
Add quantum playground simulator app

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-react',
+    '@babel/preset-typescript',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,19 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1",
+        "recharts": "^2.12.7",
         "sortablejs": "^1.15.6"
       },
       "devDependencies": {
         "@babel/core": "^7.22.0",
         "@babel/preset-env": "^7.22.0",
         "@babel/preset-react": "^7.22.0",
+        "@babel/preset-typescript": "^7.24.7",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^18.2.78",
+        "@types/react-dom": "^18.2.25",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.0",
         "copy-webpack-plugin": "^13.0.1",
@@ -35,6 +39,7 @@
         "jest-environment-jsdom": "^30.1.2",
         "resolve-cwd": "^3.0.0",
         "style-loader": "^3.3.0",
+        "typescript": "^5.6.3",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.0",
         "webpack-dev-server": "^4.15.0"
@@ -1673,6 +1678,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1853,6 +1878,26 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -20,15 +20,19 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",
+    "recharts": "^2.12.7",
     "sortablejs": "^1.15.6"
   },
   "devDependencies": {
     "@babel/core": "^7.22.0",
     "@babel/preset-env": "^7.22.0",
     "@babel/preset-react": "^7.22.0",
+    "@babel/preset-typescript": "^7.24.7",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^18.2.78",
+    "@types/react-dom": "^18.2.25",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.0",
     "copy-webpack-plugin": "^13.0.1",
@@ -40,6 +44,7 @@
     "jest-environment-jsdom": "^30.1.2",
     "resolve-cwd": "^3.0.0",
     "style-loader": "^3.3.0",
+    "typescript": "^5.6.3",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0",
     "webpack-dev-server": "^4.15.0"

--- a/src/apps/quantum-playground/CircuitEditor.tsx
+++ b/src/apps/quantum-playground/CircuitEditor.tsx
@@ -1,0 +1,469 @@
+import React, { FormEvent, useMemo, useState } from 'react';
+import {
+  CircuitStep,
+  GateOperation,
+  GateType,
+  QuantumCircuit,
+  formatAngleLabel,
+} from './simulator';
+
+const gateLibrary: Array<{
+  type: GateType;
+  label: string;
+  description: string;
+  requiresAngle?: boolean;
+  defaultAngle?: number;
+  requiresControl?: boolean;
+  requiresSecondaryTarget?: boolean;
+}> = [
+  { type: 'H', label: 'Hadamard', description: 'Creates superposition on a single qubit.' },
+  { type: 'X', label: 'Pauli-X', description: 'Bit flip gate (NOT).' },
+  { type: 'Y', label: 'Pauli-Y', description: 'Pauli-Y gate with phase rotation.' },
+  { type: 'Z', label: 'Pauli-Z', description: 'Phase flip gate.' },
+  { type: 'S', label: 'S Gate', description: 'Phase gate adding +π/2 on |1⟩.' },
+  { type: 'T', label: 'T Gate', description: 'π/4 phase gate on |1⟩.' },
+  {
+    type: 'Rx',
+    label: 'Rx(θ)',
+    description: 'Rotation around the X-axis by angle θ.',
+    requiresAngle: true,
+    defaultAngle: Math.PI,
+  },
+  {
+    type: 'Ry',
+    label: 'Ry(θ)',
+    description: 'Rotation around the Y-axis by angle θ.',
+    requiresAngle: true,
+    defaultAngle: Math.PI,
+  },
+  {
+    type: 'Rz',
+    label: 'Rz(θ)',
+    description: 'Rotation around the Z-axis by angle θ.',
+    requiresAngle: true,
+    defaultAngle: Math.PI / 2,
+  },
+  {
+    type: 'CNOT',
+    label: 'CNOT',
+    description: 'Controlled-NOT gate entangling two qubits.',
+    requiresControl: true,
+  },
+  {
+    type: 'CZ',
+    label: 'CZ',
+    description: 'Controlled-Z phase gate.',
+    requiresControl: true,
+  },
+  {
+    type: 'SWAP',
+    label: 'SWAP',
+    description: 'Swap the state of two qubits.',
+    requiresSecondaryTarget: true,
+  },
+];
+
+const createGateId = (prefix: string) => `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+const createStepId = () => `step-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+const formatStepTitle = (step: CircuitStep, index: number) =>
+  step.description ?? `Step ${index + 1}`;
+
+const collectQubits = (operation: GateOperation): number[] => [
+  ...(operation.targets ?? []),
+  ...(operation.controls ?? []),
+];
+
+const hasQubitOverlap = (a: GateOperation, b: GateOperation): boolean => {
+  const aQubits = collectQubits(a);
+  const bQubits = collectQubits(b);
+  return aQubits.some((qubit) => bQubits.includes(qubit));
+};
+
+const describeCell = (operation: GateOperation, qubit: number): string | null => {
+  if (operation.targets?.includes(qubit)) {
+    if (operation.type === 'Rz' || operation.type === 'Rx' || operation.type === 'Ry') {
+      return `${operation.type}(${formatAngleLabel(operation.angle)})`;
+    }
+    if (operation.type === 'SWAP') {
+      return 'SWAP';
+    }
+    return operation.type;
+  }
+
+  if (operation.controls?.includes(qubit)) {
+    if (operation.type === 'CNOT') {
+      return '● (ctrl)';
+    }
+    if (operation.type === 'CZ') {
+      return '⊙ (ctrl)';
+    }
+  }
+
+  return null;
+};
+
+interface CircuitEditorProps {
+  circuit: QuantumCircuit;
+  onCircuitChange: (circuit: QuantumCircuit) => void;
+  qubitCount: number;
+}
+
+const CircuitEditor: React.FC<CircuitEditorProps> = ({ circuit, onCircuitChange, qubitCount }) => {
+  const [selectedGateType, setSelectedGateType] = useState<GateType>('H');
+  const [selectedStepId, setSelectedStepId] = useState<string>('append');
+  const [targetQubit, setTargetQubit] = useState(0);
+  const [secondaryTarget, setSecondaryTarget] = useState(1);
+  const [controlQubit, setControlQubit] = useState(1);
+  const [angle, setAngle] = useState(Math.PI / 2);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const gateDefinition = useMemo(
+    () => gateLibrary.find((gate) => gate.type === selectedGateType) ?? gateLibrary[0],
+    [selectedGateType],
+  );
+
+  const handleGateTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const type = event.target.value as GateType;
+    setSelectedGateType(type);
+    const definition = gateLibrary.find((gate) => gate.type === type);
+    if (definition?.requiresControl && controlQubit === targetQubit) {
+      setControlQubit((targetQubit + 1) % qubitCount);
+    }
+    if (definition?.requiresSecondaryTarget && secondaryTarget === targetQubit) {
+      setSecondaryTarget((targetQubit + 1) % qubitCount);
+    }
+    if (definition?.requiresAngle && typeof definition.defaultAngle === 'number') {
+      setAngle(definition.defaultAngle);
+    }
+  };
+
+  const handleAddGate = (event: FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const definition = gateDefinition;
+    const newGate: GateOperation = {
+      id: createGateId(selectedGateType.toLowerCase()),
+      type: selectedGateType,
+      targets: [targetQubit],
+    };
+
+    if (definition.requiresSecondaryTarget) {
+      if (secondaryTarget === targetQubit) {
+        setFormError('SWAP gate requires two distinct targets.');
+        return;
+      }
+      newGate.targets = [targetQubit, secondaryTarget];
+    }
+
+    if (definition.requiresControl) {
+      if (controlQubit === targetQubit) {
+        setFormError('Control and target qubits must be different.');
+        return;
+      }
+      newGate.controls = [controlQubit];
+    }
+
+    if (definition.requiresAngle) {
+      newGate.angle = angle;
+    }
+
+    const targetIndex = selectedStepId === 'append'
+      ? circuit.length
+      : circuit.findIndex((step, index) => (step.id ?? `step-${index}`) === selectedStepId);
+
+    if (targetIndex === -1 || targetIndex >= circuit.length) {
+      const newStep: CircuitStep = {
+        id: createStepId(),
+        operations: [newGate],
+      };
+      onCircuitChange([...circuit, newStep]);
+      setSelectedStepId(newStep.id ?? 'append');
+      return;
+    }
+
+    const targetStep = circuit[targetIndex];
+    const conflicts = targetStep.operations.some((operation) => hasQubitOverlap(operation, newGate));
+    if (conflicts) {
+      setFormError('Selected gate conflicts with an existing operation in this step.');
+      return;
+    }
+
+    const updatedStep: CircuitStep = {
+      ...targetStep,
+      operations: [...targetStep.operations, newGate],
+    };
+
+    const nextCircuit = [...circuit];
+    nextCircuit[targetIndex] = updatedStep;
+    onCircuitChange(nextCircuit);
+  };
+
+  const handleRemoveGate = (stepIndex: number, gateId: string | undefined) => {
+    const step = circuit[stepIndex];
+    const filtered = step.operations.filter((operation) => operation.id !== gateId);
+    const nextCircuit = [...circuit];
+    nextCircuit[stepIndex] = { ...step, operations: filtered };
+    onCircuitChange(nextCircuit);
+  };
+
+  const handleRemoveStep = (stepIndex: number) => {
+    const nextCircuit = circuit.filter((_, index) => index !== stepIndex);
+    onCircuitChange(nextCircuit);
+    setSelectedStepId('append');
+  };
+
+  const handleClearCircuit = () => {
+    onCircuitChange([]);
+    setSelectedStepId('append');
+  };
+
+  const stepOptions = useMemo(
+    () => circuit.map((step, index) => ({
+      id: step.id ?? `step-${index}`,
+      label: formatStepTitle(step, index),
+    })),
+    [circuit],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Circuit Builder</h2>
+            <p className="text-sm text-slate-400">Compose gates per step and manage entanglement layout.</p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm font-medium text-slate-100 transition hover:bg-slate-700"
+            onClick={handleClearCircuit}
+          >
+            Clear Circuit
+          </button>
+        </div>
+
+        <form className="grid grid-cols-1 gap-4 md:grid-cols-2" onSubmit={handleAddGate}>
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gate-type">
+              Gate
+            </label>
+            <select
+              id="gate-type"
+              className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+              value={selectedGateType}
+              onChange={handleGateTypeChange}
+            >
+              {gateLibrary.map((gate) => (
+                <option key={gate.type} value={gate.type}>
+                  {gate.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-slate-500">{gateDefinition.description}</p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="step-selector">
+              Step
+            </label>
+            <select
+              id="step-selector"
+              className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+              value={selectedStepId}
+              onChange={(event) => setSelectedStepId(event.target.value)}
+            >
+              <option value="append">Append new step</option>
+              {stepOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-slate-500">Concurrent gates in the same step must touch disjoint qubits.</p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="target-qubit">
+              Target Qubit
+            </label>
+            <select
+              id="target-qubit"
+              className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+              value={targetQubit}
+              onChange={(event) => setTargetQubit(Number(event.target.value))}
+            >
+              {Array.from({ length: qubitCount }).map((_, index) => (
+                <option key={`target-${index}`} value={index}>
+                  q{index}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {gateDefinition.requiresSecondaryTarget ? (
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="secondary-target">
+                Second Target
+              </label>
+              <select
+                id="secondary-target"
+                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                value={secondaryTarget}
+                onChange={(event) => setSecondaryTarget(Number(event.target.value))}
+              >
+                {Array.from({ length: qubitCount }).map((_, index) => (
+                  <option key={`secondary-${index}`} value={index}>
+                    q{index}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {gateDefinition.requiresControl ? (
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="control-qubit">
+                Control Qubit
+              </label>
+              <select
+                id="control-qubit"
+                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                value={controlQubit}
+                onChange={(event) => setControlQubit(Number(event.target.value))}
+              >
+                {Array.from({ length: qubitCount }).map((_, index) => (
+                  <option key={`control-${index}`} value={index}>
+                    q{index}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {gateDefinition.requiresAngle ? (
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="gate-angle">
+                Angle (radians)
+              </label>
+              <input
+                id="gate-angle"
+                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                type="number"
+                step="0.01"
+                value={angle}
+                onChange={(event) => setAngle(Number(event.target.value))}
+              />
+            </div>
+          ) : null}
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+            >
+              Add Gate
+            </button>
+            {formError ? <p className="mt-2 text-sm text-rose-400">{formError}</p> : null}
+          </div>
+        </form>
+      </div>
+
+      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+        <h3 className="text-base font-semibold text-slate-100">Circuit Timeline</h3>
+        <p className="mb-3 text-sm text-slate-400">Visual overview of gates applied per step and qubit.</p>
+        <div className="overflow-x-auto">
+          <table className="w-full table-auto border-collapse text-sm text-slate-100">
+            <thead>
+              <tr>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Qubit
+                </th>
+                {circuit.map((step, index) => (
+                  <th
+                    key={step.id ?? `step-header-${index}`}
+                    className="border border-slate-800 bg-slate-900 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-400"
+                  >
+                    Step {index + 1}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: qubitCount }).map((_, qubitIndex) => (
+                <tr key={`qubit-row-${qubitIndex}`} className="odd:bg-slate-900 even:bg-slate-900/60">
+                  <th className="border border-slate-800 px-3 py-2 text-left font-semibold text-slate-200">
+                    q{qubitIndex}
+                  </th>
+                  {circuit.map((step, stepIndex) => {
+                    const gateLabel = step.operations
+                      .map((operation) => describeCell(operation, qubitIndex))
+                      .find((label) => label !== null);
+                    return (
+                      <td
+                        key={`${step.id ?? `step-${stepIndex}`}-q${qubitIndex}`}
+                        className="border border-slate-800 px-3 py-2 text-center text-xs text-slate-200"
+                      >
+                        {gateLabel ?? '—'}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {circuit.map((step, index) => (
+          <div
+            key={step.id ?? `step-card-${index}`}
+            className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 shadow"
+          >
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <h4 className="text-sm font-semibold text-slate-100">{formatStepTitle(step, index)}</h4>
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-md border border-slate-700 bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-100 transition hover:bg-slate-700"
+                onClick={() => handleRemoveStep(index)}
+              >
+                Remove Step
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {step.operations.map((operation) => (
+                <div
+                  key={operation.id}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-100"
+                >
+                  <span className="font-semibold uppercase tracking-wide text-slate-200">{operation.type}</span>
+                  {operation.angle !== undefined ? (
+                    <span className="text-slate-400">θ={formatAngleLabel(operation.angle)}</span>
+                  ) : null}
+                  {operation.controls?.length ? (
+                    <span className="text-slate-400">ctrl: {operation.controls.join(', ')}</span>
+                  ) : null}
+                  <span className="text-slate-400">targets: {operation.targets.join(', ')}</span>
+                  <button
+                    type="button"
+                    className="inline-flex items-center rounded-md bg-rose-500/20 px-2 py-1 text-xs font-semibold text-rose-200 transition hover:bg-rose-500/30"
+                    onClick={() => handleRemoveGate(index, operation.id)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              {step.operations.length === 0 ? (
+                <p className="text-sm text-slate-500">No gates added in this step yet.</p>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CircuitEditor;

--- a/src/apps/quantum-playground/Visualizer.tsx
+++ b/src/apps/quantum-playground/Visualizer.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo } from 'react';
+import {
+  MeasurementResult,
+  ProbabilityEntry,
+  QuantumCircuit,
+  StateVectorEntry,
+} from './simulator';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface VisualizerProps {
+  circuit: QuantumCircuit;
+  probabilities: ProbabilityEntry[];
+  stateVector: StateVectorEntry[];
+  measurement: MeasurementResult | null;
+  measuredQubits: number[];
+}
+
+const Visualizer: React.FC<VisualizerProps> = ({
+  circuit,
+  probabilities,
+  stateVector,
+  measurement,
+  measuredQubits,
+}) => {
+  const probabilityData = useMemo(
+    () => probabilities.map((entry) => ({
+      basis: entry.state.replace(/[<>|]/g, ''),
+      probability: Number(entry.probability.toFixed(6)),
+    })),
+    [probabilities],
+  );
+
+  const measurementData = useMemo(() => {
+    if (!measurement) {
+      return [];
+    }
+    const keys = Object.keys(measurement.probabilities).sort();
+    return keys.map((key) => ({
+      outcome: key,
+      probability: Number((measurement.probabilities[key] ?? 0).toFixed(6)),
+      shots: measurement.histogram[key] ?? 0,
+    }));
+  }, [measurement]);
+
+  const circuitSummary = useMemo(() => ({
+    depth: circuit.length,
+    totalGates: circuit.reduce((count, step) => count + step.operations.length, 0),
+  }), [circuit]);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+        <h2 className="text-lg font-semibold text-slate-100">Simulation Snapshot</h2>
+        <p className="text-sm text-slate-400">
+          Depth {circuitSummary.depth} • Total gates {circuitSummary.totalGates} • Measuring qubits
+          {' '}
+          {measuredQubits.length > 0 ? measuredQubits.map((q) => `q${q}`).join(', ') : 'none'}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+          <h3 className="text-base font-semibold text-slate-100">State Probabilities</h3>
+          <p className="mb-2 text-sm text-slate-400">Amplitude probabilities across the 4-qubit computational basis.</p>
+          <div className="h-64 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={probabilityData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                <XAxis dataKey="basis" stroke="#cbd5f5" />
+                <YAxis stroke="#cbd5f5" domain={[0, 1]} tickFormatter={(value) => value.toFixed(2)} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', color: '#e2e8f0' }}
+                  formatter={(value: number) => value.toFixed(4)}
+                />
+                <Legend />
+                <Bar dataKey="probability" fill="#38bdf8" name="Probability" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+          <h3 className="text-base font-semibold text-slate-100">Measurement Outcomes</h3>
+          <p className="mb-2 text-sm text-slate-400">Sampling histogram from the selected measurement registers.</p>
+          <div className="h-64 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={measurementData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                <XAxis dataKey="outcome" stroke="#cbd5f5" />
+                <YAxis stroke="#cbd5f5" tickFormatter={(value) => value.toFixed(2)} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#0f172a', border: '1px solid #1e293b', color: '#e2e8f0' }}
+                  formatter={(value: number, name) => (name === 'shots' ? value : value.toFixed(4))}
+                />
+                <Legend />
+                <Bar dataKey="probability" fill="#34d399" name="Probability" />
+                <Bar dataKey="shots" fill="#818cf8" name="Sample Count" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-slate-800 bg-slate-900 p-4 shadow-lg">
+        <h3 className="text-base font-semibold text-slate-100">State Vector</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full table-auto border-collapse text-sm text-slate-100">
+            <thead>
+              <tr>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Basis
+                </th>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Amplitude (Re)
+                </th>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Amplitude (Im)
+                </th>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Probability
+                </th>
+                <th className="border border-slate-800 bg-slate-900 px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Phase
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {stateVector.map((entry) => (
+                <tr key={entry.index} className="odd:bg-slate-900 even:bg-slate-900/60">
+                  <td className="border border-slate-800 px-3 py-2 font-mono text-slate-100">{entry.basis}</td>
+                  <td className="border border-slate-800 px-3 py-2 text-right text-slate-200">{entry.amplitude.re.toFixed(4)}</td>
+                  <td className="border border-slate-800 px-3 py-2 text-right text-slate-200">{entry.amplitude.im.toFixed(4)}</td>
+                  <td className="border border-slate-800 px-3 py-2 text-right text-slate-200">{entry.probability.toFixed(4)}</td>
+                  <td className="border border-slate-800 px-3 py-2 text-right text-slate-200">{entry.phase.toFixed(4)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-dashed border-slate-700 bg-slate-900/60 p-4 text-sm text-slate-400">
+        <h3 className="text-base font-semibold text-slate-100">Bloch Sphere Visualizations</h3>
+        <p>
+          Placeholder for per-qubit Bloch sphere renderings. TODO: integrate full Bloch sphere widgets per qubit for deeper
+          intuition.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Visualizer;

--- a/src/apps/quantum-playground/examples.ts
+++ b/src/apps/quantum-playground/examples.ts
@@ -1,0 +1,118 @@
+import { CircuitStep, GateOperation, QuantumCircuit } from './simulator';
+
+export interface QuantumExample {
+  id: string;
+  name: string;
+  description: string;
+  circuit: QuantumCircuit;
+  tags?: string[];
+}
+
+let gateIdCounter = 0;
+let stepIdCounter = 0;
+
+const nextGateId = (type: string) => {
+  gateIdCounter += 1;
+  return `${type}-${gateIdCounter}`;
+};
+
+const nextStepId = (label: string) => {
+  stepIdCounter += 1;
+  return `${label}-${stepIdCounter}`;
+};
+
+const withGateIds = (gate: Omit<GateOperation, 'id'>): GateOperation => ({
+  ...gate,
+  id: nextGateId(gate.type),
+});
+
+const createStep = (operations: Omit<GateOperation, 'id'>[], label: string): CircuitStep => ({
+  id: nextStepId(label),
+  operations: operations.map(withGateIds),
+});
+
+const buildControlledPhase = (
+  control: number,
+  target: number,
+  angle: number,
+): CircuitStep[] => [
+  createStep([
+    { type: 'Rz', targets: [target], angle: angle / 2 },
+  ], `rz-pre-${control}-${target}`),
+  createStep([
+    { type: 'CNOT', controls: [control], targets: [target] },
+  ], `cnot-phase-${control}-${target}`),
+  createStep([
+    { type: 'Rz', targets: [target], angle: -angle / 2 },
+  ], `rz-neg-${control}-${target}`),
+  createStep([
+    { type: 'CNOT', controls: [control], targets: [target] },
+  ], `cnot-phase2-${control}-${target}`),
+  createStep([
+    { type: 'Rz', targets: [control], angle: angle / 2 },
+  ], `rz-control-${control}-${target}`),
+];
+
+const buildQftCircuit = (qubits: number): QuantumCircuit => {
+  const steps: CircuitStep[] = [];
+  for (let control = qubits - 1; control >= 0; control -= 1) {
+    steps.push(createStep([{ type: 'H', targets: [control] }], `qft-h-${control}`));
+    for (let target = control - 1; target >= 0; target -= 1) {
+      const angle = Math.PI / 2 ** (control - target);
+      steps.push(...buildControlledPhase(control, target, angle));
+    }
+  }
+
+  for (let i = 0; i < Math.floor(qubits / 2); i += 1) {
+    steps.push(createStep([{ type: 'SWAP', targets: [i, qubits - 1 - i] }], `qft-swap-${i}`));
+  }
+  return steps;
+};
+
+export const BELL_STATE: QuantumExample = {
+  id: 'bell-state',
+  name: 'Bell State',
+  description: 'Creates a maximally entangled Bell pair on qubits 0 and 1.',
+  tags: ['entanglement', 'two-qubit'],
+  circuit: [
+    createStep([{ type: 'H', targets: [0] }], 'bell-h'),
+    createStep([{ type: 'CNOT', controls: [0], targets: [1] }], 'bell-cnot'),
+  ],
+};
+
+export const GHZ_STATE: QuantumExample = {
+  id: 'ghz-state',
+  name: 'GHZ State',
+  description: 'Builds a four-qubit Greenberger–Horne–Zeilinger state.',
+  tags: ['entanglement', 'multi-qubit'],
+  circuit: [
+    createStep([{ type: 'H', targets: [0] }], 'ghz-h'),
+    createStep([{ type: 'CNOT', controls: [0], targets: [1] }], 'ghz-cnot-01'),
+    createStep([{ type: 'CNOT', controls: [1], targets: [2] }], 'ghz-cnot-12'),
+    createStep([{ type: 'CNOT', controls: [2], targets: [3] }], 'ghz-cnot-23'),
+  ],
+};
+
+export const QFT_FOUR_QUBIT: QuantumExample = {
+  id: 'qft-4-qubit',
+  name: 'Quantum Fourier Transform',
+  description: 'Implements the four-qubit Quantum Fourier Transform using phase rotations.',
+  tags: ['fourier', 'transform'],
+  circuit: buildQftCircuit(4),
+};
+
+export const QUANTUM_EXAMPLES: QuantumExample[] = [
+  BELL_STATE,
+  GHZ_STATE,
+  QFT_FOUR_QUBIT,
+];
+
+export const getRandomExample = (excludeId?: string): QuantumExample => {
+  const candidates = QUANTUM_EXAMPLES.filter((example) => example.id !== excludeId);
+  const pool = candidates.length > 0 ? candidates : QUANTUM_EXAMPLES;
+  const index = Math.floor(Math.random() * pool.length);
+  return pool[index];
+};
+
+export const findExampleById = (id: string): QuantumExample | undefined =>
+  QUANTUM_EXAMPLES.find((example) => example.id === id);

--- a/src/apps/quantum-playground/index.tsx
+++ b/src/apps/quantum-playground/index.tsx
@@ -1,0 +1,304 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import CircuitEditor from './CircuitEditor';
+import Visualizer from './Visualizer';
+import {
+  MeasurementResult,
+  ProbabilityEntry,
+  QuantumCircuit,
+  QuantumSimulator,
+  StateVectorEntry,
+  loadCircuitFromStorage,
+  saveCircuitToStorage,
+} from './simulator';
+import {
+  BELL_STATE,
+  QUANTUM_EXAMPLES,
+  QuantumExample,
+  getRandomExample,
+} from './examples';
+import './styles.css';
+
+const cloneCircuit = (circuit: QuantumCircuit): QuantumCircuit =>
+  circuit.map((step, stepIndex) => ({
+    ...step,
+    id: step.id ?? `step-${stepIndex}`,
+    operations: step.operations.map((operation, gateIndex) => ({
+      ...operation,
+      id: operation.id ?? `${operation.type}-${stepIndex}-${gateIndex}`,
+    })),
+  }));
+
+const DEFAULT_EXAMPLE = BELL_STATE;
+
+const QuantumPlaygroundApp: React.FC = () => {
+  const simulatorRef = useRef<QuantumSimulator | null>(null);
+  if (!simulatorRef.current) {
+    simulatorRef.current = new QuantumSimulator(4);
+  }
+
+  const storedCircuit = useMemo(() => loadCircuitFromStorage(), []);
+  const [circuit, setCircuit] = useState<QuantumCircuit>(() => (
+    storedCircuit && storedCircuit.length > 0
+      ? cloneCircuit(storedCircuit)
+      : cloneCircuit(DEFAULT_EXAMPLE.circuit)
+  ));
+  const [activeExample, setActiveExample] = useState<QuantumExample>(DEFAULT_EXAMPLE);
+  const [stateVector, setStateVector] = useState<StateVectorEntry[]>(
+    () => simulatorRef.current!.getStateVector(),
+  );
+  const [probabilities, setProbabilities] = useState<ProbabilityEntry[]>(
+    () => simulatorRef.current!.getProbabilityDistribution(),
+  );
+  const [measurement, setMeasurement] = useState<MeasurementResult | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [shots, setShots] = useState(512);
+  const qubitCount = simulatorRef.current!.getQubitCount();
+  const [measurementMask, setMeasurementMask] = useState<boolean[]>(
+    () => Array.from({ length: qubitCount }, () => true),
+  );
+
+  const measuredQubits = useMemo(
+    () => measurementMask.reduce<number[]>((acc, flag, index) => {
+      if (flag) {
+        acc.push(index);
+      }
+      return acc;
+    }, []),
+    [measurementMask],
+  );
+
+  const refreshState = useCallback(() => {
+    const simulator = simulatorRef.current;
+    if (!simulator) {
+      return;
+    }
+    setStateVector(simulator.getStateVector());
+    setProbabilities(simulator.getProbabilityDistribution());
+    setMeasurement(simulator.measure(measuredQubits, shots, false));
+  }, [measuredQubits, shots]);
+
+  useEffect(() => {
+    const simulator = simulatorRef.current;
+    if (!simulator) {
+      return;
+    }
+    simulator.reset();
+    setStateVector(simulator.getStateVector());
+    setProbabilities(simulator.getProbabilityDistribution());
+    setMeasurement(simulator.measure(measuredQubits, shots, false));
+    // Initial mount only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    saveCircuitToStorage(circuit);
+  }, [circuit]);
+
+  useEffect(() => {
+    refreshState();
+  }, [measuredQubits, shots, refreshState]);
+
+  const handleCircuitChange = (nextCircuit: QuantumCircuit) => {
+    setCircuit(cloneCircuit(nextCircuit));
+  };
+
+  const handleReset = () => {
+    const simulator = simulatorRef.current;
+    if (!simulator) {
+      return;
+    }
+    simulator.reset();
+    setCurrentStep(0);
+    refreshState();
+  };
+
+  const handleRun = () => {
+    const simulator = simulatorRef.current;
+    if (!simulator) {
+      return;
+    }
+    simulator.runCircuit(circuit);
+    setCurrentStep(circuit.length);
+    refreshState();
+  };
+
+  const handleStep = () => {
+    const simulator = simulatorRef.current;
+    if (!simulator) {
+      return;
+    }
+
+    let nextIndex = currentStep;
+    if (nextIndex >= circuit.length) {
+      nextIndex = 0;
+    }
+
+    if (nextIndex === 0) {
+      simulator.reset();
+    }
+
+    const step = circuit[nextIndex];
+    if (step) {
+      simulator.applyStep(step);
+      setCurrentStep(nextIndex + 1);
+      refreshState();
+    }
+  };
+
+  const handleRandomExample = () => {
+    const example = getRandomExample(activeExample.id);
+    setActiveExample(example);
+    const cloned = cloneCircuit(example.circuit);
+    setCircuit(cloned);
+    const simulator = simulatorRef.current;
+    if (simulator) {
+      simulator.reset();
+    }
+    setCurrentStep(0);
+    refreshState();
+  };
+
+  const handleToggleMeasurement = (index: number) => {
+    setMeasurementMask((mask) => {
+      const next = [...mask];
+      next[index] = !next[index];
+      if (!next.some(Boolean)) {
+        next[index] = true;
+      }
+      return next;
+    });
+  };
+
+  const handleShotsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isFinite(value) && value > 0) {
+      setShots(Math.min(10000, Math.max(1, Math.floor(value))));
+    }
+  };
+
+  return (
+    <div className="quantum-playground min-h-screen space-y-6 bg-slate-950 px-6 py-6 text-slate-100">
+      <header className="rounded-xl border border-slate-800 bg-slate-900 p-6 shadow-lg">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100">Quantum Playground</h1>
+            <p className="text-sm text-slate-400">
+              Explore a four-qubit state-vector simulator with an interactive circuit editor, measurement sampling, and
+              persistent circuit storage.
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+            <p className="font-semibold text-slate-100">Example circuits</p>
+            <ul className="mt-2 space-y-1 text-xs text-slate-400">
+              {QUANTUM_EXAMPLES.map((example) => (
+                <li key={example.id}>
+                  <span className={example.id === activeExample.id ? 'text-emerald-400' : ''}>{example.name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          <CircuitEditor circuit={circuit} onCircuitChange={handleCircuitChange} qubitCount={qubitCount} />
+        </div>
+        <div className="space-y-4 rounded-xl border border-slate-800 bg-slate-900 p-4 shadow-lg">
+          <h2 className="text-lg font-semibold text-slate-100">Simulation Controls</h2>
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500"
+              onClick={handleRun}
+            >
+              Run Circuit
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700"
+              onClick={handleStep}
+            >
+              Step
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700"
+              onClick={handleReset}
+            >
+              Reset
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-700"
+              onClick={handleRandomExample}
+            >
+              Random Example
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Step Progress</p>
+            <p className="text-slate-100">{currentStep} / {circuit.length}</p>
+          </div>
+
+          <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 space-y-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Measurement Qubits</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {Array.from({ length: qubitCount }).map((_, index) => (
+                  <label
+                    key={`measure-${index}`}
+                    className={`inline-flex items-center gap-2 rounded-md border border-slate-700 px-3 py-1 text-xs font-semibold transition hover:bg-slate-800 ${measurementMask[index] ? 'bg-emerald-500/10 text-emerald-300' : 'bg-slate-900 text-slate-300'}`}
+                  >
+                    <input
+                      className="accent-emerald-500"
+                      type="checkbox"
+                      checked={measurementMask[index]}
+                      onChange={() => handleToggleMeasurement(index)}
+                    />
+                    q{index}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="shot-count">
+                Shots
+              </label>
+              <input
+                id="shot-count"
+                className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100"
+                type="number"
+                min={1}
+                max={10000}
+                value={shots}
+                onChange={handleShotsChange}
+              />
+              <p className="text-xs text-slate-500">Number of samples used for the measurement histogram.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-slate-800 bg-slate-900 p-6 shadow-lg">
+        <Visualizer
+          circuit={circuit}
+          probabilities={probabilities}
+          stateVector={stateVector}
+          measurement={measurement}
+          measuredQubits={measuredQubits}
+        />
+      </section>
+    </div>
+  );
+};
+
+export default QuantumPlaygroundApp;

--- a/src/apps/quantum-playground/simulator.ts
+++ b/src/apps/quantum-playground/simulator.ts
@@ -1,0 +1,646 @@
+import type { MutableRefObject } from 'react';
+
+export type GateType =
+  | 'H'
+  | 'X'
+  | 'Y'
+  | 'Z'
+  | 'S'
+  | 'T'
+  | 'Rx'
+  | 'Ry'
+  | 'Rz'
+  | 'CNOT'
+  | 'CZ'
+  | 'SWAP';
+
+export interface GateOperation {
+  id?: string;
+  type: GateType;
+  targets: number[];
+  controls?: number[];
+  angle?: number;
+  label?: string;
+}
+
+export interface CircuitStep {
+  id?: string;
+  description?: string;
+  operations: GateOperation[];
+}
+
+export type QuantumCircuit = CircuitStep[];
+
+export interface ComplexNumber {
+  re: number;
+  im: number;
+}
+
+export interface StateVectorEntry {
+  index: number;
+  basis: string;
+  amplitude: ComplexNumber;
+  probability: number;
+  phase: number;
+}
+
+export interface ProbabilityEntry {
+  state: string;
+  probability: number;
+}
+
+export interface MeasurementResult {
+  histogram: Record<string, number>;
+  probabilities: Record<string, number>;
+  shots: number;
+  measuredQubits: number[];
+  collapsedOutcome: string | null;
+}
+
+const EPSILON = 1e-12;
+const DEFAULT_STORAGE_KEY = 'quantum-playground:circuit';
+
+type Matrix2x2 = [
+  [ComplexNumber, ComplexNumber],
+  [ComplexNumber, ComplexNumber]
+];
+
+const ZERO_COMPLEX: ComplexNumber = { re: 0, im: 0 };
+
+const ensureWindow = () => (typeof window !== 'undefined' ? window : undefined);
+
+const createComplex = (re: number, im = 0): ComplexNumber => ({ re, im });
+
+const complexAdd = (a: ComplexNumber, b: ComplexNumber): ComplexNumber => ({
+  re: a.re + b.re,
+  im: a.im + b.im,
+});
+
+const complexMul = (a: ComplexNumber, b: ComplexNumber): ComplexNumber => ({
+  re: a.re * b.re - a.im * b.im,
+  im: a.re * b.im + a.im * b.re,
+});
+
+const normalizeAngle = (angle?: number) => (typeof angle === 'number' ? angle : 0);
+
+export class QuantumSimulator {
+  private readonly qubitCount: number;
+
+  private readonly dimension: number;
+
+  private readonly real: Float64Array;
+
+  private readonly imag: Float64Array;
+
+  constructor(qubitCount = 4) {
+    this.qubitCount = qubitCount;
+    this.dimension = 1 << qubitCount;
+    this.real = new Float64Array(this.dimension);
+    this.imag = new Float64Array(this.dimension);
+    this.reset();
+  }
+
+  getQubitCount(): number {
+    return this.qubitCount;
+  }
+
+  reset(): void {
+    this.real.fill(0);
+    this.imag.fill(0);
+    this.real[0] = 1;
+  }
+
+  cloneState(): { real: Float64Array; imag: Float64Array } {
+    return {
+      real: new Float64Array(this.real),
+      imag: new Float64Array(this.imag),
+    };
+  }
+
+  restoreState(state: { real: Float64Array; imag: Float64Array }): void {
+    this.real.set(state.real);
+    this.imag.set(state.imag);
+  }
+
+  getAmplitude(index: number): ComplexNumber {
+    return { re: this.real[index], im: this.imag[index] };
+  }
+
+  getStateVector(): StateVectorEntry[] {
+    const entries: StateVectorEntry[] = [];
+    for (let index = 0; index < this.dimension; index += 1) {
+      const amplitude = this.getAmplitude(index);
+      const probability = amplitude.re * amplitude.re + amplitude.im * amplitude.im;
+      const phase = Math.atan2(amplitude.im, amplitude.re);
+      entries.push({
+        index,
+        basis: this.formatBasis(index),
+        amplitude,
+        probability,
+        phase,
+      });
+    }
+    return entries;
+  }
+
+  getProbabilityDistribution(): ProbabilityEntry[] {
+    const distribution: ProbabilityEntry[] = [];
+    for (let index = 0; index < this.dimension; index += 1) {
+      const amplitude = this.getAmplitude(index);
+      const probability = amplitude.re * amplitude.re + amplitude.im * amplitude.im;
+      if (probability > EPSILON) {
+        distribution.push({ state: this.formatBasis(index), probability });
+      }
+    }
+    return distribution;
+  }
+
+  runCircuit(circuit: QuantumCircuit): void {
+    this.reset();
+    circuit.forEach((step) => this.applyStep(step));
+  }
+
+  applyStep(step: CircuitStep | null | undefined): void {
+    if (!step || !Array.isArray(step.operations)) {
+      return;
+    }
+
+    const occupiedQubits = new Set<number>();
+    step.operations.forEach((operation) => {
+      const involved = [
+        ...(operation.targets ?? []),
+        ...(operation.controls ?? []),
+      ];
+
+      involved.forEach((qubit) => {
+        if (occupiedQubits.has(qubit)) {
+          throw new Error(`Conflicting gate placement on qubit ${qubit}`);
+        }
+        occupiedQubits.add(qubit);
+      });
+
+      this.applyGate(operation);
+    });
+  }
+
+  applyGate(operation: GateOperation): void {
+    const { type, targets, controls } = operation;
+    const target = targets?.[0];
+
+    switch (type) {
+      case 'H':
+        this.applySingleQubitGate(getHadamardMatrix(), target);
+        break;
+      case 'X':
+        this.applySingleQubitGate(getPauliXMatrix(), target);
+        break;
+      case 'Y':
+        this.applySingleQubitGate(getPauliYMatrix(), target);
+        break;
+      case 'Z':
+        this.applySingleQubitGate(getPauliZMatrix(), target);
+        break;
+      case 'S':
+        this.applySingleQubitGate(getPhaseMatrix(Math.PI / 2), target);
+        break;
+      case 'T':
+        this.applySingleQubitGate(getPhaseMatrix(Math.PI / 4), target);
+        break;
+      case 'Rx':
+        this.applySingleQubitGate(getRxMatrix(normalizeAngle(operation.angle)), target);
+        break;
+      case 'Ry':
+        this.applySingleQubitGate(getRyMatrix(normalizeAngle(operation.angle)), target);
+        break;
+      case 'Rz':
+        this.applySingleQubitGate(getRzMatrix(normalizeAngle(operation.angle)), target);
+        break;
+      case 'CNOT': {
+        const control = controls?.[0];
+        if (control === undefined) {
+          throw new Error('CNOT gate missing control qubit');
+        }
+        this.applyControlledNot(control, target);
+        break;
+      }
+      case 'CZ': {
+        const control = controls?.[0];
+        if (control === undefined) {
+          throw new Error('CZ gate missing control qubit');
+        }
+        this.applyControlledZ(control, target);
+        break;
+      }
+      case 'SWAP': {
+        const targetB = targets?.[1];
+        if (targetB === undefined) {
+          throw new Error('SWAP gate requires two target qubits');
+        }
+        this.applySwap(target, targetB);
+        break;
+      }
+      default:
+        throw new Error(`Unsupported gate type: ${type}`);
+    }
+  }
+
+  measure(
+    qubits: number[],
+    shots = 1024,
+    collapse = false,
+  ): MeasurementResult {
+    const measuredQubits = this.normalizeMeasurementTargets(qubits);
+    if (measuredQubits.length === 0) {
+      return {
+        histogram: {},
+        probabilities: {},
+        shots: 0,
+        measuredQubits,
+        collapsedOutcome: null,
+      };
+    }
+
+    const probabilitiesMap = this.computeMeasurementProbabilities(measuredQubits);
+    const entries = Array.from(probabilitiesMap.entries()).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    const cumulative: number[] = [];
+    let runningTotal = 0;
+    entries.forEach(([, probability]) => {
+      runningTotal += probability;
+      cumulative.push(runningTotal);
+    });
+
+    const histogram: Record<string, number> = {};
+
+    if (shots > 0 && entries.length > 0) {
+      for (let shot = 0; shot < shots; shot += 1) {
+        const sample = Math.random();
+        let index = 0;
+        while (index < cumulative.length && sample > cumulative[index]) {
+          index += 1;
+        }
+        const outcomeKey = entries[Math.min(index, entries.length - 1)][0];
+        histogram[outcomeKey] = (histogram[outcomeKey] ?? 0) + 1;
+      }
+    }
+
+    let collapsedOutcome: string | null = null;
+    if (collapse && entries.length > 0) {
+      const sample = Math.random();
+      let index = 0;
+      while (index < cumulative.length && sample > cumulative[index]) {
+        index += 1;
+      }
+      const selected = entries[Math.min(index, entries.length - 1)][0];
+      collapsedOutcome = selected;
+      this.collapseState(measuredQubits, selected, probabilitiesMap.get(selected) ?? 0);
+    }
+
+    const probabilities: Record<string, number> = {};
+    entries.forEach(([key, probability]) => {
+      probabilities[key] = probability;
+    });
+
+    return {
+      histogram,
+      probabilities,
+      shots,
+      measuredQubits,
+      collapsedOutcome,
+    };
+  }
+
+  private normalizeMeasurementTargets(qubits: number[]): number[] {
+    const unique = new Set<number>();
+    qubits.forEach((qubit) => {
+      if (Number.isInteger(qubit) && qubit >= 0 && qubit < this.qubitCount) {
+        unique.add(qubit);
+      }
+    });
+    if (unique.size === 0) {
+      for (let qubit = 0; qubit < this.qubitCount; qubit += 1) {
+        unique.add(qubit);
+      }
+    }
+    return Array.from(unique).sort((a, b) => a - b);
+  }
+
+  private computeMeasurementProbabilities(qubits: number[]): Map<string, number> {
+    const probabilities = new Map<string, number>();
+    const totalStates = this.dimension;
+
+    for (let index = 0; index < totalStates; index += 1) {
+      const amplitude = this.getAmplitude(index);
+      const probability = amplitude.re * amplitude.re + amplitude.im * amplitude.im;
+      if (probability < EPSILON) {
+        continue;
+      }
+      const outcomeKey = this.formatMeasurementOutcome(qubits, index);
+      probabilities.set(outcomeKey, (probabilities.get(outcomeKey) ?? 0) + probability);
+    }
+
+    let total = 0;
+    probabilities.forEach((value) => {
+      total += value;
+    });
+
+    if (total > 0) {
+      probabilities.forEach((value, key) => {
+        probabilities.set(key, value / total);
+      });
+    }
+
+    return probabilities;
+  }
+
+  private collapseState(qubits: number[], outcome: string, outcomeProbability: number): void {
+    if (outcomeProbability <= EPSILON) {
+      return;
+    }
+
+    const mask = this.createMask(qubits);
+    const outcomeBits = this.outcomeStringToBits(qubits, outcome);
+
+    let norm = 0;
+    for (let index = 0; index < this.dimension; index += 1) {
+      if ((index & mask) !== outcomeBits) {
+        this.real[index] = 0;
+        this.imag[index] = 0;
+      } else {
+        norm += this.real[index] * this.real[index] + this.imag[index] * this.imag[index];
+      }
+    }
+
+    const scale = norm > 0 ? 1 / Math.sqrt(norm) : 1;
+    for (let index = 0; index < this.dimension; index += 1) {
+      if ((index & mask) === outcomeBits) {
+        this.real[index] *= scale;
+        this.imag[index] *= scale;
+      }
+    }
+  }
+
+  private formatBasis(index: number): string {
+    const bits = index.toString(2).padStart(this.qubitCount, '0');
+    return `|${bits}>`;
+  }
+
+  private formatMeasurementOutcome(qubits: number[], index: number): string {
+    const descending = [...qubits].sort((a, b) => b - a);
+    const bits = descending
+      .map((qubit) => ((index >> qubit) & 1).toString())
+      .join('');
+    return bits || '0';
+  }
+
+  private outcomeStringToBits(qubits: number[], outcome: string): number {
+    const descending = [...qubits].sort((a, b) => b - a);
+    let bits = 0;
+    for (let i = 0; i < descending.length; i += 1) {
+      const qubit = descending[i];
+      const bit = outcome[i] === '1' ? 1 : 0;
+      const mask = 1 << qubit;
+      if (bit) {
+        bits |= mask;
+      }
+    }
+    return bits;
+  }
+
+  private createMask(qubits: number[]): number {
+    return qubits.reduce((mask, qubit) => mask | (1 << qubit), 0);
+  }
+
+  private applySingleQubitGate(matrix: Matrix2x2, target: number): void {
+    if (!Number.isInteger(target) || target < 0 || target >= this.qubitCount) {
+      throw new Error(`Invalid target qubit: ${target}`);
+    }
+
+    const stride = 1 << target;
+    const span = stride << 1;
+
+    for (let base = 0; base < this.dimension; base += span) {
+      for (let offset = 0; offset < stride; offset += 1) {
+        const index0 = base + offset;
+        const index1 = index0 + stride;
+
+        const a0 = { re: this.real[index0], im: this.imag[index0] };
+        const a1 = { re: this.real[index1], im: this.imag[index1] };
+
+        const r0 = complexAdd(
+          complexMul(matrix[0][0], a0),
+          complexMul(matrix[0][1], a1),
+        );
+        const r1 = complexAdd(
+          complexMul(matrix[1][0], a0),
+          complexMul(matrix[1][1], a1),
+        );
+
+        this.real[index0] = r0.re;
+        this.imag[index0] = r0.im;
+        this.real[index1] = r1.re;
+        this.imag[index1] = r1.im;
+      }
+    }
+  }
+
+  private applyControlledNot(control: number, target: number): void {
+    if (!Number.isInteger(control) || !Number.isInteger(target)) {
+      throw new Error('Control and target must be integers');
+    }
+    if (control === target) {
+      throw new Error('Control and target qubits must differ for CNOT');
+    }
+
+    const controlMask = 1 << control;
+    const targetMask = 1 << target;
+
+    for (let index = 0; index < this.dimension; index += 1) {
+      if ((index & controlMask) !== 0) {
+        const flippedIndex = index ^ targetMask;
+        if (index < flippedIndex) {
+          const realTemp = this.real[index];
+          const imagTemp = this.imag[index];
+          this.real[index] = this.real[flippedIndex];
+          this.imag[index] = this.imag[flippedIndex];
+          this.real[flippedIndex] = realTemp;
+          this.imag[flippedIndex] = imagTemp;
+        }
+      }
+    }
+  }
+
+  private applyControlledZ(control: number, target: number): void {
+    if (!Number.isInteger(control) || !Number.isInteger(target)) {
+      throw new Error('Control and target must be integers');
+    }
+
+    const controlMask = 1 << control;
+    const targetMask = 1 << target;
+
+    for (let index = 0; index < this.dimension; index += 1) {
+      if ((index & controlMask) !== 0 && (index & targetMask) !== 0) {
+        this.real[index] = -this.real[index];
+        this.imag[index] = -this.imag[index];
+      }
+    }
+  }
+
+  private applySwap(qubitA: number, qubitB: number): void {
+    if (qubitA === qubitB) {
+      return;
+    }
+
+    const maskA = 1 << qubitA;
+    const maskB = 1 << qubitB;
+
+    for (let index = 0; index < this.dimension; index += 1) {
+      const hasA = (index & maskA) !== 0;
+      const hasB = (index & maskB) !== 0;
+      if (hasA !== hasB) {
+        const swapIndex = index ^ (maskA | maskB);
+        if (index < swapIndex) {
+          const realTemp = this.real[index];
+          const imagTemp = this.imag[index];
+          this.real[index] = this.real[swapIndex];
+          this.imag[index] = this.imag[swapIndex];
+          this.real[swapIndex] = realTemp;
+          this.imag[swapIndex] = imagTemp;
+        }
+      }
+    }
+  }
+}
+
+const getHadamardMatrix = (): Matrix2x2 => {
+  const factor = 1 / Math.sqrt(2);
+  return [
+    [createComplex(factor), createComplex(factor)],
+    [createComplex(factor), createComplex(-factor)],
+  ];
+};
+
+const getPauliXMatrix = (): Matrix2x2 => ([
+  [ZERO_COMPLEX, createComplex(1)],
+  [createComplex(1), ZERO_COMPLEX],
+]);
+
+const getPauliYMatrix = (): Matrix2x2 => ([
+  [ZERO_COMPLEX, createComplex(0, -1)],
+  [createComplex(0, 1), ZERO_COMPLEX],
+]);
+
+const getPauliZMatrix = (): Matrix2x2 => ([
+  [createComplex(1), ZERO_COMPLEX],
+  [ZERO_COMPLEX, createComplex(-1)],
+]);
+
+const getPhaseMatrix = (angle: number): Matrix2x2 => ([
+  [createComplex(1), ZERO_COMPLEX],
+  [ZERO_COMPLEX, createComplex(Math.cos(angle), Math.sin(angle))],
+]);
+
+const getRxMatrix = (angle: number): Matrix2x2 => {
+  const half = angle / 2;
+  const cos = Math.cos(half);
+  const sin = Math.sin(half);
+  return [
+    [createComplex(cos), createComplex(0, -sin)],
+    [createComplex(0, -sin), createComplex(cos)],
+  ];
+};
+
+const getRyMatrix = (angle: number): Matrix2x2 => {
+  const half = angle / 2;
+  const cos = Math.cos(half);
+  const sin = Math.sin(half);
+  return [
+    [createComplex(cos), createComplex(-sin)],
+    [createComplex(sin), createComplex(cos)],
+  ];
+};
+
+const getRzMatrix = (angle: number): Matrix2x2 => {
+  const half = angle / 2;
+  return [
+    [createComplex(Math.cos(half), -Math.sin(half)), ZERO_COMPLEX],
+    [ZERO_COMPLEX, createComplex(Math.cos(half), Math.sin(half))],
+  ];
+};
+
+export const saveCircuitToStorage = (
+  circuit: QuantumCircuit,
+  storageKey = DEFAULT_STORAGE_KEY,
+): void => {
+  const storageHost = ensureWindow();
+  if (!storageHost?.localStorage) {
+    return;
+  }
+
+  try {
+    const serialized = JSON.stringify(circuit);
+    storageHost.localStorage.setItem(storageKey, serialized);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to persist circuit', error);
+  }
+};
+
+export const loadCircuitFromStorage = (
+  storageKey = DEFAULT_STORAGE_KEY,
+): QuantumCircuit | null => {
+  const storageHost = ensureWindow();
+  if (!storageHost?.localStorage) {
+    return null;
+  }
+
+  try {
+    const serialized = storageHost.localStorage.getItem(storageKey);
+    if (!serialized) {
+      return null;
+    }
+    const parsed = JSON.parse(serialized) as QuantumCircuit;
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed.map((step) => ({
+      ...step,
+      operations: Array.isArray(step?.operations) ? step.operations.map((operation) => ({ ...operation })) : [],
+    }));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to read circuit from storage', error);
+    return null;
+  }
+};
+
+export const clearCircuitFromStorage = (storageKey = DEFAULT_STORAGE_KEY): void => {
+  const storageHost = ensureWindow();
+  if (!storageHost?.localStorage) {
+    return;
+  }
+  storageHost.localStorage.removeItem(storageKey);
+};
+
+export const attachSimulatorToRef = <T extends QuantumSimulator>(
+  ref: MutableRefObject<T | null>,
+  simulator: T,
+): void => {
+  // eslint-disable-next-line no-param-reassign
+  ref.current = simulator;
+};
+
+export const formatAngleLabel = (angle?: number): string => {
+  if (typeof angle !== 'number') {
+    return '';
+  }
+  if (Math.abs(angle - Math.PI) < 1e-6) {
+    return 'π';
+  }
+  if (Math.abs(angle - Math.PI / 2) < 1e-6) {
+    return 'π/2';
+  }
+  if (Math.abs(angle - Math.PI / 4) < 1e-6) {
+    return 'π/4';
+  }
+  return angle.toFixed(2);
+};

--- a/src/apps/quantum-playground/styles.css
+++ b/src/apps/quantum-playground/styles.css
@@ -1,0 +1,160 @@
+.quantum-playground {
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at top left, rgba(30, 41, 59, 0.8), #020617 60%);
+}
+
+.min-h-screen { min-height: 100vh; }
+
+.bg-slate-950 { background-color: #020617; }
+.bg-slate-900 { background-color: #0f172a; }
+.bg-slate-900\/60 { background-color: rgba(15, 23, 42, 0.6); }
+.bg-slate-800 { background-color: #1e293b; }
+.bg-slate-700 { background-color: #334155; }
+.bg-emerald-600 { background-color: #059669; }
+.bg-emerald-500\/10 { background-color: rgba(16, 185, 129, 0.1); }
+.bg-rose-500\/20 { background-color: rgba(244, 63, 94, 0.2); }
+.bg-rose-500\/30 { background-color: rgba(244, 63, 94, 0.3); }
+.bg-slate-900\/60 { background-color: rgba(15, 23, 42, 0.6); }
+.bg-slate-900\/60:hover { background-color: rgba(15, 23, 42, 0.7); }
+
+.text-white { color: #ffffff; }
+.text-slate-100 { color: #e2e8f0; }
+.text-slate-200 { color: #e2e8f0; }
+.text-slate-300 { color: #cbd5f5; }
+.text-slate-400 { color: #94a3b8; }
+.text-slate-500 { color: #64748b; }
+.text-emerald-300 { color: #6ee7b7; }
+.text-emerald-400 { color: #34d399; }
+.text-rose-200 { color: #fecdd3; }
+.text-rose-400 { color: #fb7185; }
+
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.p-6 { padding: 1.5rem; }
+.p-4 { padding: 1rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+
+.mt-2 { margin-top: 0.5rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+
+.space-y-6 > * + * { margin-top: 1.5rem; }
+.space-y-4 > * + * { margin-top: 1rem; }
+.space-y-3 > * + * { margin-top: 0.75rem; }
+.space-y-2 > * + * { margin-top: 0.5rem; }
+.space-y-1 > * + * { margin-top: 0.25rem; }
+
+.grid { display: grid; }
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-cols-3 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-cols-2 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md\:grid-cols-2 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+
+@media (min-width: 768px) {
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .md\:col-span-2 { grid-column: span 2 / span 2; }
+}
+
+@media (min-width: 1024px) {
+  .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .lg\:col-span-2 { grid-column: span 2 / span 2; }
+  .lg\:flex-row { flex-direction: row; }
+  .lg\:items-center { align-items: center; }
+  .lg\:justify-between { justify-content: space-between; }
+}
+
+.flex { display: flex; }
+.inline-flex { display: inline-flex; }
+.flex-col { flex-direction: column; }
+.flex-wrap { flex-wrap: wrap; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+
+.gap-6 { gap: 1.5rem; }
+.gap-4 { gap: 1rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-2 { gap: 0.5rem; }
+
+.rounded-xl { border-radius: 1rem; }
+.rounded-lg { border-radius: 0.75rem; }
+.rounded-md { border-radius: 0.5rem; }
+.rounded-full { border-radius: 9999px; }
+
+.border { border-width: 1px; border-style: solid; border-color: rgba(148, 163, 184, 0.2); }
+.border-slate-800 { border-color: #1e293b; }
+.border-slate-700 { border-color: #334155; }
+.border-dashed { border-style: dashed; }
+
+.shadow-lg { box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.45); }
+.shadow { box-shadow: 0 10px 30px -12px rgba(15, 23, 42, 0.35); }
+
+.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+.text-xs { font-size: 0.75rem; line-height: 1rem; }
+.text-base { font-size: 1rem; line-height: 1.5rem; }
+.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.text-2xl { font-size: 1.5rem; line-height: 2rem; }
+
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.font-mono { font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace; }
+
+.uppercase { text-transform: uppercase; }
+.tracking-wide { letter-spacing: 0.08em; }
+
+.text-right { text-align: right; }
+.text-left { text-align: left; }
+.text-center { text-align: center; }
+
+.transition { transition: all 0.2s ease-in-out; }
+.hover\:bg-emerald-500:hover { background-color: #10b981; }
+.hover\:bg-slate-700:hover { background-color: #334155; }
+.hover\:bg-slate-800:hover { background-color: #1f2937; }
+.hover\:bg-rose-500\/30:hover { background-color: rgba(244, 63, 94, 0.3); }
+
+.w-full { width: 100%; }
+.table-auto { table-layout: auto; }
+.border-collapse { border-collapse: collapse; }
+.overflow-x-auto { overflow-x: auto; }
+.h-64 { height: 16rem; }
+
+.font-semibold.text-slate-100 { color: #e2e8f0; }
+
+.inline-flex.items-center { align-items: center; }
+.flex.flex-wrap { display: flex; flex-wrap: wrap; }
+
+.odd\:bg-slate-900:nth-child(odd) { background-color: #0f172a; }
+.even\:bg-slate-900\/60:nth-child(even) { background-color: rgba(15, 23, 42, 0.6); }
+
+.accent-emerald-500 { accent-color: #10b981; }
+
+.text-emerald-300 { color: #6ee7b7; }
+
+input[type='number'] {
+  color: #e2e8f0;
+}
+
+input, select {
+  background-color: #0f172a;
+  border: 1px solid #1e293b;
+  color: #e2e8f0;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+ul { list-style: none; padding-left: 0; }
+
+.table-auto th, .table-auto td {
+  border: 1px solid #1e293b;
+}

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -223,6 +223,19 @@ export const APP_REGISTRY = {
     created: '2024-07-01',
     featured: true
   }),
+  'quantum-playground': withDefaults({
+    id: 'quantum-playground',
+    title: 'Quantum Playground',
+    description: 'Design circuits, run a 4-qubit simulator, and visualize state-vector measurements.',
+    icon: '🧬',
+    category: 'Education',
+    component: null,
+    loader: () => import('./quantum-playground'),
+    path: '/apps/quantum-playground',
+    tags: ['quantum', 'simulator', 'visualization', 'education'],
+    created: '2024-12-01',
+    featured: true,
+  }),
   'app-3': withDefaults({
     id: 'app-3',
     title: 'Coming Soon',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,12 +53,12 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(js|jsx|ts|tsx)$/,
         exclude: [/node_modules/, ...relocatedSubAppDirs],
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env', '@babel/preset-react']
+            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript']
           }
         }
       },
@@ -68,6 +68,9 @@ module.exports = {
         use: ['style-loader', 'css-loader'],
       },
     ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js', '.jsx', '.json'],
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
## Summary
- enable TypeScript builds and add Recharts support for data visualizations
- implement a reusable four-qubit state-vector simulator with gate execution, sampling, and storage helpers
- add the Quantum Playground app with circuit editing UI, controls, and probability/measurement visualizations

## Testing
- npm test -- --watch=false
- npx tsc --noEmit *(fails: cache-lab workspace lacks Playwright types and strict options)*

------
https://chatgpt.com/codex/tasks/task_e_68d18e952308832bbf6fe46a20330318