### PR TITLE
Revamp CatNap Leap game over overlay

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -305,6 +305,10 @@
   max-width: 600px;
 }
 
+.overlay-card.gameover {
+  max-width: 540px;
+}
+
 .overlay-card h2 {
   margin: 0 0 0.5rem;
   font-size: 1.8rem;
@@ -572,10 +576,93 @@
   color: #7b66ff;
 }
 
-.treat-summary {
+.gameover-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1.25rem 0;
+  text-align: left;
+}
+
+.gameover-stats {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.gameover-stat-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(123, 102, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(123, 102, 255, 0.12);
+}
+
+.gameover-stat-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7c74a4;
+}
+
+.gameover-stat-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #3d3560;
+}
+
+.gameover-treat-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(244, 124, 156, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(244, 124, 156, 0.16);
+}
+
+.gameover-treat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.gameover-treat-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.gameover-treat-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  align-self: flex-start;
   font-weight: 600;
-  color: #6f65a4;
-  margin: 0.5rem 0 0;
+  color: #5a4d7f;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(123, 102, 255, 0.18);
+}
+
+.gameover-treat-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #5a4d7f;
+  line-height: 1.4;
+}
+
+.overlay-actions.gameover-actions {
+  justify-content: stretch;
+}
+
+.overlay-actions.gameover-actions .overlay-button {
+  flex: 1 1 140px;
 }
 
 .catnap-footer {

--- a/src/apps/CatNapLeapApp/CatNapLeapApp.js
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.js
@@ -118,6 +118,11 @@ const SHOP_ITEMS = [
   },
 ];
 
+const SHOP_ITEM_LABELS = SHOP_ITEMS.reduce((acc, item) => {
+  acc[item.id] = item.name;
+  return acc;
+}, {});
+
 const CatSpritePreview = ({ appearance }) => {
   const { colors, pattern } = appearance;
   const { body, earOuter, earInner, eye, highlight, nose, mouth } = colors;
@@ -550,7 +555,7 @@ const CatNapLeapApp = () => {
     publishEffects([]);
 
     setPhase('gameover');
-    setMessage(`${reason} Tap or press space to try again.`);
+    setMessage(`${reason} Choose your next move.`);
   };
 
   const applyJump = () => {
@@ -1636,7 +1641,7 @@ const CatNapLeapApp = () => {
         {phase !== 'playing' && (
           <div className={`catnap-overlay ${phase}`}>
             <div
-              className={`overlay-card ${phase === 'selecting' ? 'selecting' : ''} ${phase === 'shop' ? 'shop' : ''} ${phase === 'start' ? 'start' : ''}`}
+              className={`overlay-card ${phase === 'selecting' ? 'selecting' : ''} ${phase === 'shop' ? 'shop' : ''} ${phase === 'start' ? 'start' : ''} ${phase === 'gameover' ? 'gameover' : ''}`}
             >
               {phase === 'start' && (
                 <>
@@ -1795,10 +1800,45 @@ const CatNapLeapApp = () => {
                 <>
                   <h2>Dream Over</h2>
                   <p>{message}</p>
-                  <p className="treat-summary">Treats this session: {treats}</p>
-                  <div className="overlay-actions">
-                    <button type="button" className="overlay-button" onClick={() => resetGameState({ forcePhase: 'ready' })}>
-                      Restart Dream
+                  <div className="gameover-summary">
+                    <div className="gameover-stats">
+                      <div className="gameover-stat-row">
+                        <span className="gameover-stat-label">Run Score</span>
+                        <span className="gameover-stat-value">{stats.score}</span>
+                      </div>
+                      <div className="gameover-stat-row">
+                        <span className="gameover-stat-label">High Score</span>
+                        <span className="gameover-stat-value">{stats.best}</span>
+                      </div>
+                    </div>
+                    <div className="gameover-treat-summary">
+                      <div className="gameover-treat-header">
+                        <span className="gameover-stat-label">Treats Collected</span>
+                        <span className="gameover-stat-value">{treats}</span>
+                      </div>
+                      {queuedBoosts.length > 0 ? (
+                        <ul className="gameover-treat-list">
+                          {queuedBoosts.map(({ type, count }) => (
+                            <li key={type}>
+                              {SHOP_ITEM_LABELS[type] || type} ×{count}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="gameover-treat-note">No boosts queued yet. Visit the shop to spend treats.</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="overlay-actions gameover-actions">
+                    <button
+                      type="button"
+                      className="overlay-button"
+                      onClick={() => resetGameState({ forcePhase: 'ready' })}
+                    >
+                      Play Again
+                    </button>
+                    <button type="button" className="overlay-button secondary" onClick={() => setPhase('selecting')}>
+                      Customize
                     </button>
                     <button
                       type="button"
@@ -1810,7 +1850,7 @@ const CatNapLeapApp = () => {
                         shopFocusRef.current = 0;
                       }}
                     >
-                      Visit Shop
+                      Shop
                     </button>
                   </div>
                 </>


### PR DESCRIPTION
## Summary
- add a run stats and treat summary panel to the CatNap Leap game over overlay with refreshed actions
- update the game over message and button wiring to support replay, customization, and shop navigation
- expand CatNap Leap overlay styles to lay out the new stats and button group while keeping the frosted backdrop

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d66b1118832b8a50f763ef3e24c4