### PR TITLE
Add collapsible control for featured apps section

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -213,6 +213,41 @@
   font-size: 1.2rem;
 }
 
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.section-header .section-title {
+  margin-bottom: 0;
+}
+
+.section-toggle {
+  border: 2px solid #e1e5e9;
+  background: white;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #4a4a4a;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.section-toggle:hover,
+.section-toggle:focus {
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+  outline: none;
+}
+
+.section-toggle:active {
+  transform: translateY(1px);
+}
+
 .section-title {
   display: flex;
   align-items: center;
@@ -227,6 +262,16 @@
   margin-bottom: 40px;
   padding-bottom: 30px;
   border-bottom: 2px solid #f0f0f0;
+}
+
+.featured-section.collapsed {
+  padding-bottom: 0;
+  border-bottom: none;
+  margin-bottom: 24px;
+}
+
+.featured-section.collapsed .apps-container {
+  display: none;
 }
 
 .apps-container {

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -19,6 +19,7 @@ const AppLauncher = () => {
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState('grid'); // 'grid' or 'list'
+  const [isFeaturedCollapsed, setIsFeaturedCollapsed] = useState(false);
   const [torontoTime, setTorontoTime] = useState('--:--:--');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [gistSettingsForm, setGistSettingsForm] = useState({
@@ -202,6 +203,10 @@ const AppLauncher = () => {
     closeSettingsModal();
   };
 
+  const toggleFeaturedSection = useCallback(() => {
+    setIsFeaturedCollapsed((prev) => !prev);
+  }, []);
+
   const renderAppCard = (app) => {
     const favorited = isFavorited(app.id);
     return (
@@ -311,10 +316,22 @@ const AppLauncher = () => {
         </nav>
 
         {selectedCategory === 'All' && featuredApps.length > 0 && (
-          <section className="featured-section">
-            <h2 className="section-title">⭐ Featured Apps</h2>
+          <section
+            className={`featured-section${isFeaturedCollapsed ? ' collapsed' : ''}`}
+          >
+            <div className="section-header">
+              <h2 className="section-title">⭐ Featured Apps</h2>
+              <button
+                type="button"
+                className="section-toggle"
+                aria-expanded={!isFeaturedCollapsed}
+                onClick={toggleFeaturedSection}
+              >
+                {isFeaturedCollapsed ? 'Show' : 'Hide'}
+              </button>
+            </div>
             <div className={`apps-container ${viewMode}`}>
-              {featuredApps.map(renderAppCard)}
+              {!isFeaturedCollapsed && featuredApps.map(renderAppCard)}
             </div>
           </section>
         )}


### PR DESCRIPTION
## Summary
- add state and toggle handler to collapse the featured apps section
- wrap the featured section header with a flex container and toggle button driven by the collapse state
- style the new toggle control and collapsed section behavior in CSS so the grid hides cleanly

## Testing
- npm test -- --watchAll=false *(fails: existing QuantumSimulator and Sudoku tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a6f94a20832bbf7c5458d450e403