### PR TITLE
Refactor Zen Go app with KataGo board engine

### DIFF
--- a/src/apps/ZenGoApp/ZenGoApp.js
+++ b/src/apps/ZenGoApp/ZenGoApp.js
@@ -11,15 +11,15 @@ const ZenGoApp = ({ onBack }) => {
         <div>
           <h1>Zen Go</h1>
           <p>
-            Sharpen your corner instincts on a focused 9×9 board. Pick a rank,
-            add handicap stones, and duel a GNU Go engine compiled to
-            WebAssembly.
+            Take on a KataGo-trained sparring partner across a full 19×19
+            goban. Sample different policy heads, trace score swings, and follow
+            a running move log without leaving the browser.
           </p>
         </div>
         <ul className="zen-go-highlights">
-          <li>WGo.js renders captures, ko, and coordinates crisply.</li>
-          <li>Difficulty maps to Go ranks with an approximate ELO readout.</li>
-          <li>Handicap presets (2–9 stones) follow standard star-point layouts.</li>
+          <li>Canvas renderer highlights star points, captures, and last-move halos.</li>
+          <li>KataGo policy sampling picks among the top three moves for human-like flow.</li>
+          <li>Model selector swaps between swift, balanced, and deep KataGo nets.</li>
         </ul>
       </section>
 

--- a/src/apps/zen-go/index.html
+++ b/src/apps/zen-go/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Zen Go — 9×9 Web Go sparring</title>
+    <title>Zen Go — 19×19 KataGo sparring</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -19,15 +19,44 @@
           <header class="zen-go-header">
             <h1>Zen Go</h1>
             <p>
-              Practice 9×9 fuseki against a prototype opponent that plays random
-              legal moves. Adjust strength labels, set handicap stones, and enjoy
-              a calm board-side flow while we build a stronger sparring partner.
+              Challenge a KataGo-inspired sparring partner on a full 19×19 board.
+              Play as Black, watch the engine sample from its top-three policy
+              moves, and follow the estimated score as the fight evolves.
             </p>
           </header>
+
           <div class="board-wrapper">
-            <div id="board" class="board-canvas" aria-label="Go board"></div>
+            <canvas
+              id="boardCanvas"
+              class="board-canvas"
+              role="img"
+              aria-label="19 by 19 Go board"
+            ></canvas>
           </div>
-          <div class="zen-go-status" id="statusText">Ready when you are.</div>
+
+          <div class="zen-go-status zen-go-status--info" id="statusText">
+            Tap a point to begin as Black.
+          </div>
+
+          <div class="zen-go-hud">
+            <div class="hud-item">
+              <span class="hud-label">Turn</span>
+              <span class="hud-value" id="turnLabel">Black to move</span>
+            </div>
+            <div class="hud-item">
+              <span class="hud-label">Move</span>
+              <span class="hud-value" id="moveNumber">0</span>
+            </div>
+            <div class="hud-item">
+              <span class="hud-label">Score lead</span>
+              <span class="hud-value" id="scoreLead">Tied</span>
+            </div>
+            <div class="hud-item hud-span">
+              <span class="hud-label">Last move</span>
+              <span class="hud-value" id="lastMove">None</span>
+            </div>
+          </div>
+
           <div class="zen-go-captures">
             <div class="capture-card capture-black">
               <span class="capture-label">Black captures</span>
@@ -39,69 +68,39 @@
             </div>
           </div>
         </div>
+
         <aside class="zen-go-side-panel">
           <section class="control-group">
-            <h2>Match setup</h2>
-            <label class="control-field" for="difficultySelect">
-              <span class="control-label">AI difficulty</span>
-              <select id="difficultySelect" class="control-select"></select>
+            <h2>Engine model</h2>
+            <label class="control-field" for="modelSelect">
+              <span class="control-label">KataGo policy</span>
+              <select id="modelSelect" class="control-select"></select>
             </label>
-            <div class="difficulty-meta">
-              <span id="rankLabel" class="difficulty-rank"></span>
-              <span id="eloLabel" class="difficulty-elo"></span>
-            </div>
-            <p class="difficulty-note" id="difficultyNote"></p>
+            <p class="control-help" id="modelNote"></p>
           </section>
-          <section class="control-group">
-            <h2>Handicap</h2>
-            <label class="control-field" for="handicapSelect">
-              <span class="control-label">Stones for Black</span>
-              <select id="handicapSelect" class="control-select">
-                <option value="0">None</option>
-                <option value="2">2 stones</option>
-                <option value="3">3 stones</option>
-                <option value="4">4 stones</option>
-                <option value="5">5 stones</option>
-                <option value="6">6 stones</option>
-                <option value="7">7 stones</option>
-                <option value="8">8 stones</option>
-                <option value="9">9 stones</option>
-              </select>
-            </label>
-            <p class="control-help">
-              Handicap stones follow standard 9×9 star points. White plays first
-              whenever handicap ≥ 2.
-            </p>
-          </section>
+
           <section class="control-group">
             <h2>Actions</h2>
-            <div class="button-row">
+            <div class="button-column">
               <button id="newGameButton" class="primary-button">New game</button>
-              <button id="undoButton" class="ghost-button">Undo</button>
+              <button id="passButton" class="ghost-button">Pass</button>
               <button id="resignButton" class="ghost-button danger">Resign</button>
             </div>
-          </section>
-          <section class="control-group">
-            <h2>Engine status</h2>
-            <div id="engineStatus" class="engine-status">Random opponent ready.</div>
             <p class="control-help">
-              This prototype uses a simple random move generator for all
-              difficulties. A proper AI sparring partner will return in a future
-              update.
+              You play Black. After each move the engine selects from its
+              highest-value KataGo policy suggestions.
             </p>
           </section>
-          <section class="control-group future-note">
-            <h2>Coming next</h2>
-            <ul>
-              <li>13×13 and 19×19 boards</li>
-              <li>Game review with SGF export</li>
-              <li>Win-rate graphs and deeper analysis</li>
+
+          <section class="control-group">
+            <h2>Move log</h2>
+            <ul class="insight-list" id="historyList">
+              <li class="insight-empty">No moves yet.</li>
             </ul>
           </section>
         </aside>
       </section>
     </main>
-    <script src="vendor/wgo.min.js"></script>
-    <script src="main.js"></script>
+    <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/src/apps/zen-go/js/goban.js
+++ b/src/apps/zen-go/js/goban.js
@@ -1,0 +1,465 @@
+const BOARD_SIZE = 19;
+const EMPTY = 0;
+const BLACK = 1;
+const WHITE = 2;
+const BORDER = 3;
+
+export const COLORS = Object.freeze({
+  BLACK,
+  WHITE
+});
+
+export const PASS_MOVE = 'pass';
+
+const LETTERS = 'ABCDEFGHJKLMNOPQRST';
+
+function clampTemperature(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 1;
+  }
+  return value;
+}
+
+export default class Goban {
+  constructor(size = BOARD_SIZE) {
+    this.size = size;
+    this.gridSize = size + 2; // build a 21×21 board with a sentinel border
+    this.board = new Uint8Array(this.gridSize * this.gridSize);
+    this.captures = {
+      [BLACK]: 0,
+      [WHITE]: 0
+    };
+    this.moveHistory = [];
+    this.snapshots = [];
+    this.lastMove = null;
+    this.consecutivePasses = 0;
+    this.reset();
+  }
+
+  reset() {
+    const total = this.gridSize * this.gridSize;
+    for (let i = 0; i < total; i += 1) {
+      this.board[i] = BORDER;
+    }
+    for (let y = 0; y < this.size; y += 1) {
+      for (let x = 0; x < this.size; x += 1) {
+        this.board[this.toIndex(x, y)] = EMPTY;
+      }
+    }
+    this.captures[BLACK] = 0;
+    this.captures[WHITE] = 0;
+    this.moveHistory = [];
+    this.snapshots = [];
+    this.lastMove = null;
+    this.consecutivePasses = 0;
+  }
+
+  createSnapshot() {
+    return {
+      board: Uint8Array.from(this.board),
+      captures: {
+        [BLACK]: this.captures[BLACK],
+        [WHITE]: this.captures[WHITE]
+      },
+      lastMove: this.lastMove ? { ...this.lastMove } : null,
+      consecutivePasses: this.consecutivePasses
+    };
+  }
+
+  restoreBoard(snapshot) {
+    if (!snapshot) {
+      return;
+    }
+    this.board.set(snapshot.board);
+    this.captures[BLACK] = snapshot.captures[BLACK];
+    this.captures[WHITE] = snapshot.captures[WHITE];
+    this.lastMove = snapshot.lastMove ? { ...snapshot.lastMove } : null;
+    this.consecutivePasses = snapshot.consecutivePasses ?? 0;
+  }
+
+  toIndex(x, y) {
+    return (y + 1) * this.gridSize + (x + 1);
+  }
+
+  indexToPoint(index) {
+    const row = Math.floor(index / this.gridSize) - 1;
+    const col = index % this.gridSize - 1;
+    return { x: col, y: row };
+  }
+
+  isOnBoard(x, y) {
+    return x >= 0 && x < this.size && y >= 0 && y < this.size;
+  }
+
+  getStone(x, y) {
+    if (!this.isOnBoard(x, y)) {
+      return BORDER;
+    }
+    return this.board[this.toIndex(x, y)];
+  }
+
+  getCaptures() {
+    return {
+      black: this.captures[BLACK],
+      white: this.captures[WHITE]
+    };
+  }
+
+  getMoveHistory() {
+    return this.moveHistory.slice();
+  }
+
+  getLastMove() {
+    return this.lastMove ? { ...this.lastMove } : null;
+  }
+
+  opponent(color) {
+    return color === BLACK ? WHITE : BLACK;
+  }
+
+  setStone(x, y, color) {
+    if (!this.isOnBoard(x, y)) {
+      return { ok: false, reason: 'off_board' };
+    }
+    const index = this.toIndex(x, y);
+    if (this.board[index] !== EMPTY) {
+      return { ok: false, reason: 'occupied' };
+    }
+
+    this.board[index] = color;
+
+    const opponent = this.opponent(color);
+    const captured = [];
+
+    for (const neighbor of this.getNeighborIndexes(index)) {
+      if (this.board[neighbor] === opponent) {
+        const info = this.countLiberties(neighbor, opponent);
+        if (info.libertyCount === 0) {
+          const removed = this.clearBlock(info.stones);
+          if (removed.length) {
+            captured.push(...removed);
+          }
+        }
+      }
+    }
+
+    const ownInfo = this.countLiberties(index, color);
+    if (ownInfo.libertyCount === 0 && captured.length === 0) {
+      this.board[index] = EMPTY;
+      return { ok: false, reason: 'suicide' };
+    }
+
+    if (captured.length) {
+      this.captures[color] += captured.length;
+    }
+
+    return {
+      ok: true,
+      captured,
+      liberties: ownInfo.libertyCount
+    };
+  }
+
+  playMove(x, y, color, meta = {}) {
+    const snapshot = this.createSnapshot();
+    const result = this.setStone(x, y, color);
+    if (!result.ok) {
+      this.restoreBoard(snapshot);
+      return result;
+    }
+
+    this.snapshots.push(snapshot);
+    const moveRecord = {
+      type: 'play',
+      moveNumber: this.moveHistory.length + 1,
+      color,
+      x,
+      y,
+      captured: result.captured,
+      liberties: result.liberties,
+      ...meta
+    };
+    this.moveHistory.push(moveRecord);
+    this.lastMove = {
+      color,
+      x,
+      y,
+      captured: result.captured,
+      liberties: result.liberties
+    };
+    this.consecutivePasses = 0;
+    return { ...result, move: moveRecord };
+  }
+
+  passMove(color, meta = {}) {
+    const snapshot = this.createSnapshot();
+    this.snapshots.push(snapshot);
+    const moveRecord = {
+      type: PASS_MOVE,
+      moveNumber: this.moveHistory.length + 1,
+      color,
+      pass: true,
+      ...meta
+    };
+    this.moveHistory.push(moveRecord);
+    this.lastMove = {
+      color,
+      pass: true
+    };
+    this.consecutivePasses += 1;
+    return { ok: true, move: moveRecord };
+  }
+
+  undo() {
+    if (!this.moveHistory.length) {
+      return false;
+    }
+    const snapshot = this.snapshots.pop();
+    if (!snapshot) {
+      return false;
+    }
+    this.restoreBoard(snapshot);
+    this.moveHistory.pop();
+    this.lastMove = this.moveHistory.length
+      ? { ...this.moveHistory[this.moveHistory.length - 1] }
+      : null;
+    return true;
+  }
+
+  getNeighborIndexes(index) {
+    return [
+      index - 1,
+      index + 1,
+      index - this.gridSize,
+      index + this.gridSize
+    ];
+  }
+
+  getNeighborCoords(x, y) {
+    return [
+      { x: x - 1, y },
+      { x: x + 1, y },
+      { x, y: y - 1 },
+      { x, y: y + 1 }
+    ].filter((point) => this.isOnBoard(point.x, point.y));
+  }
+
+  countLiberties(startIndex, color) {
+    const stack = [startIndex];
+    const visited = new Set();
+    const liberties = new Set();
+
+    while (stack.length) {
+      const index = stack.pop();
+      if (visited.has(index)) {
+        continue;
+      }
+      visited.add(index);
+      for (const neighbor of this.getNeighborIndexes(index)) {
+        const stone = this.board[neighbor];
+        if (stone === color) {
+          stack.push(neighbor);
+        } else if (stone === EMPTY) {
+          liberties.add(neighbor);
+        }
+      }
+    }
+
+    return {
+      libertyCount: liberties.size,
+      liberties: Array.from(liberties),
+      stones: Array.from(visited)
+    };
+  }
+
+  countLibertiesAt(x, y, color = this.getStone(x, y)) {
+    if (!this.isOnBoard(x, y) || (color !== BLACK && color !== WHITE)) {
+      return { libertyCount: 0, liberties: [], stones: [] };
+    }
+    return this.countLiberties(this.toIndex(x, y), color);
+  }
+
+  clearBlock(stones) {
+    const removed = [];
+    for (const index of stones) {
+      const stoneColor = this.board[index];
+      if (stoneColor === BLACK || stoneColor === WHITE) {
+        const point = this.indexToPoint(index);
+        removed.push({
+          x: point.x,
+          y: point.y,
+          color: stoneColor
+        });
+        this.board[index] = EMPTY;
+      }
+    }
+    return removed;
+  }
+
+  listLegalMoves(color) {
+    const moves = [];
+    for (let y = 0; y < this.size; y += 1) {
+      for (let x = 0; x < this.size; x += 1) {
+        if (this.isLegal(x, y, color)) {
+          moves.push({ x, y });
+        }
+      }
+    }
+    return moves;
+  }
+
+  isLegal(x, y, color) {
+    if (!this.isOnBoard(x, y)) {
+      return false;
+    }
+    if (this.getStone(x, y) !== EMPTY) {
+      return false;
+    }
+    const snapshot = this.createSnapshot();
+    const result = this.setStone(x, y, color);
+    this.restoreBoard(snapshot);
+    return result.ok;
+  }
+
+  topThreePolicy(policyEntries, color, temperature = 1) {
+    if (!Array.isArray(policyEntries) || !policyEntries.length) {
+      return { type: PASS_MOVE, color };
+    }
+
+    const temp = clampTemperature(temperature);
+    const legalCandidates = [];
+    let passWeight = 0;
+
+    for (const entry of policyEntries) {
+      if (!entry) {
+        continue;
+      }
+      if (entry.pass || entry.type === PASS_MOVE) {
+        const weight = Math.max(0, entry.policy ?? entry.weight ?? 0);
+        passWeight = Math.max(passWeight, weight);
+        continue;
+      }
+      const x = entry.x ?? entry.col ?? entry.column;
+      const y = entry.y ?? entry.row;
+      if (!Number.isInteger(x) || !Number.isInteger(y)) {
+        continue;
+      }
+      if (!this.isLegal(x, y, color)) {
+        continue;
+      }
+      const weight = Math.max(0, entry.policy ?? entry.weight ?? entry.score ?? 0);
+      if (weight <= 0) {
+        continue;
+      }
+      legalCandidates.push({ x, y, policy: weight });
+    }
+
+    if (!legalCandidates.length) {
+      return { type: PASS_MOVE, color, policy: passWeight };
+    }
+
+    legalCandidates.sort((a, b) => b.policy - a.policy);
+    const top = legalCandidates.slice(0, 3);
+
+    const adjusted = top.map((item) => ({
+      ...item,
+      weight: Math.pow(item.policy + 1e-9, 1 / temp)
+    }));
+
+    const totalWeight = adjusted.reduce((sum, item) => sum + item.weight, 0);
+    let threshold = Math.random() * totalWeight;
+    for (const item of adjusted) {
+      threshold -= item.weight;
+      if (threshold <= 0) {
+        return { type: 'play', x: item.x, y: item.y, policy: item.policy };
+      }
+    }
+
+    const fallback = adjusted[0];
+    return { type: 'play', x: fallback.x, y: fallback.y, policy: fallback.policy };
+  }
+
+  estimateScore() {
+    let black = this.captures[BLACK];
+    let white = this.captures[WHITE];
+    const visited = new Set();
+
+    for (let y = 0; y < this.size; y += 1) {
+      for (let x = 0; x < this.size; x += 1) {
+        const stone = this.getStone(x, y);
+        if (stone === BLACK) {
+          black += 1;
+        } else if (stone === WHITE) {
+          white += 1;
+        } else if (stone === EMPTY) {
+          const index = this.toIndex(x, y);
+          if (visited.has(index)) {
+            continue;
+          }
+          const region = this.exploreEmptyRegion(index, visited);
+          if (region.owner === BLACK) {
+            black += region.size;
+          } else if (region.owner === WHITE) {
+            white += region.size;
+          }
+        }
+      }
+    }
+
+    const leadValue = Math.abs(black - white);
+    const leader = leadValue === 0 ? null : black > white ? BLACK : WHITE;
+    return {
+      black,
+      white,
+      leader,
+      leadValue
+    };
+  }
+
+  exploreEmptyRegion(startIndex, visited) {
+    const stack = [startIndex];
+    const region = [];
+    const borderingColors = new Set();
+
+    while (stack.length) {
+      const index = stack.pop();
+      if (visited.has(index)) {
+        continue;
+      }
+      visited.add(index);
+      region.push(index);
+
+      for (const neighbor of this.getNeighborIndexes(index)) {
+        const stone = this.board[neighbor];
+        if (stone === EMPTY) {
+          if (!visited.has(neighbor)) {
+            stack.push(neighbor);
+          }
+        } else if (stone === BLACK || stone === WHITE) {
+          borderingColors.add(stone);
+        }
+      }
+    }
+
+    let owner = null;
+    if (borderingColors.size === 1) {
+      owner = borderingColors.values().next().value;
+    }
+
+    return {
+      size: region.length,
+      owner
+    };
+  }
+
+  vertexFromPoint(x, y) {
+    if (!this.isOnBoard(x, y)) {
+      return PASS_MOVE;
+    }
+    const letter = LETTERS[x] ?? '?';
+    const row = this.size - y;
+    return `${letter}${row}`;
+  }
+}
+
+export { BOARD_SIZE };

