### PR TITLE
Prioritize favorites in app launcher

### DIFF
--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -152,15 +152,28 @@ const AppLauncher = () => {
 
   const allApps = useMemo(() => getAllApps(), []);
 
-  const filteredApps = useMemo(() => allApps
-    .filter((app) => {
-      const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
-      const matchesSearch = app.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         app.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         app.tags.some((tag) => tag.toLowerCase().includes(searchQuery.toLowerCase()));
-      return matchesCategory && matchesSearch && !app.disabled;
-    })
-    .sort((a, b) => a.title.localeCompare(b.title)), [allApps, selectedCategory, searchQuery]);
+  const filteredApps = useMemo(() => {
+    const favoriteSet = new Set(favoriteIds);
+    return allApps
+      .filter((app) => {
+        const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
+        const matchesSearch = app.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                           app.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                           app.tags.some((tag) => tag.toLowerCase().includes(searchQuery.toLowerCase()));
+        return matchesCategory && matchesSearch && !app.disabled;
+      })
+      .sort((a, b) => {
+        const aFavorited = favoriteSet.has(a.id);
+        const bFavorited = favoriteSet.has(b.id);
+        if (aFavorited && !bFavorited) {
+          return -1;
+        }
+        if (!aFavorited && bFavorited) {
+          return 1;
+        }
+        return a.title.localeCompare(b.title);
+      });
+  }, [allApps, favoriteIds, searchQuery, selectedCategory]);
 
   const featuredApps = useMemo(() => allApps
     .filter((app) => app.featured && !app.disabled)

--- a/src/components/__tests__/AppLauncher.test.js
+++ b/src/components/__tests__/AppLauncher.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import AppLauncher from '../AppLauncher';
+
+jest.mock('../../apps/registry', () => {
+  const mockApps = [
+    {
+      id: 'alpha-app',
+      title: 'Alpha App',
+      description: 'Alpha description',
+      icon: '🅰️',
+      category: 'Productivity',
+      path: '/apps/alpha',
+      tags: ['alpha'],
+      version: '1.0.0',
+      featured: false,
+      disabled: false,
+    },
+    {
+      id: 'beta-app',
+      title: 'Beta App',
+      description: 'Beta description',
+      icon: '🅱️',
+      category: 'Productivity',
+      path: '/apps/beta',
+      tags: ['beta'],
+      version: '1.0.0',
+      featured: false,
+      disabled: false,
+    },
+    {
+      id: 'gamma-app',
+      title: 'Gamma App',
+      description: 'Gamma description',
+      icon: '🌀',
+      category: 'Productivity',
+      path: '/apps/gamma',
+      tags: ['gamma'],
+      version: '1.0.0',
+      featured: false,
+      disabled: false,
+    },
+  ];
+
+  return {
+    __esModule: true,
+    APP_CATEGORIES: {
+      Productivity: { icon: '💼' },
+    },
+    getAllApps: jest.fn(() => mockApps),
+  };
+});
+
+jest.mock('../../state/globalGistSettings', () => ({
+  __esModule: true,
+  readGlobalGistSettings: jest.fn(() => ({ gistId: '', gistToken: '' })),
+  subscribeToGlobalGistSettings: jest.fn(() => jest.fn()),
+  writeGlobalGistSettings: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+describe('AppLauncher', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('renders favorite apps before non-favorites', () => {
+    localStorage.setItem('favoriteAppIds', JSON.stringify(['beta-app']));
+
+    render(<AppLauncher />);
+
+    const appsSection = screen.getByText(/All Apps/).closest('section');
+    expect(appsSection).not.toBeNull();
+
+    const titles = within(appsSection).getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
+
+    expect(titles).toEqual(['Beta App', 'Alpha App', 'Gamma App']);
+  });
+});


### PR DESCRIPTION
## Summary
- prioritize favorited apps when sorting the launcher by extending the filteredApps memo
- account for favorite id changes in memo dependencies
- add a focused launcher test that verifies favorites render before other apps

## Testing
- npm test -- --runTestsByPath src/components/__tests__/AppLauncher.test.js
- npm test -- --watchAll=false *(fails: existing QuantumSimulator TypeScript tests expect methods like applyHadamard/applyRotation to be present on QuantumSimulator)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a98e3cb8832b96143c5593caa2ee