### PR TITLE
Refactor app launcher into modular components

### DIFF
--- a/src/components/LauncherHeader.js
+++ b/src/components/LauncherHeader.js
@@ -1,0 +1,69 @@
+import React from 'react';
+
+const LauncherHeader = ({
+  appCount,
+  torontoTime,
+  searchQuery,
+  onSearchChange,
+  viewMode,
+  onChangeViewMode,
+  onOpenSettings,
+  settingsButtonRef,
+}) => (
+  <header className="launcher-header">
+    <div className="launcher-header-top">
+      <h1 className="launcher-title">
+        <span className="title-icon">📱</span>
+        64 Apps
+        <span className="app-count">({appCount} apps)</span>
+      </h1>
+
+      <div className="toronto-clock" aria-label="Current time">
+        <span className="clock-time">{torontoTime}</span>
+      </div>
+    </div>
+
+    <div className="launcher-controls">
+      <div className="search-container">
+        <input
+          type="text"
+          placeholder="Search apps..."
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          className="search-input"
+        />
+        <span className="search-icon">🔍</span>
+      </div>
+
+      <div className="view-controls">
+        <div className="view-toggle-group">
+          <button
+            type="button"
+            className={`view-btn ${viewMode === 'grid' ? 'active' : ''}`}
+            onClick={() => onChangeViewMode('grid')}
+          >
+            ⊞
+          </button>
+          <button
+            type="button"
+            className={`view-btn ${viewMode === 'list' ? 'active' : ''}`}
+            onClick={() => onChangeViewMode('list')}
+          >
+            ☰
+          </button>
+        </div>
+        <button
+          type="button"
+          className="settings-btn"
+          onClick={onOpenSettings}
+          ref={settingsButtonRef}
+        >
+          <span aria-hidden="true">⚙️</span>
+          <span className="settings-btn-label">Settings</span>
+        </button>
+      </div>
+    </div>
+  </header>
+);
+
+export default LauncherHeader;