--- a/src/apps/zen-go/styles.css
+++ b/src/apps/zen-go/styles.css
@@ -1,14 +1,14 @@
 :root {
   color-scheme: light;
-  --surface: rgba(255, 255, 255, 0.92);
-  --surface-alt: rgba(255, 255, 255, 0.78);
-  --accent: #2c7be5;
-  --accent-soft: rgba(44, 123, 229, 0.14);
-  --accent-strong: rgba(44, 123, 229, 0.24);
+  --surface: rgba(255, 255, 255, 0.94);
+  --surface-alt: rgba(255, 255, 255, 0.82);
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --accent-strong: rgba(37, 99, 235, 0.18);
   --ink: #1f2933;
-  --muted: #52616b;
+  --muted: #55606b;
   --border: rgba(15, 23, 42, 0.08);
-  --shadow: 0 22px 44px -18px rgba(15, 23, 42, 0.4);
+  --shadow: 0 22px 44px -18px rgba(15, 23, 42, 0.35);
   --radius-lg: 24px;
   --radius-md: 18px;
   --radius-sm: 12px;
@@ -33,18 +33,18 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(20px, 4vw, 48px);
+  padding: clamp(20px, 5vw, 52px);
 }
 
 .zen-go-shell {
-  width: min(1100px, 100%);
+  width: min(1120px, 100%);
   display: flex;
-  gap: clamp(20px, 3vw, 40px);
+  gap: clamp(20px, 3vw, 44px);
   background: var(--surface);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
-  padding: clamp(24px, 4vw, 44px);
-  backdrop-filter: blur(16px);
+  padding: clamp(24px, 4vw, 46px);
+  backdrop-filter: blur(18px);
 }
 
 .zen-go-board-panel {
@@ -52,7 +52,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: clamp(18px, 3vw, 28px);
+  gap: clamp(18px, 3vw, 30px);
 }
 
 .zen-go-header {
@@ -62,22 +62,22 @@ body {
 
 .zen-go-header h1 {
   margin: 0 0 12px;
-  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-size: clamp(2.1rem, 4vw, 2.7rem);
   letter-spacing: -0.01em;
 }
 
 .zen-go-header p {
   margin: 0;
   color: var(--muted);
-  font-size: clamp(0.95rem, 2vw, 1.05rem);
-  line-height: 1.55;
+  font-size: clamp(0.98rem, 2.2vw, 1.1rem);
+  line-height: 1.6;
 }
 
 .board-wrapper {
   width: 100%;
-  max-width: 520px;
+  max-width: 620px;
   aspect-ratio: 1 / 1;
-  padding: clamp(10px, 1.8vw, 18px);
+  padding: clamp(12px, 1.8vw, 20px);
   border-radius: var(--radius-lg);
   background: linear-gradient(145deg, #f9e4c7, #ebd0a9);
   box-shadow: inset 0 2px 6px rgba(94, 71, 42, 0.25),
@@ -90,45 +90,90 @@ body {
 .board-canvas {
   width: 100%;
   height: 100%;
-  position: relative;
-}
-
-.board-canvas canvas {
+  display: block;
   border-radius: calc(var(--radius-md) * 0.9);
-  box-shadow: inset 0 0 0 1px rgba(94, 71, 42, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(94, 71, 42, 0.22);
 }
 
 .zen-go-status {
   font-weight: 600;
   font-size: 1rem;
-  color: var(--accent);
-  background: var(--accent-soft);
   padding: 12px 18px;
   border-radius: var(--radius-sm);
-  width: min(480px, 100%);
+  width: min(520px, 100%);
   text-align: center;
   transition: color var(--transition), background var(--transition);
 }
 
-.zen-go-status.passive {
+.zen-go-status--info {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.zen-go-status--thinking {
+  color: #9a6700;
+  background: rgba(248, 202, 48, 0.18);
+}
+
+.zen-go-status--success {
+  color: #0f766e;
+  background: rgba(15, 118, 110, 0.16);
+}
+
+.zen-go-status--error {
+  color: #b42323;
+  background: rgba(255, 148, 148, 0.22);
+}
+
+.zen-go-status--passive {
   color: var(--muted);
   background: rgba(15, 23, 42, 0.08);
 }
 
-.zen-go-status.error {
-  color: #b42323;
-  background: rgba(255, 148, 148, 0.2);
+.zen-go-hud {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(12px, 2vw, 18px);
+}
+
+.hud-item {
+  padding: 14px 18px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hud-span {
+  grid-column: span 2;
+}
+
+.hud-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+
+.hud-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--ink);
 }
 
 .zen-go-captures {
   display: flex;
-  gap: clamp(14px, 2vw, 24px);
+  gap: clamp(16px, 2.4vw, 28px);
   flex-wrap: wrap;
   justify-content: center;
 }
 
 .capture-card {
-  min-width: 160px;
+  min-width: 170px;
   padding: 14px 20px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
@@ -137,6 +182,7 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .capture-black {
@@ -144,27 +190,26 @@ body {
 }
 
 .capture-white {
-  box-shadow: inset 0 0 0 2px rgba(44, 123, 229, 0.12);
+  box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.12);
 }
 
 .capture-label {
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--muted);
 }
 
 .capture-count {
-  font-size: 1.65rem;
+  font-size: 1.8rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
 }
 
 .zen-go-side-panel {
   width: min(320px, 100%);
   display: flex;
   flex-direction: column;
-  gap: clamp(18px, 2.4vw, 28px);
+  gap: clamp(18px, 2.6vw, 30px);
 }
 
 .control-group {
@@ -172,7 +217,7 @@ body {
   background: var(--surface-alt);
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .control-group h2 {
@@ -185,7 +230,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-size: 0.95rem;
+  font-size: 0.96rem;
   color: var(--muted);
 }
 
@@ -198,7 +243,7 @@ body {
   font: inherit;
   padding: 10px 14px;
   border-radius: 12px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.14);
   background: #fff;
   transition: border var(--transition), box-shadow var(--transition);
   appearance: none;
@@ -207,43 +252,19 @@ body {
 .control-select:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(44, 123, 229, 0.18);
-}
-
-.difficulty-meta {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.9rem;
-  color: var(--muted);
-  margin-top: 10px;
-}
-
-.difficulty-rank {
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.difficulty-elo {
-  font-weight: 600;
-}
-
-.difficulty-note {
-  margin: 12px 0 0;
-  font-size: 0.9rem;
-  line-height: 1.4;
-  color: var(--muted);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.16);
 }
 
 .control-help {
-  margin: 12px 0 0;
-  font-size: 0.85rem;
-  line-height: 1.45;
+  margin: 14px 0 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
   color: var(--muted);
 }
 
-.button-row {
+.button-column {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 10px;
 }
 
@@ -264,81 +285,73 @@ button:disabled {
 }
 
 .primary-button {
-  flex: 1 1 140px;
-  padding: 12px 18px;
+  padding: 13px 18px;
   background: var(--accent);
   color: #fff;
   font-weight: 600;
-  box-shadow: 0 12px 22px -12px rgba(44, 123, 229, 0.7);
+  box-shadow: 0 14px 26px -16px rgba(37, 99, 235, 0.75);
 }
 
 .primary-button:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 16px 24px -14px rgba(44, 123, 229, 0.75);
+  box-shadow: 0 18px 28px -18px rgba(37, 99, 235, 0.78);
 }
 
 .ghost-button {
-  flex: 1 1 110px;
   padding: 12px 16px;
-  background: rgba(15, 23, 42, 0.04);
+  background: rgba(15, 23, 42, 0.05);
   color: var(--ink);
   border: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .ghost-button:hover:not(:disabled) {
-  background: rgba(44, 123, 229, 0.08);
-  border-color: rgba(44, 123, 229, 0.2);
+  background: rgba(37, 99, 235, 0.1);
+  border-color: rgba(37, 99, 235, 0.18);
 }
 
 .ghost-button.danger {
   color: #b42323;
-  border-color: rgba(180, 35, 35, 0.12);
-  background: rgba(255, 163, 163, 0.08);
+  border-color: rgba(180, 35, 35, 0.16);
+  background: rgba(255, 163, 163, 0.12);
 }
 
 .ghost-button.danger:hover:not(:disabled) {
-  background: rgba(255, 110, 110, 0.12);
+  background: rgba(255, 120, 120, 0.16);
   border-color: rgba(180, 35, 35, 0.24);
 }
 
-.engine-status {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: var(--ink);
-  background: rgba(12, 183, 84, 0.1);
-  border-radius: 10px;
-  padding: 10px 12px;
-}
-
-.engine-status.pending {
-  color: #9a6700;
-  background: rgba(248, 202, 48, 0.18);
-}
-
-.engine-status.error {
-  color: #b42323;
-  background: rgba(255, 148, 148, 0.2);
-}
-
-.engine-status.success {
-  color: #0f766e;
-  background: rgba(15, 118, 110, 0.14);
-}
-
-.engine-status.passive {
-  color: var(--muted);
-  background: rgba(15, 23, 42, 0.05);
-}
-
-.future-note ul {
+.insight-list {
   margin: 0;
-  padding-left: 18px;
-  color: var(--muted);
-  font-size: 0.9rem;
-  line-height: 1.5;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 220px;
+  overflow-y: auto;
 }
 
-@media (max-width: 1080px) {
+.insight-list li {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.insight-list li strong {
+  color: var(--ink);
+}
+
+.insight-empty {
+  text-align: center;
+  font-size: 0.88rem;
+  color: var(--muted);
+  padding: 12px;
+}
+
+@media (max-width: 1120px) {
   .zen-go-shell {
     flex-direction: column;
   }
@@ -355,18 +368,21 @@ button:disabled {
   }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 760px) {
   .zen-go-shell {
     padding: 20px;
   }
 
-  .board-wrapper {
-    max-width: 100%;
-    padding: clamp(8px, 2vw, 16px);
-  }
-
   .zen-go-status {
     width: 100%;
+  }
+
+  .zen-go-hud {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hud-span {
+    grid-column: span 2;
   }
 
   .zen-go-side-panel {


### PR DESCRIPTION
## Summary
- add a dedicated goban engine with 21×21 sentinel board, liberty accounting, move history, and top-three policy sampling
- rebuild the Zen Go browser app around a canvas-rendered 19×19 board, HUD, model selector, and KataGo-inspired turn loop
- refresh the static markup, styles, and React wrapper copy to describe the new full-board KataGo sparring experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c4e62f4c832b923881ec5eb29263