### PR TITLE
Refine CatNap Leap HUD layout

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -20,58 +20,96 @@
   z-index: 2;
 }
 
+
 .catnap-hud {
   display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 0.75rem;
   align-items: stretch;
   width: 100%;
+  max-width: 420px;
 }
 
-.catnap-hud .scoreboard,
-.catnap-hud .start-boost-banner,
-.catnap-hud .drowsiness-meter {
+.catnap-hud-panel,
+.catnap-hud .start-boost-banner {
   pointer-events: auto;
 }
 
-.scoreboard {
-  flex: 1 1 320px;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
-  box-shadow: 0 12px 24px rgba(47, 42, 69, 0.08);
-  backdrop-filter: blur(8px);
-}
-
-.score-item {
+.catnap-hud-panel {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(246, 241, 255, 0.85));
+  border-radius: 20px;
+  padding: 1rem 1.3rem;
+  box-shadow: 0 18px 36px rgba(47, 42, 69, 0.12);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.hud-metrics {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.hud-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #2f2a45;
+}
+
+.hud-metric.primary .hud-metric-value {
+  font-size: 2.05rem;
+  line-height: 1.1;
+}
+
+.hud-metric.secondary {
+  align-self: flex-start;
+}
+
+.hud-metric.secondary .hud-metric-value {
+  font-size: 1.4rem;
+}
+
+.hud-metric-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 16px;
+  background: rgba(128, 111, 199, 0.12);
+}
+
+.hud-metric-group .hud-metric {
   gap: 0.2rem;
 }
 
-.score-item .label {
+.hud-metric-label {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: #746c9a;
 }
 
-.score-item .value {
+.hud-metric-value {
   font-size: 1.6rem;
   font-weight: 700;
   color: #2f2a45;
 }
 
-.score-item.treats .value {
+.hud-metric.treats .hud-metric-value {
   color: #f47c9c;
 }
 
+.hud-metric.perfects .hud-metric-value {
+  color: #6f5fb7;
+}
+
 .start-boost-banner {
-  flex: 1 1 100%;
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -105,23 +143,51 @@
   font-weight: 600;
 }
 
-.drowsiness-meter {
-  flex: 1 1 220px;
-  background: rgba(255, 255, 255, 0.85);
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
-  box-shadow: 0 12px 24px rgba(47, 42, 69, 0.08);
+.hud-meter {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
-  min-width: 220px;
 }
 
-.meter-header {
+.hud-meter-header {
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
   font-weight: 600;
   color: #5b5185;
+}
+
+.hud-meter-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.hud-sleepy-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #ffe7ef, #fcd6e5);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  box-shadow: 0 6px 12px rgba(244, 124, 156, 0.25);
+}
+
+.hud-meter-label {
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.hud-meter-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #2f2a45;
+  min-width: 3ch;
+  text-align: right;
 }
 
 .mode-indicator {
@@ -185,6 +251,10 @@
   border-radius: 999px;
   background: rgba(140, 118, 200, 0.16);
   font-weight: 600;
+}
+
+.catnap-hud-overlay .active-effects {
+  margin-top: 0.1rem;
 }
 
 .catnap-canvas-wrapper {
@@ -543,17 +613,36 @@
   font-size: 0.85rem;
 }
 
+@media (min-width: 540px) {
+  .catnap-hud {
+    max-width: 460px;
+  }
+
+  .hud-metrics {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+
+  .hud-metric.secondary {
+    align-self: stretch;
+    justify-content: center;
+  }
+}
+
 @media (max-width: 600px) {
   .catnap-app {
     gap: 1rem;
   }
 
-  .scoreboard {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .catnap-hud {
+    max-width: 100%;
   }
 
-  .drowsiness-meter {
-    min-width: unset;
+  .catnap-hud-panel {
+    padding: 0.9rem 1.1rem;
+  }
+
+  .hud-metric-group {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .overlay-card {

--- a/src/apps/CatNapLeapApp/CatNapLeapApp.js
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import './CatNapLeapApp.css';
 import { createBirdSpawn, createPowerupSpawn, summarizeLoadout } from './spawnLogic';
 
@@ -257,6 +257,8 @@ const CatNapLeapApp = () => {
   const shopFocusRef = useRef(0);
   const [catFocusIndex, setCatFocusIndex] = useState(0);
   const catFocusRef = useRef(0);
+  const drowsinessLabelId = useId();
+  const drowsinessValueId = useId();
 
   const selectedAppearance = useMemo(
     () => CAT_VARIATIONS.find((cat) => cat.id === selectedCatId) || CAT_VARIATIONS[0],
@@ -1247,28 +1249,67 @@ const CatNapLeapApp = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const drowsinessPercent = Math.round(drowsiness);
+
   return (
     <div className="catnap-app" ref={containerRef}>
       <div className="catnap-canvas-wrapper">
         <canvas ref={canvasRef} className="catnap-canvas" />
         <div className="catnap-hud-overlay">
           <div className="catnap-hud">
-            <div className="scoreboard" aria-live="polite">
-              <div className="score-item">
-                <span className="label">Score</span>
-                <span className="value">{stats.score}</span>
+            <div className="catnap-hud-panel">
+              <div className="hud-metrics" aria-live="polite">
+                <div className="hud-metric primary">
+                  <span className="hud-metric-label">Score</span>
+                  <span className="hud-metric-value">{stats.score}</span>
+                </div>
+                <div className="hud-metric secondary">
+                  <span className="hud-metric-label">Best</span>
+                  <span className="hud-metric-value">{stats.best}</span>
+                </div>
+                <div className="hud-metric-group" role="group" aria-label="Bonus stats">
+                  <div className="hud-metric treats">
+                    <span className="hud-metric-label">Treats</span>
+                    <span className="hud-metric-value">{treats}</span>
+                  </div>
+                  <div className="hud-metric perfects">
+                    <span className="hud-metric-label">Perfect Leaps</span>
+                    <span className="hud-metric-value">{stats.perfects}</span>
+                  </div>
+                </div>
               </div>
-              <div className="score-item">
-                <span className="label">Best</span>
-                <span className="value">{stats.best}</span>
-              </div>
-              <div className="score-item treats">
-                <span className="label">Treats</span>
-                <span className="value">{treats}</span>
-              </div>
-              <div className="score-item">
-                <span className="label">Perfect Leaps</span>
-                <span className="value">{stats.perfects}</span>
+
+              <div className="hud-meter">
+                <div className="hud-meter-header">
+                  <div className="hud-meter-title" id={drowsinessLabelId}>
+                    <span className="hud-sleepy-icon" aria-hidden="true">😴</span>
+                    <span className="hud-meter-label">Drowsiness</span>
+                  </div>
+                  <span className="hud-meter-value" id={drowsinessValueId} aria-live="polite">
+                    {drowsinessPercent}%
+                  </span>
+                </div>
+                <div className={`mode-indicator ${kittenMode ? 'active' : ''}`} aria-live="polite">
+                  {kittenMode ? 'Kitten Mode · Cozy pacing' : 'Cat Mode · Classic challenge'}
+                </div>
+                <div
+                  className="meter-track"
+                  role="progressbar"
+                  aria-labelledby={drowsinessLabelId}
+                  aria-describedby={drowsinessValueId}
+                  aria-valuenow={drowsinessPercent}
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                >
+                  <div className="meter-fill" style={{ width: `${clamp(drowsiness, 0, 100)}%` }} />
+                </div>
+                {effects.length > 0 && (
+                  <ul className="active-effects">
+                    {effects.map((effect) => (
+                      <li key={effect}>{effect}</li>
+                    ))}
+                  </ul>
+                )}
               </div>
             </div>
 
@@ -1282,32 +1323,6 @@ const CatNapLeapApp = () => {
                 </ul>
               </div>
             )}
-
-            <div className="drowsiness-meter" aria-label="Drowsiness meter">
-              <div className="meter-header">
-                <span>Drowsiness</span>
-                <span>{Math.round(drowsiness)}%</span>
-              </div>
-              <div className={`mode-indicator ${kittenMode ? 'active' : ''}`} aria-live="polite">
-                {kittenMode ? 'Kitten Mode · Cozy pacing' : 'Cat Mode · Classic challenge'}
-              </div>
-              <div
-                className="meter-track"
-                role="progressbar"
-                aria-valuenow={Math.round(drowsiness)}
-                aria-valuemin="0"
-                aria-valuemax="100"
-              >
-                <div className="meter-fill" style={{ width: `${clamp(drowsiness, 0, 100)}%` }} />
-              </div>
-              {effects.length > 0 && (
-                <ul className="active-effects">
-                  {effects.map((effect) => (
-                    <li key={effect}>{effect}</li>
-                  ))}
-                </ul>
-              )}
-            </div>
           </div>
         </div>
         {phase !== 'playing' && (


### PR DESCRIPTION
## Summary
- merge the CatNap Leap HUD metrics into a single accessible panel with grouped stats and drowsiness meter
- restyle the HUD with a soft card look, sleepy icon, and responsive spacing that keeps it clear of the canvas

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' required by existing config)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c84d3140832b893839bebd601019