### PR TITLE
Use import map for Three.js in cosmos app

### DIFF
--- a/src/apps/cosmos/index.html
+++ b/src/apps/cosmos/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cosmos • Solar System Simulator</title>
     <link rel="stylesheet" href="./styles.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.162/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162/examples/jsm/"
+        }
+      }
+    </script>
   </head>
   <body>
     <div class="cosmos-app">

--- a/src/apps/cosmos/main.js
+++ b/src/apps/cosmos/main.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.162/build/three.module.js';
-import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.162/examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { loadBodyData, createBodyMeshes, createSunLight, updateBodyMeshes } from './bodies.js';
 import { SolarSystemSimulation, SCALE } from './simulation.js';
 import { setupControlPanel } from './controls.js';


### PR DESCRIPTION
## Summary
- add an import map to the Cosmos app entry page pointing three.js specifiers at the CDN modules
- update Cosmos main module to use the new three.js and OrbitControls import specifiers

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68d1d6a75ac8832ba5b3a2c0672c95e0