### PR TITLE
Fix Today removal order update

### DIFF
--- a/src/apps/ZenDoApp/views/TodayView.js
+++ b/src/apps/ZenDoApp/views/TodayView.js
@@ -39,7 +39,7 @@ const TodayView = ({
         evt.item.remove();
       },
       onRemove: (evt) => {
-        const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
+        const order = Array.from(evt.from.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
         onReorderBucket('today', order);
       },
     });


### PR DESCRIPTION
## Summary
- adjust the Today list drag removal handler to compute the remaining order from the source list so the persisted today schedule stays in sync

## Testing
- `npm test -- --watch=false` *(fails: missing @babel/preset-typescript dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19d241e64832b8fe90c7b2c92e614