### PR TITLE
Refine Cat Typing app to use global gist settings

### DIFF
--- a/src/apps/cat-typing-speed-test/index.html
+++ b/src/apps/cat-typing-speed-test/index.html
@@ -12,28 +12,20 @@
         <h1>Cat Typing Speed Test</h1>
         <p>Warm up your paws and measure typing speed with Kimchi, Rythm, and Siella.</p>
         <p class="alias-display" id="alias-display" hidden>
-          Signed in as <span id="current-alias"></span>
+          Alias ready: <span id="current-alias"></span>
         </p>
       </header>
 
       <section class="card login-card" id="login-panel">
         <h2>Sign in with your alias</h2>
         <p class="login-intro">
-          Enter an alias to track your scores. Provide the GitHub Gist ID and a Personal Access Token with the
-          <code>gist</code> scope so results can sync.
+          Enter an alias to track your scores. Manage the GitHub gist connection from the global settings to sync
+          results.
         </p>
-        <form id="login-form" class="login-grid">
+        <form id="login-form">
           <label class="field" for="alias-input">
             <span>Alias</span>
             <input id="alias-input" type="text" placeholder="e.g. whisker-wizard" autocomplete="username" spellcheck="false" required />
-          </label>
-          <label class="field" for="gist-id-input">
-            <span>GitHub Gist ID</span>
-            <input id="gist-id-input" type="text" placeholder="Paste the gist ID" autocomplete="off" spellcheck="false" required />
-          </label>
-          <label class="field" for="token-input">
-            <span>GitHub Token</span>
-            <input id="token-input" type="password" placeholder="ghp_..." autocomplete="off" spellcheck="false" required />
           </label>
           <div class="login-actions">
             <button type="submit" class="login-submit" id="login-button">Login</button>
@@ -41,7 +33,7 @@
           </div>
         </form>
         <p class="login-note">
-          Tokens are stored only for this browser tab using session storage. Create a public or secret gist that contains a
+          Open the global settings to provide a GitHub gist and token. Create a public or secret gist that contains a
           <code>cat-typing-speed-test.json</code> file with <code>{}</code> to get started.
         </p>
         <p class="status-message" id="login-status" aria-live="polite"></p>

--- a/src/apps/cat-typing-speed-test/styles.css
+++ b/src/apps/cat-typing-speed-test/styles.css
@@ -67,10 +67,9 @@ body {
   color: var(--muted);
 }
 
-.login-grid {
+#login-form {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .field {
@@ -82,7 +81,7 @@ body {
   font-weight: 600;
 }
 
-.login-grid input {
+#login-form input {
   border-radius: 0.85rem;
   border: 2px solid rgba(236, 72, 153, 0.18);
   background: rgba(255, 255, 255, 0.85);
@@ -91,7 +90,7 @@ body {
   transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.login-grid input:focus-visible {
+#login-form input:focus-visible {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.25);
   outline: none;
@@ -472,10 +471,6 @@ textarea:disabled {
 
   .actions button {
     flex: 1;
-  }
-
-  .login-grid {
-    grid-template-columns: 1fr;
   }
 
   .login-actions {


### PR DESCRIPTION
## Summary
- remove the gist ID/token fields from the Cat Typing login form and update the supporting copy and styles
- initialize and react to shared GitHub gist settings in the Cat Typing script instead of per-form inputs
- preserve shared credentials on logout and handle sync requests gracefully when gist access goes missing

## Testing
- npm test *(fails: quantum-playground simulator API changes, sudoku logic expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68d19fe4503c832baa5e187500e3a730