### PR TITLE
Move CatNap HUD into canvas overlay

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -9,15 +9,34 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+.catnap-hud-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  padding: 1.25rem;
+  pointer-events: none;
+  z-index: 2;
+}
+
 .catnap-hud {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: space-between;
   align-items: stretch;
+  width: 100%;
+}
+
+.catnap-hud .scoreboard,
+.catnap-hud .start-boost-banner,
+.catnap-hud .drowsiness-meter {
+  pointer-events: auto;
 }
 
 .scoreboard {
+  flex: 1 1 320px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   background: rgba(255, 255, 255, 0.85);
@@ -191,6 +210,7 @@
   padding: 1.5rem;
   background: rgba(24, 20, 38, 0.35);
   backdrop-filter: blur(6px);
+  z-index: 3;
 }
 
 .overlay-card {

--- a/src/apps/CatNapLeapApp/CatNapLeapApp.js
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.js
@@ -1249,60 +1249,67 @@ const CatNapLeapApp = () => {
 
   return (
     <div className="catnap-app" ref={containerRef}>
-      <div className="catnap-hud">
-        <div className="scoreboard" aria-live="polite">
-          <div className="score-item">
-            <span className="label">Score</span>
-            <span className="value">{stats.score}</span>
-          </div>
-          <div className="score-item">
-            <span className="label">Best</span>
-            <span className="value">{stats.best}</span>
-          </div>
-          <div className="score-item treats">
-            <span className="label">Treats</span>
-            <span className="value">{treats}</span>
-          </div>
-          <div className="score-item">
-            <span className="label">Perfect Leaps</span>
-            <span className="value">{stats.perfects}</span>
-          </div>
-        </div>
-
-        {startBoostIndicators.length > 0 && (
-          <div className="start-boost-banner" aria-live="polite">
-            <span className="boost-label">Shop Boosts Active</span>
-            <ul>
-              {startBoostIndicators.map((boost) => (
-                <li key={boost}>{boost}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        <div className="drowsiness-meter" aria-label="Drowsiness meter">
-          <div className="meter-header">
-            <span>Drowsiness</span>
-            <span>{Math.round(drowsiness)}%</span>
-          </div>
-          <div className={`mode-indicator ${kittenMode ? 'active' : ''}`} aria-live="polite">
-            {kittenMode ? 'Kitten Mode · Cozy pacing' : 'Cat Mode · Classic challenge'}
-          </div>
-          <div className="meter-track" role="progressbar" aria-valuenow={Math.round(drowsiness)} aria-valuemin="0" aria-valuemax="100">
-            <div className="meter-fill" style={{ width: `${clamp(drowsiness, 0, 100)}%` }} />
-          </div>
-          {effects.length > 0 && (
-            <ul className="active-effects">
-              {effects.map((effect) => (
-                <li key={effect}>{effect}</li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-
       <div className="catnap-canvas-wrapper">
         <canvas ref={canvasRef} className="catnap-canvas" />
+        <div className="catnap-hud-overlay">
+          <div className="catnap-hud">
+            <div className="scoreboard" aria-live="polite">
+              <div className="score-item">
+                <span className="label">Score</span>
+                <span className="value">{stats.score}</span>
+              </div>
+              <div className="score-item">
+                <span className="label">Best</span>
+                <span className="value">{stats.best}</span>
+              </div>
+              <div className="score-item treats">
+                <span className="label">Treats</span>
+                <span className="value">{treats}</span>
+              </div>
+              <div className="score-item">
+                <span className="label">Perfect Leaps</span>
+                <span className="value">{stats.perfects}</span>
+              </div>
+            </div>
+
+            {startBoostIndicators.length > 0 && (
+              <div className="start-boost-banner" aria-live="polite">
+                <span className="boost-label">Shop Boosts Active</span>
+                <ul>
+                  {startBoostIndicators.map((boost) => (
+                    <li key={boost}>{boost}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className="drowsiness-meter" aria-label="Drowsiness meter">
+              <div className="meter-header">
+                <span>Drowsiness</span>
+                <span>{Math.round(drowsiness)}%</span>
+              </div>
+              <div className={`mode-indicator ${kittenMode ? 'active' : ''}`} aria-live="polite">
+                {kittenMode ? 'Kitten Mode · Cozy pacing' : 'Cat Mode · Classic challenge'}
+              </div>
+              <div
+                className="meter-track"
+                role="progressbar"
+                aria-valuenow={Math.round(drowsiness)}
+                aria-valuemin="0"
+                aria-valuemax="100"
+              >
+                <div className="meter-fill" style={{ width: `${clamp(drowsiness, 0, 100)}%` }} />
+              </div>
+              {effects.length > 0 && (
+                <ul className="active-effects">
+                  {effects.map((effect) => (
+                    <li key={effect}>{effect}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
         {phase !== 'playing' && (
           <div className={`catnap-overlay ${phase}`}>
             <div


### PR DESCRIPTION
## Summary
- embed the CatNap HUD inside the canvas wrapper so metrics render above the playfield
- add overlay styling, pointer-event handling, and z-index tweaks to coexist with modal overlays

## Testing
- npm test -- --watchAll=false *(fails: QuantumSimulator tests expect methods that are not implemented in the current simulator implementation)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f7ec578832b9c4e57225c793b88