### PR TITLE
Add favorites section to app launcher

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -223,10 +223,26 @@
   color: #333;
 }
 
+.favorites-section {
+  margin-bottom: 40px;
+  padding-bottom: 30px;
+  border-bottom: 2px solid #f0f0f0;
+}
+
 .featured-section {
   margin-bottom: 40px;
   padding-bottom: 30px;
   border-bottom: 2px solid #f0f0f0;
+}
+
+.favorites-empty-message {
+  margin-bottom: 30px;
+  padding: 18px 24px;
+  border-radius: 12px;
+  border: 2px dashed rgba(102, 126, 234, 0.4);
+  background: rgba(102, 126, 234, 0.08);
+  color: #4a4a4a;
+  font-weight: 500;
 }
 
 .apps-container {


### PR DESCRIPTION
## Summary
- derive favorite apps from stored IDs so they honor the current filters and remain sorted
- surface a favorites section ahead of featured apps and show guidance when filters hide all favorites
- align launcher styles with a dedicated favorites section and helper message styling

## Testing
- npm test -- --runInBand *(fails: existing QuantumSimulator tests expect unimplemented gate helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a6fa4b2c832bb046e6ae32ed984f