### PR TITLE
Add Zen Go GTP CLI and shared engine modules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,10 @@ Your site will be available at the `homepage` URL.
 * `npm run deploy`: Publish `dist/` to `gh-pages`.
 * `npm test`: Run Jest suite for launcher React apps.
 
+### Engine utilities
+
+* `node gtp/gtp.js`: Launch the Zen Go Go Text Protocol (GTP) loop backed by the shared board logic. Useful for piping `genmove`, `play`, and `showboard` commands during testing.
+
 ### Cache Lab Workspace
 
 * `npm run build:cache-lab`: Build Cache Lab assets within `src/apps/cache-lab`.

--- a/gtp/gtp.js
+++ b/gtp/gtp.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+
+const readline = require('node:readline');
+const { stdin, stdout } = require('node:process');
+const { createEngine } = require('../src/apps/zen-go/js/engine.js');
+const { toGtpCoord } = require('../src/apps/zen-go/js/goban.js');
+const packageJson = require('../package.json');
+
+const engine = createEngine({ size: 9 });
+
+const COMMAND_LIST = [
+  'protocol_version',
+  'name',
+  'version',
+  'list_commands',
+  'boardsize',
+  'clear_board',
+  'showboard',
+  'play',
+  'genmove',
+  'quit'
+];
+
+const rl = readline.createInterface({
+  input: stdin,
+  output: stdout,
+  terminal: false
+});
+
+let processing = Promise.resolve();
+let exitRequested = false;
+
+rl.on('line', (line) => {
+  processing = processing.then(() => handleLine(line)).catch((error) => {
+    respond(false, null, error.message || 'unknown error');
+  });
+});
+
+rl.on('close', () => {
+  if (!exitRequested) {
+    process.exit(0);
+  }
+});
+
+async function handleLine(rawLine) {
+  const line = typeof rawLine === 'string' ? rawLine : '';
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (trimmed.startsWith('#')) {
+    return;
+  }
+  const commentIndex = trimmed.indexOf('#');
+  const content = commentIndex >= 0 ? trimmed.slice(0, commentIndex).trim() : trimmed;
+  if (!content) {
+    return;
+  }
+
+  const parsed = parseCommand(content);
+  if (!parsed) {
+    respond(false, null, 'invalid command');
+    return;
+  }
+
+  const { id, command, args } = parsed;
+  if (!command) {
+    respond(false, id, 'unknown command');
+    return;
+  }
+  const handler = handlers[command];
+  if (!handler) {
+    respond(false, id, `unknown command: ${command}`);
+    return;
+  }
+
+  try {
+    const result = handler(args, id);
+    const resolved = result instanceof Promise ? await result : result;
+    if (resolved && typeof resolved === 'object' && resolved.__response) {
+      respond(resolved.__response.ok, id, resolved.__response.message);
+    } else if (typeof resolved === 'string' && resolved.length > 0) {
+      respond(true, id, resolved);
+    } else if (resolved === '') {
+      respond(true, id, '');
+    } else {
+      respond(true, id, '');
+    }
+    if (command === 'quit') {
+      exitRequested = true;
+      rl.close();
+    }
+  } catch (error) {
+    respond(false, id, error && error.message ? error.message : 'command failed');
+  }
+}
+
+function parseCommand(input) {
+  const tokens = input.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return null;
+  }
+  let id = null;
+  let command = tokens[0];
+  let args = tokens.slice(1);
+  if (!handlers[command]) {
+    id = command;
+    if (tokens.length === 1) {
+      return { id, command: null, args: [] };
+    }
+    command = tokens[1];
+    args = tokens.slice(2);
+  }
+  return { id, command, args };
+}
+
+function respond(success, id, message) {
+  const prefix = success ? '=' : '?';
+  const idPart = id ? String(id) : '';
+  const hasMessage = typeof message === 'string' && message.length > 0;
+  if (hasMessage && message.includes('\n')) {
+    let header = prefix;
+    if (idPart) {
+      header += idPart;
+    }
+    stdout.write(`${header}\n${message}\n\n`);
+    return;
+  }
+  let line = prefix;
+  if (idPart) {
+    line += idPart;
+  }
+  if (hasMessage) {
+    line += ' ';
+    line += message;
+  }
+  stdout.write(`${line}\n\n`);
+}
+
+const handlers = {
+  protocol_version: () => '2',
+  name: () => 'Zen Go',
+  version: () => (packageJson && packageJson.version ? packageJson.version : 'dev'),
+  list_commands: () => COMMAND_LIST.join('\n'),
+  boardsize: (args) => {
+    if (!args || args.length === 0) {
+      throw new Error('boardsize requires a single integer argument.');
+    }
+    const size = Number.parseInt(args[0], 10);
+    if (!Number.isInteger(size)) {
+      throw new Error('boardsize requires a numeric value.');
+    }
+    engine.setBoardSize(size);
+    return '';
+  },
+  clear_board: () => {
+    engine.clearBoard();
+    return '';
+  },
+  showboard: () => engine.showBoard(),
+  play: (args) => {
+    if (!args || args.length < 2) {
+      throw new Error('play requires color and vertex arguments.');
+    }
+    const color = args[0];
+    const vertex = args[1];
+    engine.play(color, vertex);
+    return '';
+  },
+  genmove: async (args) => {
+    if (!args || args.length === 0) {
+      throw new Error('genmove requires a color argument.');
+    }
+    const color = args[0];
+    const move = await engine.genMove(color);
+    if (!move) {
+      return 'PASS';
+    }
+    if (move.pass) {
+      return 'PASS';
+    }
+    if (move.vertex) {
+      return move.vertex.toUpperCase();
+    }
+    return toGtpCoord(move.x, move.y, engine.size);
+  },
+  quit: () => ''
+};
+
+module.exports = {
+  handleLine,
+  parseCommand,
+  respond
+};

