### PR TITLE
Add concurrent Cache Lab dev workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,10 +78,12 @@ Gif coming soon
 git clone https://github.com/Hardik-S/g1.git
 cd g1
 npm install
-npm start
+npm run dev
 ```
 
-Then open [http://localhost:3000](http://localhost:3000).
+This launches the webpack dev server at [http://localhost:3000](http://localhost:3000) for the launcher and the Cache Lab Vite
+instance at [http://localhost:4173](http://localhost:4173). Use `CACHE_LAB_DEV_URL` to point the iframe to a different Cache Lab
+origin when necessary (e.g. a remote tunnel or alternate port).
 
 ### Build
 
@@ -109,7 +111,8 @@ Your site will be available at the `homepage` URL.
 
 ### Launcher
 
-* `npm start`: Start webpack dev server at `http://localhost:3000`.
+* `npm run dev`: Run the launcher webpack dev server alongside the Cache Lab Vite dev server (defaults to ports 3000 and 4173).
+* `npm start`: Start only the launcher webpack dev server at `http://localhost:3000`.
 * `npm run build`: Build Cache Lab and the launcher production bundle into `dist/`.
 * `npm run deploy`: Publish `dist/` to `gh-pages`.
 * `npm test`: Run Jest suite for launcher React apps.
@@ -119,6 +122,7 @@ Your site will be available at the `homepage` URL.
 * `npm run build:cache-lab`: Build Cache Lab assets within `src/apps/cache-lab`.
 * `npm run test:cache-lab`: Run Cache Lab unit tests via pnpm.
 * `npm run e2e:cache-lab`: Run Playwright E2E tests for Cache Lab via pnpm.
+* `CACHE_LAB_DEV_URL`: Optional env var to override the Cache Lab dev iframe URL when running `npm run dev`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^18.2.25",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.0",
+        "concurrently": "^9.1.2",
         "copy-webpack-plugin": "^13.0.1",
         "css-loader": "^6.8.0",
         "gh-pages": "^6.0.0",
@@ -6442,6 +6443,31 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -12959,6 +12985,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -14031,6 +14067,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trim-repeated": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "start": "webpack serve --mode development",
+    "dev": "concurrently \"pnpm --filter cache-lab dev\" \"webpack serve --mode development\"",
     "build:cache-lab": "npm --prefix src/apps/cache-lab run build",
     "build": "npm run build:cache-lab && webpack --mode production",
     "test": "jest",
@@ -36,6 +37,7 @@
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.0",
     "copy-webpack-plugin": "^13.0.1",
+    "concurrently": "^9.1.2",
     "css-loader": "^6.8.0",
     "gh-pages": "^6.0.0",
     "html-webpack-plugin": "^5.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-router-dom:
         specifier: ^6.30.1
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.12.7
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sortablejs:
         specifier: ^1.15.6
         version: 1.15.6
@@ -30,6 +33,9 @@ importers:
       '@babel/preset-react':
         specifier: ^7.22.0
         version: 7.27.1(@babel/core@7.28.4)
+      '@babel/preset-typescript':
+        specifier: ^7.24.7
+        version: 7.27.1(@babel/core@7.28.4)
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -39,6 +45,12 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@9.3.4)
+      '@types/react':
+        specifier: ^18.2.78
+        version: 18.3.24
+      '@types/react-dom':
+        specifier: ^18.2.25
+        version: 18.3.7(@types/react@18.3.24)
       babel-jest:
         specifier: ^29.7.0
         version: 29.7.0(@babel/core@7.28.4)
@@ -72,6 +84,9 @@ importers:
       style-loader:
         specifier: ^3.3.0
         version: 3.3.4(webpack@5.101.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.2
       webpack:
         specifier: ^5.88.0
         version: 5.101.3(webpack-cli@5.1.4)
@@ -732,6 +747,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-typescript@7.28.0':
+    resolution: {integrity: sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-unicode-escapes@7.27.1':
     resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
     engines: {node: '>=6.9.0'}
@@ -769,6 +790,12 @@ packages:
 
   '@babel/preset-react@7.27.1':
     resolution: {integrity: sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.27.1':
+    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5351,6 +5378,17 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.4)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.4)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
@@ -5466,6 +5504,17 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.4)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.4)
       '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.28.4)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
 

--- a/src/apps/CacheLabApp/index.js
+++ b/src/apps/CacheLabApp/index.js
@@ -1,9 +1,18 @@
 import React from 'react';
 import './styles.css';
 
-const CacheLabApp = ({ onBack }) => {
+const resolveCacheLabUrl = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return process.env.CACHE_LAB_DEV_URL || 'http://localhost:4173/';
+  }
+
   const base = process.env.PUBLIC_URL || '';
-  const embeddedUrl = `${base}/cache-lab/`;
+  const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${normalizedBase}/cache-lab/`;
+};
+
+const CacheLabApp = ({ onBack }) => {
+  const embeddedUrl = resolveCacheLabUrl();
 
   return (
     <div className="cache-lab-embed">


### PR DESCRIPTION
## Summary
- resolve the Cache Lab iframe URL with a helper that switches between the Vite dev server and the built bundle
- add a combined `npm run dev` script powered by `concurrently` and document the new workflow and `CACHE_LAB_DEV_URL` override

## Testing
- npm test
- npm run build
- npm run dev (terminated manually)


------
https://chatgpt.com/codex/tasks/task_e_68d1b3d5e720832bb4484f7d4e524d9d