### PR TITLE
Add LangMath natural-language calculator subapp

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -90,6 +90,12 @@ Cosmos Simulator shrinks the solar system by 1×10⁻⁹ and renders it with Thr
 - Experiment with post-processing bloom for the sun and motion blur for orbital trails.
 - Persist custom gravity and time-speed presets to revisit favourite slow-motion or accelerated scenarios.
 
+## LangMath
+LangMath converts short natural-language math prompts into validated arithmetic expressions and evaluates them entirely in-browser through Pyodide. It recognises number words from zero through fifty, strips punctuation, and applies Python’s operator precedence so conversational questions return precise answers with a single tap.
+- Extend the vocabulary past fifty and introduce fractions or negative values for broader coverage.
+- Offer inline hints when parsing fails, suggesting supported operator phrasing.
+- Cache the Pyodide runtime between sessions to shorten subsequent cold starts.
+
 ## Cache Lab
 Cache Lab embeds the dedicated cache-learning subapp that lives under `/cache-lab`. Eight mini-modules cover mapping, replacement, parameter sweeps, locality visualisation, miss classification, hierarchy exploration, pipeline impact, and trace loading. Auxiliary tabs (Learn, Experiment, Assess, Dashboard) guide newcomers, let advanced users tinker, and track quiz progress with localStorage persistence.
 - Ship more visualisations (e.g., animated heatmaps) for large traces while maintaining performance.

--- a/docs/GITSTORY.md
+++ b/docs/GITSTORY.md
@@ -13,3 +13,4 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 - 2025-10-07 — feature+docs — Added Zen Go with a WebAssembly GNU Go engine, handicap presets, and launcher/documentation updates.
 - 2025-10-12 — feature+docs — Added Cosmos solar system simulator with Three.js physics subapp, launcher integration, and refreshed docs.
 - 2025-10-18 — removal — Retired the Chessboard Summit experience and deleted associated assets, tests, and documentation.
+- 2025-10-20 — feature+docs — Added LangMath natural-language calculator with Pyodide evaluation, launcher wiring, and refreshed documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Gif coming soon
 * **Quantum Playground**: design interactive circuits, run a four-qubit simulator, and visualize measurements.
 * **Cache Lab**: explore cache mapping, replacement, hierarchy, and assessments via `/cache-lab`.
 * **Cosmos Simulator**: orbit a scaled solar system with live Newtonian physics and camera fly-to controls.
+* **LangMath**: convert natural-language arithmetic into validated expressions evaluated with Pyodide.
 
 ---
 