--- a/src/components/SettingsModal.js
+++ b/src/components/SettingsModal.js
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef } from 'react';
+
+const SettingsModal = ({
+  isOpen,
+  gistSettingsForm,
+  onFieldChange,
+  onCancel,
+  onSubmit,
+}) => {
+  const gistIdInputRef = useRef(null);
+  const gistTokenInputRef = useRef(null);
+  const cancelButtonRef = useRef(null);
+  const saveButtonRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const focusableElements = () => [
+      gistIdInputRef.current,
+      gistTokenInputRef.current,
+      cancelButtonRef.current,
+      saveButtonRef.current,
+    ].filter(Boolean);
+
+    const firstElement = focusableElements()[0];
+    if (firstElement) {
+      setTimeout(() => {
+        firstElement.focus();
+      }, 0);
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const elements = focusableElements();
+      if (elements.length === 0) {
+        return;
+      }
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !elements.includes(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last || !elements.includes(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="settings-modal-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        className="settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gist-settings-title"
+      >
+        <form onSubmit={onSubmit}>
+          <h2 id="gist-settings-title" className="settings-modal-title">
+            GitHub Gist Sync
+          </h2>
+
+          <div className="settings-field">
+            <label htmlFor="gist-id-input">Gist ID</label>
+            <input
+              id="gist-id-input"
+              ref={gistIdInputRef}
+              type="text"
+              value={gistSettingsForm.gistId}
+              onChange={onFieldChange('gistId')}
+              placeholder="e.g. a1b2c3d4e5"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-field">
+            <label htmlFor="gist-token-input">Personal Access Token</label>
+            <input
+              id="gist-token-input"
+              ref={gistTokenInputRef}
+              type="password"
+              value={gistSettingsForm.gistToken}
+              onChange={onFieldChange('gistToken')}
+              placeholder="ghp_..."
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-modal-actions">
+            <button
+              type="button"
+              className="settings-secondary-btn"
+              onClick={onCancel}
+              ref={cancelButtonRef}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="settings-primary-btn"
+              ref={saveButtonRef}
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/src/components/__tests__/AppLauncher.test.js
+++ b/src/components/__tests__/AppLauncher.test.js
@@ -1,0 +1,221 @@
+import React from 'react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import AppLauncher from '../AppLauncher';
+import {
+  readGlobalGistSettings,
+  subscribeToGlobalGistSettings,
+  writeGlobalGistSettings,
+} from '../../state/globalGistSettings';
+
+jest.mock('../../apps/registry', () => {
+  const mockApps = [
+    {
+      id: 'alpha-app',
+      title: 'Alpha App',
+      description: 'Plan alpha level productivity tasks',
+      icon: '🅰️',
+      category: 'Productivity',
+      tags: ['alpha', 'tasks'],
+      version: '1.0.0',
+      featured: true,
+      path: '/apps/alpha',
+    },
+    {
+      id: 'beta-game',
+      title: 'Beta Game',
+      description: 'Battle friends in a vibrant beta arena',
+      icon: '🅱️',
+      category: 'Games',
+      tags: ['beta', 'arcade'],
+      version: '1.0.0',
+      featured: false,
+      path: '/apps/beta',
+    },
+    {
+      id: 'gamma-utility',
+      title: 'Gamma Utility',
+      description: 'Tune gamma rays with ease',
+      icon: '🌀',
+      category: 'Utilities',
+      tags: ['gamma', 'tool'],
+      version: '1.0.0',
+      featured: false,
+      path: '/apps/gamma',
+    },
+  ];
+
+  const mockGetAllApps = jest.fn(() => mockApps);
+
+  return {
+    __esModule: true,
+    APP_CATEGORIES: {
+      Productivity: { icon: '⚡' },
+      Games: { icon: '🎮' },
+      Utilities: { icon: '🛠️' },
+    },
+    getAllApps: mockGetAllApps,
+  };
+});
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+jest.mock('../../state/globalGistSettings', () => {
+  const readMock = jest.fn();
+  const subscribeMock = jest.fn();
+  const writeMock = jest.fn();
+
+  return {
+    __esModule: true,
+    readGlobalGistSettings: readMock,
+    subscribeToGlobalGistSettings: subscribeMock,
+    writeGlobalGistSettings: writeMock,
+  };
+});
+
+const renderLauncher = () => {
+  return render(
+    <MemoryRouter>
+      <AppLauncher />
+    </MemoryRouter>
+  );
+};
+
+const getAppsContainerForHeading = (headingMatcher) => {
+  const heading = screen.getByRole('heading', { name: headingMatcher });
+  const section = heading.closest('section');
+
+  if (!section) {
+    throw new Error(`Section not found for heading: ${headingMatcher}`);
+  }
+
+  const container = section.querySelector('.apps-container');
+
+  if (!container) {
+    throw new Error(`Apps container not found for heading: ${headingMatcher}`);
+  }
+
+  return container;
+};
+
+describe('AppLauncher', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    window.localStorage.clear();
+    readGlobalGistSettings.mockImplementation(() => ({
+      gistId: 'initial-id',
+      gistToken: 'initial-token',
+    }));
+    subscribeToGlobalGistSettings.mockImplementation(() => jest.fn());
+    writeGlobalGistSettings.mockClear();
+  });
+
+  it('filters apps by search query', async () => {
+    renderLauncher();
+    const user = userEvent.setup();
+
+    const searchInput = screen.getByPlaceholderText('Search apps...');
+    await user.type(searchInput, 'gamma');
+
+    const allAppsContainer = getAppsContainerForHeading(/All Apps/);
+
+    expect(within(allAppsContainer).getByText('Gamma Utility')).toBeInTheDocument();
+    expect(within(allAppsContainer).queryByText('Alpha App')).not.toBeInTheDocument();
+    expect(within(allAppsContainer).queryByText('Beta Game')).not.toBeInTheDocument();
+  });
+
+  it('filters apps by category selection', async () => {
+    renderLauncher();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Games/i }));
+
+    const gamesContainer = getAppsContainerForHeading(/Games Apps/);
+
+    expect(within(gamesContainer).getByText('Beta Game')).toBeInTheDocument();
+    expect(within(gamesContainer).queryByText('Gamma Utility')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Games Apps \(1\)/ })).toBeInTheDocument();
+  });
+
+  it('toggles favourites and persists them', async () => {
+    renderLauncher();
+    const user = userEvent.setup();
+
+    const allAppsContainer = getAppsContainerForHeading(/All Apps/);
+    const alphaCard = within(allAppsContainer).getByText('Alpha App').closest('.app-card');
+
+    if (!alphaCard) {
+      throw new Error('Alpha App card not found in main list');
+    }
+
+    const favoriteButton = within(alphaCard).getByRole('button', { name: 'Favorite app' });
+    await user.click(favoriteButton);
+
+    expect(favoriteButton).toHaveTextContent('★');
+    expect(within(alphaCard).getByText('★ Favorited')).toBeInTheDocument();
+    expect(window.localStorage.getItem('favoriteAppIds')).toBe(JSON.stringify(['alpha-app']));
+  });
+
+  it('handles settings updates and closing actions', async () => {
+    subscribeToGlobalGistSettings.mockClear();
+    const unsubscribeMock = jest.fn();
+    subscribeToGlobalGistSettings.mockImplementation((callback) => {
+      callback({ gistId: 'subscribed-id', gistToken: 'subscribed-token' });
+      return unsubscribeMock;
+    });
+
+    renderLauncher();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /Settings/i }));
+
+    const gistIdInput = await screen.findByLabelText('Gist ID');
+    expect(gistIdInput).toHaveValue('subscribed-id');
+
+    const gistTokenInput = screen.getByLabelText('Personal Access Token');
+    await user.clear(gistIdInput);
+    await user.type(gistIdInput, 'new-gist');
+    await user.clear(gistTokenInput);
+    await user.type(gistTokenInput, 'new-token');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(writeGlobalGistSettings).toHaveBeenCalledWith({
+      gistId: 'new-gist',
+      gistToken: 'new-token',
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /Settings/i }));
+
+    const gistIdInputAfterReopen = await screen.findByLabelText('Gist ID');
+    await user.clear(gistIdInputAfterReopen);
+    await user.type(gistIdInputAfterReopen, 'temp-id');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(writeGlobalGistSettings).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: /Settings/i }));
+
+    const gistIdAfterCancel = await screen.findByLabelText('Gist ID');
+    expect(gistIdAfterCancel).toHaveValue('initial-id');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+  });
+});

