### PR TITLE
Refine N-Pomodoro planner with modal session editor

### DIFF
--- a/src/apps/NPomodoroApp/NPomodoroApp.css
+++ b/src/apps/NPomodoroApp/NPomodoroApp.css
@@ -212,7 +212,7 @@ body.n-pomodoro-focus-active {
 .session-stack {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 14px;
   overflow-y: auto;
   padding-right: 6px;
   max-height: calc(100vh - 360px);
@@ -227,45 +227,179 @@ body.n-pomodoro-focus-active {
   border-radius: 999px;
 }
 
-.session-card {
+.session-preview {
   position: relative;
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.05);
-  box-shadow: 0 18px 46px rgba(8, 10, 28, 0.45);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.07);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.25s ease, box-shadow 0.25s ease,
+    background 0.25s ease, border-color 0.25s ease;
 }
 
-.session-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid transparent;
-  transition: border-color 0.3s ease, opacity 0.3s ease;
-  opacity: 0;
+.session-preview:hover,
+.session-preview:focus-visible {
+  outline: none;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 16px 36px rgba(8, 10, 28, 0.45);
+  transform: translateY(-1px);
 }
 
-.session-card.active {
-  transform: translateY(-4px);
-  border-color: rgba(255, 255, 255, 0.16);
-  box-shadow: 0 28px 70px rgba(12, 15, 40, 0.55);
-}
-
-.session-card.active::before {
+.session-preview.editing {
   border-color: var(--session-accent, #7f5af0);
-  opacity: 0.55;
+  box-shadow: 0 20px 40px rgba(18, 12, 48, 0.55);
+  transform: translateY(-2px);
 }
 
-.session-card-header {
+.session-preview.active:not(.editing) {
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.session-preview.focused {
+  background: rgba(127, 90, 240, 0.16);
+  border-color: var(--session-accent, #7f5af0);
+  box-shadow: 0 0 0 2px var(--session-accent, #7f5af0),
+    0 18px 42px rgba(18, 12, 48, 0.5);
+}
+
+.session-preview-accent {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--session-accent, #7f5af0);
+  box-shadow: 0 0 0 6px rgba(127, 90, 240, 0.2);
+  flex-shrink: 0;
+}
+
+.session-preview-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.session-preview-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-preview-meta {
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.session-preview-indicator {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.session-editor-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
   display: flex;
   align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 5vw, 48px);
+  background: rgba(5, 8, 24, 0.72);
+  backdrop-filter: blur(16px);
+}
+
+.session-editor-shell {
+  position: relative;
+  width: min(560px, 92vw);
+  max-height: min(720px, 90vh);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(24px, 4vw, 34px);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(14, 18, 46, 0.9);
+  box-shadow: 0 40px 120px rgba(6, 8, 30, 0.65);
+}
+
+.session-editor-shell::before {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
+}
+
+.session-editor-header {
+  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 16px;
+}
+
+.session-editor-title {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.session-editor-close {
+  appearance: none;
+  border: none;
+  border-radius: 12px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.session-editor-close:hover,
+.session-editor-close:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.session-editor-actions {
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
+}
+
+.session-editor-shell .block-editor {
+  max-height: min(360px, 55vh);
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.session-editor-shell .block-editor::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-editor-shell .block-editor::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
 }
 
 .session-name-input {
@@ -340,6 +474,13 @@ body.n-pomodoro-focus-active {
 .session-remove-btn:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px rgba(8, 10, 28, 0.35);
+}
+
+.session-focus-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .session-remove-btn:disabled {

--- a/src/apps/NPomodoroApp/NPomodoroApp.js
+++ b/src/apps/NPomodoroApp/NPomodoroApp.js
@@ -95,6 +95,7 @@ const NPomodoroApp = () => {
     return window.innerWidth >= 960;
   });
   const [isFocusMode, setIsFocusMode] = useState(false);
+  const [editingSessionId, setEditingSessionId] = useState(null);
 
   const intervalRef = useRef(null);
 
@@ -107,11 +108,32 @@ const NPomodoroApp = () => {
     }
     return `${accentColor}33`;
   }, [accentColor]);
+  const editingSessionIndex = useMemo(
+    () => sessions.findIndex((session) => session.id === editingSessionId),
+    [sessions, editingSessionId]
+  );
+  const editingSession =
+    editingSessionIndex >= 0 ? sessions[editingSessionIndex] : null;
+  const editingSessionMinutes = useMemo(() => {
+    if (!editingSession) return 0;
+    return editingSession.blocks.reduce((acc, block) => acc + block.minutes, 0);
+  }, [editingSession]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
   }, [sessions]);
+
+  useEffect(() => {
+    if (!editingSessionId) return undefined;
+    const stillExists = sessions.some(
+      (session) => session.id === editingSessionId
+    );
+    if (!stillExists) {
+      setEditingSessionId(null);
+    }
+    return undefined;
+  }, [sessions, editingSessionId]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
@@ -147,6 +169,17 @@ const NPomodoroApp = () => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isFocusMode]);
+
+  useEffect(() => {
+    if (!editingSessionId || typeof window === 'undefined') return undefined;
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape' && !isFocusMode) {
+        setEditingSessionId(null);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [editingSessionId, isFocusMode]);
 
   const totalSeconds = useMemo(
     () =>
@@ -246,6 +279,10 @@ const NPomodoroApp = () => {
 
   const exitFocusMode = useCallback(() => {
     setIsFocusMode(false);
+  }, []);
+
+  const closeSessionEditor = useCallback(() => {
+    setEditingSessionId(null);
   }, []);
 
   const handleFocusSession = useCallback(
@@ -410,6 +447,7 @@ const NPomodoroApp = () => {
   };
 
   const addSession = () => {
+    let createdSession = null;
     setSessions((prev) => {
       const sessionNumber = prev.length + 1;
       const focusColor = colorPalette[sessionNumber % colorPalette.length];
@@ -431,8 +469,12 @@ const NPomodoroApp = () => {
           }
         ]
       };
+      createdSession = newSession;
       return [...prev, newSession];
     });
+    if (createdSession) {
+      setEditingSessionId(createdSession.id);
+    }
     setIsComplete(false);
   };
 
@@ -475,6 +517,9 @@ const NPomodoroApp = () => {
       setIsPaused(false);
       setIsComplete(false);
       setIsFocusMode(false);
+    }
+    if (sessionId === editingSessionId) {
+      setEditingSessionId(null);
     }
   };
 
@@ -549,6 +594,7 @@ const NPomodoroApp = () => {
     setIsPaused(false);
     setIsComplete(false);
     setIsFocusMode(false);
+    setEditingSessionId(null);
     if (typeof window !== 'undefined') {
       window.localStorage.removeItem(STORAGE_KEY);
     }
@@ -793,123 +839,32 @@ const NPomodoroApp = () => {
                 );
                 const isActiveSession = index === currentSessionIndex;
                 const isSessionFocused = isActiveSession && isFocusMode;
+                const isEditing = session.id === editingSessionId;
+                const accent = session.blocks[0]?.color || '#7F5AF0';
                 return (
-                  <div
+                  <button
                     key={session.id}
-                    className={`session-card ${
+                    type="button"
+                    className={`session-preview ${
                       isActiveSession ? 'active' : ''
+                    } ${isEditing ? 'editing' : ''} ${
+                      isSessionFocused ? 'focused' : ''
                     }`}
-                    data-testid="session-card"
-                    style={{ '--session-accent': session.blocks[0]?.color || '#7F5AF0' }}
+                    data-testid="session-preview"
+                    style={{ '--session-accent': accent }}
+                    onClick={() => setEditingSessionId(session.id)}
+                    aria-haspopup="dialog"
                   >
-                    <div className="session-card-header">
-                      <input
-                        className="session-name-input"
-                        value={session.name}
-                        onChange={(event) =>
-                          updateSessionName(session.id, event.target.value)
-                        }
-                      />
-                      <span className="session-duration">{totalMinutes} min</span>
-                    </div>
-                    <div className="session-card-actions">
-                      <button
-                        type="button"
-                        className={`session-focus-btn ${
-                          isSessionFocused ? 'active' : ''
-                        }`}
-                        onClick={() => handleFocusSession(index)}
-                        aria-pressed={isSessionFocused}
-                      >
-                        {isSessionFocused ? 'Exit focus' : 'Focus session'}
-                      </button>
-                      <button
-                        type="button"
-                        className="session-remove-btn"
-                        onClick={() => removeSession(session.id)}
-                        disabled={sessions.length <= 1}
-                      >
-                        Remove
-                      </button>
-                    </div>
-                    <div className="block-editor">
-                      {session.blocks.map((block, blockIndex) => (
-                        <div
-                          key={block.id}
-                          className={`block-row ${
-                            index === currentSessionIndex &&
-                            blockIndex === currentBlockIndex
-                              ? 'current'
-                              : ''
-                          }`}
-                          data-testid="block-row"
-                        >
-                          <button
-                            type="button"
-                            className="block-handle"
-                            onClick={() => focusBlock(index, blockIndex)}
-                          >
-                            {blockIndex + 1}
-                          </button>
-                          <input
-                            className="block-name-input"
-                            value={block.name}
-                            onChange={(event) =>
-                              updateBlock(session.id, block.id, {
-                                name: event.target.value
-                              })
-                            }
-                          />
-                          <div className="block-duration-input">
-                            <input
-                              type="number"
-                              min="1"
-                              max="999"
-                              value={block.minutes}
-                              onChange={(event) => {
-                                const value = Math.max(
-                                  1,
-                                  Math.min(
-                                    999,
-                                    parseInt(event.target.value, 10) || 0
-                                  )
-                                );
-                                updateBlock(session.id, block.id, {
-                                  minutes: value
-                                });
-                              }}
-                            />
-                            <span>min</span>
-                          </div>
-                          <input
-                            type="color"
-                            className="block-color-input"
-                            value={block.color}
-                            onChange={(event) =>
-                              updateBlock(session.id, block.id, {
-                                color: event.target.value
-                              })
-                            }
-                          />
-                          <button
-                            type="button"
-                            className="block-remove-btn"
-                            onClick={() => removeBlock(session.id, block.id)}
-                            disabled={session.blocks.length <= 1}
-                          >
-                            ✕
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                    <button
-                      type="button"
-                      className="add-block-btn"
-                      onClick={() => addBlock(session.id)}
-                    >
-                      + Add block
-                    </button>
-                  </div>
+                    <span className="session-preview-accent" aria-hidden="true" />
+                    <span className="session-preview-content">
+                      <span className="session-preview-name">{session.name}</span>
+                      <span className="session-preview-meta">
+                        {totalMinutes} min · {session.blocks.length}{' '}
+                        {session.blocks.length === 1 ? 'block' : 'blocks'}
+                      </span>
+                    </span>
+                    <span className="session-preview-indicator">Edit</span>
+                  </button>
                 );
               })}
             </div>
@@ -968,6 +923,154 @@ const NPomodoroApp = () => {
             />
           )}
         </div>
+
+        {editingSession && (
+          <div
+            className="session-editor-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Edit ${editingSession.name}`}
+            data-testid="session-editor-modal"
+            onClick={closeSessionEditor}
+          >
+            <div
+              className="session-editor-shell"
+              style={{
+                '--session-accent':
+                  editingSession.blocks[0]?.color || '#7F5AF0'
+              }}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div className="session-editor-header">
+                <div className="session-editor-title">
+                  <input
+                    className="session-name-input"
+                    value={editingSession.name}
+                    onChange={(event) =>
+                      updateSessionName(editingSession.id, event.target.value)
+                    }
+                    autoFocus
+                  />
+                  <span className="session-duration">
+                    {editingSessionMinutes} min planned
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className="session-editor-close"
+                  onClick={closeSessionEditor}
+                  aria-label="Close session editor"
+                >
+                  ✕
+                </button>
+              </div>
+              <div className="session-editor-actions">
+                <button
+                  type="button"
+                  className={`session-focus-btn ${
+                    editingSessionIndex === currentSessionIndex && isFocusMode
+                      ? 'active'
+                      : ''
+                  }`}
+                  onClick={() => handleFocusSession(editingSessionIndex)}
+                  aria-pressed={
+                    editingSessionIndex === currentSessionIndex && isFocusMode
+                  }
+                  disabled={editingSessionIndex === -1}
+                >
+                  {editingSessionIndex === currentSessionIndex && isFocusMode
+                    ? 'Exit focus'
+                    : 'Focus session'}
+                </button>
+                <button
+                  type="button"
+                  className="session-remove-btn"
+                  onClick={() => removeSession(editingSession.id)}
+                  disabled={sessions.length <= 1}
+                >
+                  Remove session
+                </button>
+              </div>
+              <div className="block-editor">
+                {editingSession.blocks.map((block, blockIndex) => (
+                  <div
+                    key={block.id}
+                    className={`block-row ${
+                      editingSessionIndex === currentSessionIndex &&
+                      blockIndex === currentBlockIndex
+                        ? 'current'
+                        : ''
+                    }`}
+                    data-testid="block-row"
+                  >
+                    <button
+                      type="button"
+                      className="block-handle"
+                      onClick={() => focusBlock(editingSessionIndex, blockIndex)}
+                    >
+                      {blockIndex + 1}
+                    </button>
+                    <input
+                      className="block-name-input"
+                      value={block.name}
+                      onChange={(event) =>
+                        updateBlock(editingSession.id, block.id, {
+                          name: event.target.value
+                        })
+                      }
+                    />
+                    <div className="block-duration-input">
+                      <input
+                        type="number"
+                        min="1"
+                        max="999"
+                        value={block.minutes}
+                        onChange={(event) => {
+                          const value = Math.max(
+                            1,
+                            Math.min(
+                              999,
+                              parseInt(event.target.value, 10) || 0
+                            )
+                          );
+                          updateBlock(editingSession.id, block.id, {
+                            minutes: value
+                          });
+                        }}
+                      />
+                      <span>min</span>
+                    </div>
+                    <input
+                      type="color"
+                      className="block-color-input"
+                      value={block.color}
+                      onChange={(event) =>
+                        updateBlock(editingSession.id, block.id, {
+                          color: event.target.value
+                        })
+                      }
+                    />
+                    <button
+                      type="button"
+                      className="block-remove-btn"
+                      onClick={() => removeBlock(editingSession.id, block.id)}
+                      disabled={editingSession.blocks.length <= 1}
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="add-block-btn"
+                onClick={() => addBlock(editingSession.id)}
+              >
+                + Add block
+              </button>
+            </div>
+          </div>
+        )}
 
         {isFocusMode && (
           <div

--- a/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
+++ b/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
@@ -17,8 +17,11 @@ describe('NPomodoroApp interactions', () => {
     render(<NPomodoroApp />);
     const user = userEvent.setup();
 
-    const sessionCards = screen.getAllByTestId('session-card');
-    const focusButton = within(sessionCards[0]).getByRole('button', {
+    const sessionPreviews = screen.getAllByTestId('session-preview');
+    await user.click(sessionPreviews[0]);
+
+    const editor = screen.getByTestId('session-editor-modal');
+    const focusButton = within(editor).getByRole('button', {
       name: /focus session/i
     });
 
@@ -33,21 +36,29 @@ describe('NPomodoroApp interactions', () => {
       expect(screen.queryByTestId('focus-mode-overlay')).not.toBeInTheDocument();
     });
     expect(focusButton).toHaveTextContent(/focus session/i);
+
+    const closeButton = within(editor).getByRole('button', {
+      name: /close session editor/i
+    });
+    await user.click(closeButton);
   });
 
   it('removes a session when the remove button is pressed', async () => {
     render(<NPomodoroApp />);
     const user = userEvent.setup();
 
-    const sessionCards = screen.getAllByTestId('session-card');
-    const secondSession = sessionCards[1];
-    expect(within(secondSession).getByDisplayValue(/midday flow/i)).toBeInTheDocument();
+    const sessionPreviews = screen.getAllByTestId('session-preview');
+    const secondSession = sessionPreviews[1];
+    expect(within(secondSession).getByText(/midday flow/i)).toBeInTheDocument();
 
-    const removeButton = within(secondSession).getByRole('button', { name: /remove/i });
+    await user.click(secondSession);
+
+    const editor = screen.getByTestId('session-editor-modal');
+    const removeButton = within(editor).getByRole('button', { name: /remove session/i });
     await user.click(removeButton);
 
     await waitFor(() => {
-      expect(screen.queryByDisplayValue(/midday flow/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/midday flow/i)).not.toBeInTheDocument();
     });
   });
 
@@ -55,17 +66,20 @@ describe('NPomodoroApp interactions', () => {
     render(<NPomodoroApp />);
     const user = userEvent.setup();
 
-    const initialSessionCard = screen.getAllByTestId('session-card')[0];
-    const initialBlocks = within(initialSessionCard).getAllByTestId('block-row');
-    const addBlockButton = within(initialSessionCard).getByRole('button', {
+    const sessionPreviews = screen.getAllByTestId('session-preview');
+    await user.click(sessionPreviews[0]);
+
+    const editor = screen.getByTestId('session-editor-modal');
+    const initialBlocks = within(editor).getAllByTestId('block-row');
+    const addBlockButton = within(editor).getByRole('button', {
       name: /\+ add block/i
     });
 
     await user.click(addBlockButton);
 
     await waitFor(() => {
-      const updatedSessionCard = screen.getAllByTestId('session-card')[0];
-      const updatedBlocks = within(updatedSessionCard).getAllByTestId('block-row');
+      const updatedEditor = screen.getByTestId('session-editor-modal');
+      const updatedBlocks = within(updatedEditor).getAllByTestId('block-row');
       expect(updatedBlocks).toHaveLength(initialBlocks.length + 1);
     });
   });


### PR DESCRIPTION
## Summary
- condense the session planner list to small previews that launch a dedicated modal editor for customizing sessions
- add styling for the centered session editor modal and refreshed planner preview appearance
- update NPomodoro tests to drive interactions through the modal workflow

## Testing
- npm test -- NPomodoroApp

------
https://chatgpt.com/codex/tasks/task_e_68d1f08563f0832b9165744a506c0a03