--- a/src/apps/zen-go/js/engine.js
+++ b/src/apps/zen-go/js/engine.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const {
+  Goban,
+  fromGtpCoord,
+  toGtpCoord,
+  normalizeColor,
+  BLACK,
+  WHITE
+} = require('./goban.js');
+const { loadZenGoModel } = require('./model-wrapper.js');
+
+function cloneMove(move) {
+  if (!move || typeof move !== 'object') {
+    return null;
+  }
+  const result = {};
+  if (typeof move.x === 'number') {
+    result.x = move.x;
+  }
+  if (typeof move.y === 'number') {
+    result.y = move.y;
+  }
+  if (typeof move.vertex === 'string') {
+    result.vertex = move.vertex;
+  }
+  if (typeof move.pass === 'boolean') {
+    result.pass = move.pass;
+  }
+  if (typeof move.color === 'string') {
+    result.color = move.color;
+  }
+  return result;
+}
+
+class ZenGoEngine {
+  constructor(options = {}) {
+    const { size = 9 } = options;
+    this.goban = new Goban(size);
+    this.moveHistory = [];
+  }
+
+  get size() {
+    return this.goban.size;
+  }
+
+  setBoardSize(size) {
+    this.goban.setSize(size);
+    this.moveHistory = [];
+  }
+
+  clearBoard() {
+    this.goban.clear();
+    this.moveHistory = [];
+  }
+
+  showBoard() {
+    return this.goban.renderAscii();
+  }
+
+  getCaptures() {
+    return this.goban.getCaptures();
+  }
+
+  play(colorInput, vertexInput) {
+    const color = normalizeColor(colorInput);
+    if (typeof vertexInput !== 'string') {
+      throw new Error('Vertex is required for play command.');
+    }
+    const vertex = vertexInput.trim();
+    if (vertex.toUpperCase() === 'PASS') {
+      this.moveHistory.push({ color, pass: true });
+      return { pass: true };
+    }
+    const coords = fromGtpCoord(vertex, this.goban.size);
+    if (!coords) {
+      this.moveHistory.push({ color, pass: true });
+      return { pass: true };
+    }
+    try {
+      this.goban.play(color, coords.x, coords.y);
+      const move = { color, x: coords.x, y: coords.y, vertex: toGtpCoord(coords.x, coords.y, this.goban.size) };
+      this.moveHistory.push(move);
+      return move;
+    } catch (error) {
+      throw new Error(`Illegal move: ${error.message}`);
+    }
+  }
+
+  listLegalMoves(colorInput) {
+    const color = normalizeColor(colorInput);
+    return this.goban.listLegalMoves(color);
+  }
+
+  async genMove(colorInput) {
+    const color = normalizeColor(colorInput);
+    const legalMoves = this.goban.listLegalMoves(color);
+    if (legalMoves.length === 0) {
+      const passMove = { color, pass: true };
+      this.moveHistory.push(passMove);
+      return passMove;
+    }
+
+    let model;
+    try {
+      model = await loadZenGoModel();
+    } catch (error) {
+      model = null;
+    }
+
+    let suggestion = null;
+    if (model && typeof model.suggestMove === 'function') {
+      try {
+        const context = {
+          color,
+          legalMoves: legalMoves.map((move) => ({ ...move })),
+          board: this.goban.exportState(),
+          history: this.moveHistory.map(cloneMove),
+          toVertex: (move) => toGtpCoord(move.x, move.y, this.goban.size)
+        };
+        suggestion = await model.suggestMove(context);
+      } catch (error) {
+        suggestion = null;
+      }
+    }
+
+    let chosen = null;
+    if (suggestion) {
+      let candidate = suggestion;
+      if (typeof candidate === 'string') {
+        try {
+          const coords = fromGtpCoord(candidate, this.goban.size);
+          if (coords) {
+            candidate = coords;
+          }
+        } catch (error) {
+          candidate = null;
+        }
+      } else if (candidate && typeof candidate.vertex === 'string') {
+        try {
+          const coords = fromGtpCoord(candidate.vertex, this.goban.size);
+          if (coords) {
+            candidate = { x: coords.x, y: coords.y };
+          }
+        } catch (error) {
+          candidate = null;
+        }
+      }
+      if (
+        candidate &&
+        Number.isInteger(candidate.x) &&
+        Number.isInteger(candidate.y) &&
+        this.goban.isOnBoard(candidate.x, candidate.y) &&
+        this.goban.isLegal(color, candidate.x, candidate.y)
+      ) {
+        chosen = { x: candidate.x, y: candidate.y };
+      }
+    }
+
+    if (!chosen) {
+      const randomIndex = Math.floor(Math.random() * legalMoves.length);
+      chosen = legalMoves[randomIndex];
+    }
+
+    this.goban.play(color, chosen.x, chosen.y);
+    const resultMove = {
+      color,
+      x: chosen.x,
+      y: chosen.y,
+      vertex: toGtpCoord(chosen.x, chosen.y, this.goban.size),
+      generated: true
+    };
+    this.moveHistory.push(resultMove);
+    return resultMove;
+  }
+}
+
+function createEngine(options) {
+  return new ZenGoEngine(options);
+}
+
+module.exports = {
+  ZenGoEngine,
+  createEngine,
+  Goban,
+  BLACK,
+  WHITE
+};

