### PR TITLE
Refine cat typing screen flow

### DIFF
--- a/src/apps/cat-typing-speed-test/index.html
+++ b/src/apps/cat-typing-speed-test/index.html
@@ -16,38 +16,40 @@
         </p>
       </header>
 
-      <section class="card login-card" id="login-panel">
-        <h2>Sign in with your alias</h2>
-        <p class="login-intro">
-          Enter an alias to track your scores. Provide the GitHub Gist ID and a Personal Access Token with the
-          <code>gist</code> scope so results can sync.
-        </p>
-        <form id="login-form" class="login-grid">
-          <label class="field" for="alias-input">
-            <span>Alias</span>
-            <input id="alias-input" type="text" placeholder="e.g. whisker-wizard" autocomplete="username" spellcheck="false" required />
-          </label>
-          <label class="field" for="gist-id-input">
-            <span>GitHub Gist ID</span>
-            <input id="gist-id-input" type="text" placeholder="Paste the gist ID" autocomplete="off" spellcheck="false" required />
-          </label>
-          <label class="field" for="token-input">
-            <span>GitHub Token</span>
-            <input id="token-input" type="password" placeholder="ghp_..." autocomplete="off" spellcheck="false" required />
-          </label>
-          <div class="login-actions">
-            <button type="submit" class="login-submit" id="login-button">Login</button>
-            <button type="button" class="login-logout" id="logout-button">Logout</button>
-          </div>
-        </form>
-        <p class="login-note">
-          Tokens are stored only for this browser tab using session storage. Create a public or secret gist that contains a
-          <code>cat-typing-speed-test.json</code> file with <code>{}</code> to get started.
-        </p>
-        <p class="status-message" id="login-status" aria-live="polite"></p>
+      <section id="login-screen" aria-hidden="false">
+        <div class="card login-card" id="login-panel">
+          <h2>Sign in with your alias</h2>
+          <p class="login-intro">
+            Enter an alias to track your scores. Provide the GitHub Gist ID and a Personal Access Token with the
+            <code>gist</code> scope so results can sync.
+          </p>
+          <form id="login-form" class="login-grid">
+            <label class="field" for="alias-input">
+              <span>Alias</span>
+              <input id="alias-input" type="text" placeholder="e.g. whisker-wizard" autocomplete="username" spellcheck="false" required />
+            </label>
+            <label class="field" for="gist-id-input">
+              <span>GitHub Gist ID</span>
+              <input id="gist-id-input" type="text" placeholder="Paste the gist ID" autocomplete="off" spellcheck="false" required />
+            </label>
+            <label class="field" for="token-input">
+              <span>GitHub Token</span>
+              <input id="token-input" type="password" placeholder="ghp_..." autocomplete="off" spellcheck="false" required />
+            </label>
+            <div class="login-actions">
+              <button type="submit" class="login-submit" id="login-button">Login</button>
+              <button type="button" class="login-logout" id="logout-button">Logout</button>
+            </div>
+          </form>
+          <p class="login-note">
+            Tokens are stored only for this browser tab using session storage. Create a public or secret gist that contains a
+            <code>cat-typing-speed-test.json</code> file with <code>{}</code> to get started.
+          </p>
+          <p class="status-message" id="login-status" aria-live="polite"></p>
+        </div>
       </section>
 
-      <section class="card" id="start-screen">
+      <section class="card hidden" id="start-screen" data-screen aria-hidden="true">
         <h2>Choose a test duration</h2>
         <div class="duration-options" role="group" aria-label="Test duration">
           <button type="button" class="duration-btn" data-duration="15">15 seconds</button>
@@ -56,7 +58,7 @@
         <p class="start-hint" id="start-hint">Each test pulls fresh sentences from the cat chronicles.</p>
       </section>
 
-      <section class="card hidden" id="test-screen" aria-hidden="true">
+      <section class="card hidden" id="test-screen" data-screen aria-hidden="true">
         <div class="test-meta">
           <div class="timer" id="timer" aria-live="assertive">00:15</div>
           <dl class="stat-line" aria-label="Live typing statistics">
@@ -88,7 +90,7 @@
         </div>
       </section>
 
-      <section class="card hidden" id="results-screen" aria-hidden="true">
+      <section class="card hidden" id="results-screen" data-screen aria-hidden="true">
         <h2>Your results</h2>
         <div class="results-grid" role="presentation">
           <div>


### PR DESCRIPTION
## Summary
- wrap the cat typing login form in its own screen section and mark the start/test/results panels for grouped toggling
- introduce a screen state helper that controls visibility, aria-hidden, and focus for the login, start, test, and results views
- send users to the start screen on successful login and back to the login screen when logging out or returning without an active alias

## Testing
- npm test *(fails: QuantumSimulator missing expected methods)*

------
https://chatgpt.com/codex/tasks/task_e_68d19fe2f82c832b8ab92abdf42a42be