### PR TITLE
Add gist connection verification feedback to AppLauncher

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -16,6 +16,39 @@
   backdrop-filter: blur(10px);
 }
 
+.gist-status-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: var(--spacing-medium);
+  padding: 14px 18px;
+  border-radius: 16px;
+  font-weight: 600;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  border: 1px solid transparent;
+}
+
+.gist-status-banner.success {
+  background: rgba(76, 175, 80, 0.15);
+  color: #1b5e20;
+  border-color: rgba(76, 175, 80, 0.35);
+}
+
+.gist-status-banner.error {
+  background: rgba(244, 67, 54, 0.15);
+  color: #b71c1c;
+  border-color: rgba(244, 67, 54, 0.35);
+}
+
+.gist-status-icon {
+  font-size: 1.3rem;
+}
+
+.gist-status-message {
+  flex: 1;
+  line-height: 1.4;
+}
+
 .launcher-header-top {
   display: flex;
   justify-content: space-between;

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -12,6 +12,7 @@ import {
   subscribeToGlobalGistSettings,
   writeGlobalGistSettings,
 } from '../state/globalGistSettings';
+import { verifyGistConnection } from '../global/verifyGistConnection';
 import './AppLauncher.css';
 
 const AppLauncher = () => {
@@ -24,6 +25,10 @@ const AppLauncher = () => {
   const [gistSettingsForm, setGistSettingsForm] = useState({
     gistId: '',
     gistToken: '',
+  });
+  const [gistSettingsStatus, setGistSettingsStatus] = useState({
+    type: null,
+    message: '',
   });
   const [favoriteIds, setFavoriteIds] = useState(() => {
     try {
@@ -39,6 +44,34 @@ const AppLauncher = () => {
   const gistTokenInputRef = useRef(null);
   const cancelButtonRef = useRef(null);
   const saveButtonRef = useRef(null);
+  const gistStatusTimerRef = useRef(null);
+
+  const clearGistStatus = useCallback(() => {
+    if (gistStatusTimerRef.current) {
+      clearTimeout(gistStatusTimerRef.current);
+      gistStatusTimerRef.current = null;
+    }
+    setGistSettingsStatus({ type: null, message: '' });
+  }, []);
+
+  const scheduleGistStatusDismissal = useCallback(() => {
+    if (gistStatusTimerRef.current) {
+      clearTimeout(gistStatusTimerRef.current);
+    }
+
+    gistStatusTimerRef.current = setTimeout(() => {
+      setGistSettingsStatus({ type: null, message: '' });
+      gistStatusTimerRef.current = null;
+    }, 6000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (gistStatusTimerRef.current) {
+        clearTimeout(gistStatusTimerRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const formatter = new Intl.DateTimeFormat('en-CA', {
@@ -70,6 +103,12 @@ const AppLauncher = () => {
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    if (isSettingsOpen) {
+      clearGistStatus();
+    }
+  }, [clearGistStatus, isSettingsOpen]);
 
   const closeSettingsModal = useCallback(() => {
     setIsSettingsOpen(false);
@@ -193,14 +232,45 @@ const AppLauncher = () => {
     }));
   };
 
-  const handleSaveSettings = (event) => {
+  const handleSaveSettings = useCallback(async (event) => {
     event.preventDefault();
-    writeGlobalGistSettings({
-      gistId: gistSettingsForm.gistId,
-      gistToken: gistSettingsForm.gistToken,
-    });
-    closeSettingsModal();
-  };
+    clearGistStatus();
+
+    try {
+      const savedSettings = writeGlobalGistSettings({
+        gistId: gistSettingsForm.gistId,
+        gistToken: gistSettingsForm.gistToken,
+      });
+
+      if (savedSettings.gistId) {
+        await verifyGistConnection({
+          gistId: savedSettings.gistId,
+          gistToken: savedSettings.gistToken,
+        });
+      }
+
+      setGistSettingsStatus({
+        type: 'success',
+        message: savedSettings.gistId
+          ? 'Gist connection verified successfully.'
+          : 'Gist settings saved.',
+      });
+      closeSettingsModal();
+      scheduleGistStatusDismissal();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      setGistSettingsStatus({
+        type: 'error',
+        message: `Failed to verify gist settings: ${errorMessage}`,
+      });
+      scheduleGistStatusDismissal();
+    }
+  }, [
+    clearGistStatus,
+    closeSettingsModal,
+    gistSettingsForm,
+    scheduleGistStatusDismissal,
+  ]);
 
   const renderAppCard = (app) => {
     const favorited = isFavorited(app.id);
@@ -291,6 +361,19 @@ const AppLauncher = () => {
           </div>
         </div>
       </header>
+
+      {gistSettingsStatus.type && (
+        <div
+          className={`gist-status-banner ${gistSettingsStatus.type}`}
+          aria-live="polite"
+          role="status"
+        >
+          <span className="gist-status-icon" aria-hidden="true">
+            {gistSettingsStatus.type === 'success' ? '✅' : '⚠️'}
+          </span>
+          <span className="gist-status-message">{gistSettingsStatus.message}</span>
+        </div>
+      )}
 
       <div className="launcher-content">
         <nav className="category-nav">

--- a/src/global/verifyGistConnection.js
+++ b/src/global/verifyGistConnection.js
@@ -1,0 +1,35 @@
+const buildHeaders = (token) => {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+export const verifyGistConnection = async ({ gistId, gistToken }) => {
+  if (!gistId) {
+    throw new Error('A gist ID is required to verify the connection.');
+  }
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available in this environment.');
+  }
+
+  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+    method: 'GET',
+    headers: buildHeaders(gistToken),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Unable to verify gist (${response.status}): ${errorText || 'Unknown error'}`);
+  }
+
+  return response.json();
+};
+
+export default verifyGistConnection;


### PR DESCRIPTION
## Summary
- add a status banner in the launcher to show gist connection feedback with auto-dismiss
- verify gist settings after saving using a shared helper that calls the GitHub Gist API
- create a reusable `verifyGistConnection` helper for gist connectivity checks

## Testing
- npm test -- --watchAll=false *(fails: existing QuantumSimulator tests expect helper methods that are not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a95c1398832ba8c0a73c628335c5