--- a/src/apps/zen-go/js/goban.js
+++ b/src/apps/zen-go/js/goban.js
@@ -1,0 +1,338 @@
+'use strict';
+
+const EMPTY = 0;
+const BLACK = 'B';
+const WHITE = 'W';
+const COLUMN_ALPHABET = 'ABCDEFGHJKLMNOPQRSTUVWXYZ';
+
+function normalizeColor(input) {
+  const value = typeof input === 'string' ? input.trim().toUpperCase() : '';
+  if (value === 'B' || value === 'BLACK') {
+    return BLACK;
+  }
+  if (value === 'W' || value === 'WHITE') {
+    return WHITE;
+  }
+  throw new Error(`Unknown color: ${input}`);
+}
+
+function indexToLetters(index) {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`Invalid index: ${index}`);
+  }
+  const base = COLUMN_ALPHABET.length;
+  let value = index + 1;
+  let result = '';
+  while (value > 0) {
+    const remainder = (value - 1) % base;
+    result = COLUMN_ALPHABET[remainder] + result;
+    value = Math.floor((value - 1) / base);
+  }
+  return result;
+}
+
+function lettersToIndex(letters) {
+  if (typeof letters !== 'string' || letters.length === 0) {
+    throw new Error(`Invalid column label: ${letters}`);
+  }
+  const base = COLUMN_ALPHABET.length;
+  let value = 0;
+  for (let i = 0; i < letters.length; i += 1) {
+    const char = letters[i];
+    const offset = COLUMN_ALPHABET.indexOf(char);
+    if (offset === -1) {
+      throw new Error(`Invalid column letter: ${char}`);
+    }
+    value = value * base + (offset + 1);
+  }
+  return value - 1;
+}
+
+function buildColumnLabels(size) {
+  return Array.from({ length: size }, (_, index) => indexToLetters(index));
+}
+
+function toGtpCoord(x, y, size) {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error(`Invalid board size: ${size}`);
+  }
+  if (!Number.isInteger(x) || !Number.isInteger(y)) {
+    throw new Error(`Invalid coordinate: (${x}, ${y})`);
+  }
+  const column = indexToLetters(x);
+  const row = size - y;
+  return `${column}${row}`;
+}
+
+function fromGtpCoord(vertex, size) {
+  if (typeof vertex !== 'string' || vertex.trim() === '') {
+    throw new Error('Vertex is required.');
+  }
+  const trimmed = vertex.trim().toUpperCase();
+  if (trimmed === 'PASS') {
+    return null;
+  }
+  const match = trimmed.match(/^([A-Z]+)(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid vertex: ${vertex}`);
+  }
+  const [, columnLetters, rowDigits] = match;
+  const x = lettersToIndex(columnLetters);
+  const row = Number.parseInt(rowDigits, 10);
+  if (!Number.isInteger(row) || row < 1 || row > size) {
+    throw new Error(`Row out of range for vertex: ${vertex}`);
+  }
+  const y = size - row;
+  if (x < 0 || x >= size) {
+    throw new Error(`Column out of range for vertex: ${vertex}`);
+  }
+  return { x, y };
+}
+
+class Goban {
+  constructor(size = 9) {
+    this.maxSize = 25;
+    this.setSize(size);
+  }
+
+  setSize(size) {
+    if (!Number.isInteger(size) || size < 2 || size > this.maxSize) {
+      throw new Error(`Unsupported board size: ${size}`);
+    }
+    this.size = size;
+    this.clear();
+  }
+
+  clear() {
+    this.board = Array.from({ length: this.size }, () => Array(this.size).fill(EMPTY));
+    this.captures = { [BLACK]: 0, [WHITE]: 0 };
+    this.prevHash = null;
+    this.lastHash = this._serialize();
+  }
+
+  get(x, y) {
+    if (!this.isOnBoard(x, y)) {
+      return null;
+    }
+    return this.board[y][x];
+  }
+
+  isOnBoard(x, y) {
+    return Number.isInteger(x) && Number.isInteger(y) && x >= 0 && x < this.size && y >= 0 && y < this.size;
+  }
+
+  getNeighborCoords(x, y) {
+    const neighbors = [];
+    if (this.isOnBoard(x - 1, y)) {
+      neighbors.push([x - 1, y]);
+    }
+    if (this.isOnBoard(x + 1, y)) {
+      neighbors.push([x + 1, y]);
+    }
+    if (this.isOnBoard(x, y - 1)) {
+      neighbors.push([x, y - 1]);
+    }
+    if (this.isOnBoard(x, y + 1)) {
+      neighbors.push([x, y + 1]);
+    }
+    return neighbors;
+  }
+
+  _collectGroup(x, y) {
+    const color = this.get(x, y);
+    if (color !== BLACK && color !== WHITE) {
+      return null;
+    }
+    const stack = [[x, y]];
+    const visited = new Set();
+    const stones = [];
+    const liberties = new Set();
+    while (stack.length) {
+      const [cx, cy] = stack.pop();
+      const key = `${cx},${cy}`;
+      if (visited.has(key)) {
+        continue;
+      }
+      visited.add(key);
+      stones.push([cx, cy]);
+      const neighbors = this.getNeighborCoords(cx, cy);
+      for (let i = 0; i < neighbors.length; i += 1) {
+        const [nx, ny] = neighbors[i];
+        const neighborValue = this.get(nx, ny);
+        if (neighborValue === color) {
+          stack.push([nx, ny]);
+        } else if (neighborValue === EMPTY) {
+          liberties.add(`${nx},${ny}`);
+        }
+      }
+    }
+    return { stones, liberties: liberties.size };
+  }
+
+  _removeGroup(stones) {
+    for (let i = 0; i < stones.length; i += 1) {
+      const [x, y] = stones[i];
+      this.board[y][x] = EMPTY;
+    }
+  }
+
+  _serialize() {
+    return this.board.map((row) => row.map((cell) => {
+      if (cell === BLACK) {
+        return 'b';
+      }
+      if (cell === WHITE) {
+        return 'w';
+      }
+      return '.';
+    }).join('')).join('|');
+  }
+
+  play(colorInput, x, y, options = {}) {
+    const { simulate = false } = options;
+    const color = normalizeColor(colorInput);
+    if (!this.isOnBoard(x, y)) {
+      throw new Error('Move is off the board.');
+    }
+    if (this.get(x, y) !== EMPTY) {
+      throw new Error('Intersection already occupied.');
+    }
+
+    const backupBoard = this.board.map((row) => row.slice());
+    const backupCaptures = { ...this.captures };
+    const prevLastHash = this.lastHash;
+    const prevPrevHash = this.prevHash;
+
+    this.board[y][x] = color;
+    const opponent = color === BLACK ? WHITE : BLACK;
+    let capturedStones = 0;
+
+    const neighbors = this.getNeighborCoords(x, y);
+    for (let i = 0; i < neighbors.length; i += 1) {
+      const [nx, ny] = neighbors[i];
+      if (this.get(nx, ny) !== opponent) {
+        continue;
+      }
+      const group = this._collectGroup(nx, ny);
+      if (group && group.liberties === 0) {
+        this._removeGroup(group.stones);
+        capturedStones += group.stones.length;
+      }
+    }
+
+    const myGroup = this._collectGroup(x, y);
+    if (!myGroup) {
+      this.board = backupBoard;
+      this.captures = backupCaptures;
+      this.lastHash = prevLastHash;
+      this.prevHash = prevPrevHash;
+      throw new Error('Internal error while resolving liberties.');
+    }
+
+    if (myGroup.liberties === 0) {
+      this.board = backupBoard;
+      this.captures = backupCaptures;
+      this.lastHash = prevLastHash;
+      this.prevHash = prevPrevHash;
+      throw new Error('Suicide move is not allowed.');
+    }
+
+    const newHash = this._serialize();
+    if (prevPrevHash && newHash === prevPrevHash) {
+      this.board = backupBoard;
+      this.captures = backupCaptures;
+      this.lastHash = prevLastHash;
+      this.prevHash = prevPrevHash;
+      throw new Error('Move violates ko rule.');
+    }
+
+    if (simulate) {
+      this.board = backupBoard;
+      this.captures = backupCaptures;
+      this.lastHash = prevLastHash;
+      this.prevHash = prevPrevHash;
+      return { captured: capturedStones, liberties: myGroup.liberties };
+    }
+
+    if (capturedStones > 0) {
+      this.captures[color] += capturedStones;
+    }
+    this.prevHash = prevLastHash;
+    this.lastHash = newHash;
+    return { captured: capturedStones, liberties: myGroup.liberties };
+  }
+
+  isLegal(colorInput, x, y) {
+    try {
+      this.play(colorInput, x, y, { simulate: true });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  listLegalMoves(colorInput) {
+    const moves = [];
+    for (let y = 0; y < this.size; y += 1) {
+      for (let x = 0; x < this.size; x += 1) {
+        if (this.get(x, y) !== EMPTY) {
+          continue;
+        }
+        if (this.isLegal(colorInput, x, y)) {
+          moves.push({ x, y });
+        }
+      }
+    }
+    return moves;
+  }
+
+  getCaptures() {
+    return { ...this.captures };
+  }
+
+  exportState() {
+    return {
+      size: this.size,
+      board: this.board.map((row) => row.slice())
+    };
+  }
+
+  renderAscii() {
+    const labels = buildColumnLabels(this.size);
+    const header = `  ${labels.join(' ')}`;
+    const lines = [header];
+    const labelWidth = String(this.size).length;
+    for (let y = 0; y < this.size; y += 1) {
+      const rowIndex = this.size - y;
+      const rowLabel = rowIndex.toString().padStart(labelWidth, ' ');
+      const cells = [];
+      for (let x = 0; x < this.size; x += 1) {
+        const value = this.get(x, y);
+        if (value === BLACK) {
+          cells.push('X');
+        } else if (value === WHITE) {
+          cells.push('O');
+        } else {
+          cells.push('.');
+        }
+      }
+      lines.push(`${rowLabel} ${cells.join(' ')}`);
+    }
+    lines.push(header);
+    lines.push(`Captures B:${this.captures[BLACK]} W:${this.captures[WHITE]}`);
+    return lines.join('\n');
+  }
+}
+
+module.exports = {
+  Goban,
+  BLACK,
+  WHITE,
+  EMPTY,
+  buildColumnLabels,
+  fromGtpCoord,
+  toGtpCoord,
+  normalizeColor,
+  indexToLetters,
+  lettersToIndex
+};

--- a/src/apps/zen-go/js/model-wrapper.js
+++ b/src/apps/zen-go/js/model-wrapper.js
@@ -1,0 +1,110 @@
+'use strict';
+
+let cachedModelPromise = null;
+let fallbackWarned = false;
+
+function chooseHeuristicMove(legalMoves, boardSize) {
+  if (!Array.isArray(legalMoves) || legalMoves.length === 0) {
+    return null;
+  }
+  const size = Number.isInteger(boardSize) && boardSize > 0 ? boardSize : Math.max(legalMoves.length, 9);
+  const center = (size - 1) / 2;
+  const scored = legalMoves.map((move) => {
+    const dx = Math.abs(move.x - center);
+    const dy = Math.abs(move.y - center);
+    const score = dx + dy;
+    return { move, score };
+  });
+  scored.sort((a, b) => a.score - b.score);
+  const bestScore = scored[0].score;
+  const bestCandidates = scored.filter((entry) => entry.score === bestScore);
+  const pool = bestCandidates.length > 3 ? bestCandidates.slice(0, 3) : bestCandidates;
+  const choice = pool[Math.floor(Math.random() * pool.length)];
+  return choice ? { x: choice.move.x, y: choice.move.y } : null;
+}
+
+function createFallbackModel(reason) {
+  return {
+    id: 'zen-go-fallback',
+    backend: 'heuristic',
+    reason,
+    async suggestMove(context = {}) {
+      const legalMoves = Array.isArray(context.legalMoves) ? context.legalMoves : [];
+      const boardSize = context.board && Number.isInteger(context.board.size) ? context.board.size : legalMoves.length || 9;
+      const selected = chooseHeuristicMove(legalMoves, boardSize);
+      return selected ? { ...selected } : null;
+    }
+  };
+}
+
+async function loadZenGoModel() {
+  if (!cachedModelPromise) {
+    cachedModelPromise = (async () => {
+      const runningInNode = typeof process !== 'undefined' && process.release && process.release.name === 'node';
+      if (!runningInNode) {
+        return createFallbackModel('non-node-environment');
+      }
+
+      let path;
+      let fs;
+      try {
+        path = require('node:path');
+        fs = require('node:fs/promises');
+      } catch (error) {
+        return createFallbackModel('missing-node-apis');
+      }
+
+      const modelRoot = process.env.ZENGO_MODEL_PATH || path.resolve(__dirname, '../model');
+      let hasArtifacts = false;
+      try {
+        await fs.access(path.join(modelRoot, 'model.json'));
+        hasArtifacts = true;
+      } catch (error) {
+        hasArtifacts = false;
+      }
+
+      if (!hasArtifacts) {
+        if (!fallbackWarned && typeof console !== 'undefined' && console.warn) {
+          console.warn(`[ZenGo] TFJS model not found at ${modelRoot}. Falling back to heuristic suggestions.`);
+          fallbackWarned = true;
+        }
+        return createFallbackModel('missing-model');
+      }
+
+      try {
+        const tf = await import('@tensorflow/tfjs-node');
+        const modelUrl = `file://${path.resolve(modelRoot, 'model.json')}`;
+        const model = await tf.loadGraphModel(modelUrl);
+        return {
+          id: 'zen-go-tfjs',
+          backend: tf.getBackend ? tf.getBackend() : 'tfjs',
+          async suggestMove(context = {}) {
+            const legalMoves = Array.isArray(context.legalMoves) ? context.legalMoves : [];
+            const boardSize = context.board && Number.isInteger(context.board.size) ? context.board.size : legalMoves.length || 9;
+            if (legalMoves.length === 0) {
+              return null;
+            }
+            // Placeholder heuristic selection until scoring is wired to the loaded model.
+            return chooseHeuristicMove(legalMoves, boardSize);
+          },
+          dispose() {
+            if (model && typeof model.dispose === 'function') {
+              model.dispose();
+            }
+          }
+        };
+      } catch (error) {
+        if (!fallbackWarned && typeof console !== 'undefined' && console.warn) {
+          console.warn(`[ZenGo] Failed to load TFJS model: ${error.message}. Using heuristic fallback.`);
+          fallbackWarned = true;
+        }
+        return createFallbackModel(error.message || 'tfjs-load-error');
+      }
+    })();
+  }
+  return cachedModelPromise;
+}
+
+module.exports = {
+  loadZenGoModel
+};


### PR DESCRIPTION
## Summary
- add a `gtp/gtp.js` entry point that exposes Zen Go over the Go Text Protocol with command routing and formatted responses
- factor shared board, engine, and model-loading helpers under `src/apps/zen-go/js/` for reuse by the CLI
- document how to launch the GTP command loop so reviewers can exercise the engine locally

## Testing
- npm test
- printf 'protocol_version\nname\nlist_commands\nshowboard\nquit\n' | node gtp/gtp.js

------
https://chatgpt.com/codex/tasks/task_e_68d1c4e987c4832b9a1b84cb96e7121c