--- a/src/apps/LangMathApp/LangMathApp.css
+++ b/src/apps/LangMathApp/LangMathApp.css
@@ -1,0 +1,108 @@
+.lang-math-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  color: #1d1f35;
+}
+
+.lang-math-intro {
+  display: grid;
+  gap: 1rem;
+  padding: 1.75rem;
+  background: linear-gradient(135deg, rgba(238, 240, 255, 0.9), rgba(210, 216, 255, 0.95));
+  border-radius: 22px;
+  box-shadow: 0 24px 50px -45px rgba(55, 63, 142, 0.6);
+}
+
+.lang-math-intro h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  color: #22244b;
+}
+
+.lang-math-intro p {
+  margin: 0;
+  line-height: 1.7;
+  color: #4d5078;
+}
+
+.lang-math-points {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #5a5f85;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.lang-math-frame {
+  width: 100%;
+  min-height: clamp(480px, 68vh, 720px);
+  border: none;
+  border-radius: 22px;
+  box-shadow: 0 32px 55px -45px rgba(47, 57, 128, 0.58);
+  background: radial-gradient(circle at top, #f9f9ff 0%, #e7ebff 100%);
+}
+
+.lang-math-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.lang-math-link,
+.lang-math-back {
+  border-radius: 999px;
+  padding: 0.75rem 1.3rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lang-math-link {
+  background: rgba(108, 92, 231, 0.12);
+  color: #4c45c8;
+  box-shadow: 0 18px 32px -28px rgba(76, 69, 200, 0.7);
+}
+
+.lang-math-link:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px -32px rgba(76, 69, 200, 0.72);
+  background: rgba(108, 92, 231, 0.18);
+}
+
+.lang-math-back {
+  background: #22244b;
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 20px 42px -32px rgba(25, 27, 58, 0.65);
+}
+
+.lang-math-back:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 48px -36px rgba(25, 27, 58, 0.7);
+}
+
+@media (max-width: 720px) {
+  .lang-math-frame {
+    min-height: 520px;
+  }
+
+  .lang-math-intro {
+    padding: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lang-math-link,
+  .lang-math-back {
+    transition: none;
+  }
+}

--- a/src/apps/LangMathApp/LangMathApp.js
+++ b/src/apps/LangMathApp/LangMathApp.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import './LangMathApp.css';
+
+const LangMathApp = ({ onBack }) => {
+  const base = process.env.PUBLIC_URL || '';
+  const appUrl = `${base}/apps/lang-math/`;
+
+  return (
+    <div className="lang-math-wrapper">
+      <section className="lang-math-intro">
+        <div>
+          <h1>LangMath</h1>
+          <p>
+            Translate natural language arithmetic into precise calculations. Enter number words up to fifty,
+            combine operators like “plus”, “minus”, “times”, or “divided by”, and let the embedded Pyodide
+            runtime evaluate the expression entirely in your browser.
+          </p>
+        </div>
+        <ul className="lang-math-points">
+          <li>Understands zero through fifty, including hyphenated tens like “twenty three”.</li>
+          <li>Guards against unsafe tokens by sanitising expressions before evaluation.</li>
+          <li>Runs Python’s evaluator client-side via WebAssembly for consistent precedence.</li>
+        </ul>
+      </section>
+
+      <iframe
+        src={appUrl}
+        title="LangMath Natural Language Calculator"
+        className="lang-math-frame"
+        loading="lazy"
+      />
+
+      <div className="lang-math-actions">
+        <a className="lang-math-link" href={appUrl} target="_blank" rel="noreferrer">
+          Open full window ↗
+        </a>
+        <button type="button" className="lang-math-back" onClick={onBack}>
+          ← Back to Apps
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LangMathApp;

--- a/src/apps/LangMathApp/index.js
+++ b/src/apps/LangMathApp/index.js
@@ -1,0 +1,1 @@
+export { default } from './LangMathApp';

--- a/src/apps/lang-math/index.html
+++ b/src/apps/lang-math/index.html
@@ -1,0 +1,500 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LangMath Calculator</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", "SF Pro Display", "Segoe UI", sans-serif;
+        background: #f2f4ff;
+        min-height: 100%;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2.5rem 1.25rem;
+        background: radial-gradient(circle at top, #f9f9ff 0%, #eef1ff 65%, #e6ebff 100%);
+        color: #1f2146;
+      }
+
+      main {
+        width: min(520px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        background: rgba(255, 255, 255, 0.92);
+        border-radius: 20px;
+        padding: 2.5rem 2rem;
+        box-shadow: 0 34px 55px -45px rgba(56, 49, 235, 0.65), 0 18px 45px -35px rgba(15, 16, 60, 0.55);
+        backdrop-filter: blur(6px);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.75rem, 5vw, 2.3rem);
+        letter-spacing: -0.01em;
+      }
+
+      p {
+        margin: 0;
+        line-height: 1.6;
+        color: #5b5e7c;
+      }
+
+      .input-label {
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 600;
+        color: #7a7fb1;
+      }
+
+      .input-row {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      input[type="text"] {
+        flex: 1 1 auto;
+        padding: 0.9rem 1.05rem;
+        border-radius: 14px;
+        border: 1px solid rgba(119, 126, 173, 0.35);
+        background: rgba(248, 249, 255, 0.9);
+        font-size: 1.05rem;
+        color: #22244c;
+        transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      }
+
+      input[type="text"]::placeholder {
+        color: rgba(121, 124, 160, 0.68);
+      }
+
+      input[type="text"]:focus {
+        outline: none;
+        border-color: rgba(104, 93, 241, 0.9);
+        box-shadow: 0 18px 38px -30px rgba(104, 93, 241, 0.8), 0 0 0 3px rgba(104, 93, 241, 0.18);
+        transform: translateY(-1px);
+      }
+
+      button {
+        flex: 0 0 auto;
+        border: none;
+        border-radius: 14px;
+        padding: 0.92rem 1.55rem;
+        background: linear-gradient(135deg, #6c5ce7, #7f6bff);
+        color: white;
+        font-size: 1rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease, opacity 150ms ease;
+        box-shadow: 0 24px 35px -28px rgba(108, 92, 231, 0.95);
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+        box-shadow: none;
+        transform: none;
+      }
+
+      button:not(:disabled):hover {
+        transform: translateY(-1.5px);
+        box-shadow: 0 28px 42px -30px rgba(96, 84, 225, 0.95);
+      }
+
+      button:not(:disabled):active {
+        transform: translateY(0);
+      }
+
+      .result-box {
+        border-radius: 14px;
+        padding: 1rem 1.15rem;
+        min-height: 3.25rem;
+        display: flex;
+        align-items: center;
+        background: rgba(243, 245, 255, 0.85);
+        border: 1px solid rgba(123, 130, 200, 0.25);
+        color: #31345f;
+        font-size: 1.05rem;
+        transition: background 200ms ease, color 200ms ease, border-color 200ms ease;
+      }
+
+      .result-box[data-state="loading"] {
+        font-style: italic;
+        color: #676b94;
+      }
+
+      .result-box[data-state="error"] {
+        background: rgba(255, 235, 238, 0.9);
+        border-color: rgba(220, 85, 98, 0.4);
+        color: #c2404d;
+      }
+
+      .result-box[data-state="result"] {
+        background: rgba(224, 255, 243, 0.92);
+        border-color: rgba(74, 201, 134, 0.45);
+        color: #1f7d52;
+        font-weight: 600;
+      }
+
+      .result-box[data-state="info"] {
+        background: rgba(237, 239, 255, 0.88);
+        border-color: rgba(131, 137, 211, 0.35);
+      }
+
+      .result-box.pulse {
+        animation: resultPulse 650ms ease;
+      }
+
+      @keyframes resultPulse {
+        0% {
+          box-shadow: 0 0 0 0 rgba(108, 92, 231, 0.18);
+        }
+        100% {
+          box-shadow: 0 0 0 28px rgba(108, 92, 231, 0);
+        }
+      }
+
+      @media (max-width: 640px) {
+        body {
+          padding: 2rem 1rem;
+        }
+
+        main {
+          padding: 2rem 1.5rem;
+        }
+
+        .input-row {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        button {
+          width: 100%;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 1ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0ms !important;
+          scroll-behavior: auto !important;
+        }
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>LangMath</h1>
+        <p>Speak your arithmetic. Try phrases like “twenty one times four” or “nine plus six”.</p>
+      </header>
+
+      <label class="input-label" for="langmath-query">Math prompt</label>
+      <div class="input-row">
+        <input
+          id="langmath-query"
+          type="text"
+          inputmode="text"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="e.g. forty two divided by six"
+          aria-describedby="langmath-result"
+        />
+        <button id="langmath-button" type="button">Calculate</button>
+      </div>
+
+      <div class="result-box" id="langmath-result" role="status" aria-live="polite" data-state="loading">
+        <span id="langmath-result-text">Loading Python runtime…</span>
+      </div>
+    </main>
+
+    <script>
+      (function () {
+        const input = document.getElementById('langmath-query');
+        const button = document.getElementById('langmath-button');
+        const resultBox = document.getElementById('langmath-result');
+        const resultText = document.getElementById('langmath-result-text');
+
+        const operatorMap = {
+          plus: '+',
+          minus: '-',
+          times: '*',
+          multiplied_by: '*',
+          divided_by: '/',
+        };
+
+        const skipTokens = new Set(['and']);
+
+        const onesMap = {
+          zero: 0,
+          one: 1,
+          two: 2,
+          three: 3,
+          four: 4,
+          five: 5,
+          six: 6,
+          seven: 7,
+          eight: 8,
+          nine: 9,
+          ten: 10,
+          eleven: 11,
+          twelve: 12,
+          thirteen: 13,
+          fourteen: 14,
+          fifteen: 15,
+          sixteen: 16,
+          seventeen: 17,
+          eighteen: 18,
+          nineteen: 19,
+        };
+
+        const tensMap = {
+          twenty: 20,
+          thirty: 30,
+          forty: 40,
+          fifty: 50,
+        };
+
+        const pyodideReady = loadPyodide({ indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/' });
+
+        let runtimeReady = false;
+
+        const setResult = (message, state) => {
+          resultBox.dataset.state = state;
+          resultText.textContent = message;
+          resultBox.classList.remove('pulse');
+          void resultBox.offsetWidth;
+          resultBox.classList.add('pulse');
+        };
+
+        const sanitizeExpression = (expression) => {
+          return /^[\d\s+\-*/]+$/.test(expression);
+        };
+
+        const consumeNumber = (tokens, startIndex) => {
+          const current = tokens[startIndex];
+
+          if (/^\d+$/.test(current)) {
+            const numeric = Number.parseInt(current, 10);
+            if (!Number.isFinite(numeric) || numeric < 0 || numeric > 50) {
+              return null;
+            }
+            return { value: numeric, consumed: 1 };
+          }
+
+          if (Object.prototype.hasOwnProperty.call(onesMap, current)) {
+            return { value: onesMap[current], consumed: 1 };
+          }
+
+          if (Object.prototype.hasOwnProperty.call(tensMap, current)) {
+            let value = tensMap[current];
+            let consumed = 1;
+            const next = tokens[startIndex + 1];
+            if (next && Object.prototype.hasOwnProperty.call(onesMap, next)) {
+              const onesValue = onesMap[next];
+              if (onesValue >= 10) {
+                return null;
+              }
+              if (value === 50 && onesValue > 0) {
+                return null;
+              }
+              value += onesValue;
+              consumed = 2;
+            }
+            if (value > 50) {
+              return null;
+            }
+            return { value, consumed };
+          }
+
+          return null;
+        };
+
+        const parseQuery = (raw) => {
+          if (!raw) {
+            return null;
+          }
+
+          let prepared = raw
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, ' ')
+            .replace(/-/g, ' ')
+            .replace(/multiplied\s+by/g, 'multiplied_by')
+            .replace(/divided\s+by/g, 'divided_by')
+            .replace(/\s+/g, ' ')
+            .trim();
+
+          if (!prepared) {
+            return null;
+          }
+
+          const tokens = prepared.split(' ').filter(Boolean);
+          const pieces = [];
+          let expectingNumber = true;
+          let index = 0;
+
+          while (index < tokens.length) {
+            const token = tokens[index];
+
+            if (skipTokens.has(token)) {
+              index += 1;
+              continue;
+            }
+
+            if (expectingNumber) {
+              const numberResult = consumeNumber(tokens, index);
+              if (!numberResult) {
+                return null;
+              }
+              pieces.push(String(numberResult.value));
+              index += numberResult.consumed;
+              expectingNumber = false;
+              continue;
+            }
+
+            if (!Object.prototype.hasOwnProperty.call(operatorMap, token)) {
+              return null;
+            }
+
+            pieces.push(operatorMap[token]);
+            index += 1;
+            expectingNumber = true;
+          }
+
+          if (!pieces.length || expectingNumber) {
+            return null;
+          }
+
+          const expression = pieces.join(' ');
+          if (!sanitizeExpression(expression)) {
+            return null;
+          }
+
+          return expression;
+        };
+
+        const formatResult = (value) => {
+          const numeric = Number(value);
+          if (Number.isFinite(numeric)) {
+            if (Number.isInteger(numeric)) {
+              return numeric.toString();
+            }
+            const trimmed = Number.parseFloat(numeric.toFixed(6));
+            return trimmed.toString();
+          }
+          return value;
+        };
+
+        const handleCalculation = async () => {
+          const query = input.value.trim();
+          if (!query) {
+            setResult('Enter a math question using words to evaluate it.', 'info');
+            input.focus();
+            return;
+          }
+
+          const expression = parseQuery(query);
+          if (!expression) {
+            setResult('Could not parse query', 'error');
+            return;
+          }
+
+          if (!runtimeReady) {
+            setResult('Runtime still loading. Please wait a moment…', 'loading');
+            return;
+          }
+
+          setResult('Calculating…', 'loading');
+          button.disabled = true;
+
+          try {
+            const pyodide = await pyodideReady;
+            const python = `from math import *\nresult = eval(${JSON.stringify(expression)})\nstr(result)`;
+            let outcome;
+            try {
+              outcome = pyodide.runPython(python);
+            } catch (error) {
+              setResult('Invalid math expression', 'error');
+              console.error('[LangMath] Evaluation error', error);
+              return;
+            }
+
+            const message = formatResult(outcome);
+            setResult(message, 'result');
+          } finally {
+            button.disabled = false;
+          }
+        };
+
+        button.disabled = true;
+        setResult('Loading Python runtime…', 'loading');
+
+        pyodideReady
+          .then((pyodide) => {
+            runtimeReady = true;
+            button.disabled = false;
+            setResult('Ready when you are! Try “six times seven”.', 'info');
+            if (!input.value) {
+              input.focus();
+            }
+
+            const smokeTests = [
+              { input: 'two plus two', expected: '4' },
+              { input: 'thirteen minus eight', expected: '5' },
+              { input: 'six times seven', expected: '42' },
+              { input: 'forty divided by five', expected: '8' },
+            ];
+
+            smokeTests.forEach((test) => {
+              const expression = parseQuery(test.input);
+              if (!expression) {
+                console.warn('[LangMath] Failed to parse sample input:', test.input);
+                return;
+              }
+
+              try {
+                const python = `from math import *\nresult = eval(${JSON.stringify(expression)})\nstr(result)`;
+                const output = pyodide.runPython(python);
+                const formatted = formatResult(output);
+                const pass = formatted === test.expected;
+                console[pass ? 'info' : 'warn'](
+                  `[LangMath] Sample ${pass ? 'pass' : 'mismatch'} — "${test.input}" = ${formatted} (expected ${test.expected})`
+                );
+              } catch (error) {
+                console.error('[LangMath] Sample evaluation failed:', test.input, error);
+              }
+            });
+          })
+          .catch((error) => {
+            console.error('[LangMath] Failed to load Pyodide', error);
+            setResult('Could not start Python runtime', 'error');
+          });
+
+        button.addEventListener('click', handleCalculation);
+        input.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            handleCalculation();
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/src/apps/registry.js
+++ b/src/apps/registry.js
@@ -104,6 +104,19 @@ export const APP_REGISTRY = {
     created: '2025-09-22',
     featured: true,
   }),
+  'lang-math': withDefaults({
+    id: 'lang-math',
+    title: 'LangMath',
+    description: 'Turn number words and operator phrases into live calculations using client-side Python.',
+    icon: '🧮',
+    category: 'Education',
+    component: null,
+    loader: () => import('./LangMathApp'),
+    path: '/apps/lang-math',
+    tags: ['calculator', 'language', 'python', 'education'],
+    created: '2025-10-20',
+    featured: true,
+  }),
   // Placeholder for future apps
   'n-pomodoro': withDefaults({
     id: 'n-pomodoro',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,7 @@ module.exports = {
           'apps/cat-typing-speed-test'
         );
         addCopyPattern(patterns, ['apps/cosmos', 'src/apps/cosmos'], 'apps/cosmos');
+        addCopyPattern(patterns, ['src/apps/lang-math'], 'apps/lang-math');
         addCopyPattern(patterns, ['apps/zen-go', 'src/apps/zen-go'], 'apps/zen-go');
 
         const cacheLabSource = path.resolve(__dirname, 'src/apps/cache-lab/dist');


### PR DESCRIPTION
## Summary
- add a standalone LangMath natural-language calculator with inline styling, parsing, and Pyodide-powered evaluation
- wrap the calculator in a launcher-friendly LangMathApp, register it, and copy static assets for builds
- document the new experience across the app catalog, README, and git history log

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d1d96bb084832b993f22b716579c48