### PR TITLE
Scale Cat Nap Leap HUD to 30%

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -15,7 +15,8 @@
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
-  padding: 1.25rem;
+  --catnap-hud-scale: 0.3;
+  padding: calc(1.25rem * var(--catnap-hud-scale));
   pointer-events: none;
   z-index: 2;
 }
@@ -28,6 +29,8 @@
   align-items: stretch;
   width: 100%;
   max-width: 420px;
+  transform: scale(var(--catnap-hud-scale));
+  transform-origin: top left;
 }
 
 .catnap-hud-panel,

--- a/src/apps/CatNapLeapApp/CatNapLeapApp.js
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.js
@@ -119,8 +119,9 @@ const SHOP_ITEMS = [
 ];
 
 
-const COMPACT_HUD_HEIGHT = 44;
-const HUD_SAFE_ZONE = COMPACT_HUD_HEIGHT + 16;
+const HUD_SCALE = 0.3;
+const COMPACT_HUD_HEIGHT = 44 * HUD_SCALE;
+const HUD_SAFE_ZONE = COMPACT_HUD_HEIGHT + 16 * HUD_SCALE;
 const SHOP_ITEM_LABELS = SHOP_ITEMS.reduce((acc, item) => {
   acc[item.id] = item.name;
   return acc;


### PR DESCRIPTION
## Summary
- add a HUD_SCALE constant so Cat Nap Leap gameplay logic accounts for a 30% sized overlay
- shrink the HUD overlay via CSS transforms and scaled padding variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e6529a3c832b8adcc3112dbbba89