### PR TITLE
Switch CatPad icon to notepad

### DIFF
--- a/src/apps/__tests__/registry.test.js
+++ b/src/apps/__tests__/registry.test.js
@@ -9,7 +9,7 @@ describe('app registry', () => {
     expect(catpad).toBeTruthy();
     expect(catpad.title).toBe('CatPad');
     expect(catpad.category).toBe('Productivity');
-    expect(catpad.icon).toBe('😺');
+    expect(catpad.icon).toBe('🗒️');
     expect(catpad.path).toBe('/apps/catpad');
   });
 

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -43,7 +43,7 @@ export const APP_REGISTRY = {
     id: 'catpad',
     title: 'CatPad',
     description: 'Feline-themed notepad with cloud sync across every browser.',
-    icon: '😺',
+    icon: '🗒️',
     category: 'Productivity',
     component: null,
     loader: () => import('./CatPadApp'),


### PR DESCRIPTION
## Summary
- replace the CatPad launcher icon with a notepad emoji so it matches the app theme
- update the registry unit test to expect the new icon

## Testing
- npm test -- --runTestsByPath src/apps/__tests__/registry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1a62706d8832bbf5a6307a9b2117f