### PR TITLE
Handle null schedules in ZenDo task helpers

### DIFF
--- a/src/apps/ZenDoApp/__tests__/taskUtils.test.js
+++ b/src/apps/ZenDoApp/__tests__/taskUtils.test.js
@@ -1,0 +1,41 @@
+import { assignFocusBucket, assignTaskToDay } from '../taskUtils';
+
+describe('ZenDo task scheduling helpers', () => {
+  it('assignFocusBucket handles null schedule while updating focus metadata', () => {
+    const tasks = [
+      {
+        id: 't-1',
+        title: 'Legacy task',
+        schedule: null,
+      },
+    ];
+
+    const [updated] = assignFocusBucket(tasks, 't-1', 'deepWork', 3);
+
+    expect(updated.schedule).toEqual({
+      day: null,
+      order: 0,
+      focusBucket: 'deepWork',
+      focusOrder: 3,
+    });
+  });
+
+  it('assignTaskToDay handles null schedule while preserving focus defaults', () => {
+    const tasks = [
+      {
+        id: 't-2',
+        title: 'Legacy task',
+        schedule: null,
+      },
+    ];
+
+    const [updated] = assignTaskToDay(tasks, 't-2', 'monday', 1);
+
+    expect(updated.schedule).toEqual({
+      day: 'monday',
+      order: 1,
+      focusBucket: null,
+      focusOrder: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add normalizeSchedule utility to ensure scheduling metadata always has defaults
- update ZenDo scheduling helpers to use normalized schedules before spreading task data
- add regression tests covering null schedule handling for assignFocusBucket and assignTaskToDay

## Testing
- npm test -- --runTestsByPath src/apps/ZenDoApp/__tests__/taskUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1f47724f0832ba2088a0c1b08a586