### PR TITLE
Add random app launch control

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -172,6 +172,26 @@
   transform: translateY(-2px);
 }
 
+.random-launch-btn {
+  padding: 12px 16px;
+  border: 2px solid #e1e5e9;
+  background: white;
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.random-launch-btn:hover,
+.random-launch-btn:focus {
+  border-color: #667eea;
+  transform: translateY(-2px);
+  outline: none;
+}
+
 .settings-btn {
   display: inline-flex;
   align-items: center;

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -290,10 +290,34 @@ const AppLauncher = () => {
     });
   };
 
-  const handleAppClick = (app) => {
-    if (app.disabled) return;
+  const handleAppClick = useCallback((app) => {
+    if (!app || app.disabled) {
+      return;
+    }
     navigate(app.path);
-  };
+  }, [navigate]);
+
+  const handleRandomLaunch = useCallback(() => {
+    const candidatesSource = filteredApps.length > 0 ? filteredApps : allApps;
+    const launchableApps = candidatesSource.filter((app) => !app.disabled);
+
+    if (launchableApps.length === 0) {
+      return;
+    }
+
+    const randomIndex = Math.floor(Math.random() * launchableApps.length);
+    const randomApp = launchableApps[randomIndex];
+
+    if (!randomApp) {
+      return;
+    }
+
+    if (handleAppClick) {
+      handleAppClick(randomApp);
+    } else {
+      navigate(randomApp.path);
+    }
+  }, [allApps, filteredApps, handleAppClick, navigate]);
 
   const handleGistInputChange = (field) => (event) => {
     const { value } = event.target;
@@ -408,6 +432,14 @@ const AppLauncher = () => {
           </div>
 
           <div className="view-controls">
+            <button
+              type="button"
+              className="random-launch-btn"
+              onClick={handleRandomLaunch}
+              aria-label="Launch a random app"
+            >
+              🎲
+            </button>
             <div className="view-toggle-group">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- add a memoized random launch handler that navigates to an enabled app from the current or full catalog
- introduce a dice button in the launcher controls wired to the random launch helper
- style the random launch button so it matches the existing view toggle buttons

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e88d495c832bbffa01d8f07a191c