--- a/src/components/useFavoriteApps.js
+++ b/src/components/useFavoriteApps.js
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+
+const FAVORITES_STORAGE_KEY = 'favoriteAppIds';
+
+const canUseStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+const readStoredFavorites = () => {
+  if (!canUseStorage()) {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const useFavoriteApps = () => {
+  const [favoriteIds, setFavoriteIds] = useState(() => readStoredFavorites());
+
+  const persistFavorites = useCallback((nextFavorites) => {
+    if (!canUseStorage()) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(nextFavorites));
+    } catch (error) {
+      // ignore storage write failures
+    }
+  }, []);
+
+  const toggleFavorite = useCallback((appId) => {
+    setFavoriteIds((prev) => {
+      const next = prev.includes(appId)
+        ? prev.filter((id) => id !== appId)
+        : [...prev, appId];
+
+      persistFavorites(next);
+      return next;
+    });
+  }, [persistFavorites]);
+
+  const isFavorited = useCallback((appId) => favoriteIds.includes(appId), [favoriteIds]);
+
+  return {
+    favoriteIds,
+    isFavorited,
+    toggleFavorite,
+  };
+};
+
+export default useFavoriteApps;


### PR DESCRIPTION
## Summary
- extract a dedicated `useFavoriteApps` hook plus `LauncherHeader` and `SettingsModal` components for the app launcher
- refactor `AppLauncher` to use the new building blocks while preserving behaviour and styling
- add a focused Jest suite that exercises launcher search, filtering, favourites, and settings flows

## Testing
- npm test *(fails: existing `src/apps/quantum-playground/simulator.test.ts` expects helper methods that the simulator implementation does not expose)*
- npm test -- AppLauncher.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1a9b25594832b90f2046b690bca53