### PR TITLE
Align CatNap canvas wrapper with canvas width

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.css
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.css
@@ -266,6 +266,8 @@
   overflow: hidden;
   box-shadow: 0 24px 40px rgba(47, 42, 69, 0.15);
   background: transparent;
+  width: fit-content;
+  margin: 0 auto;
 }
 
 .catnap-canvas {


### PR DESCRIPTION
## Summary
- keep the CatNap canvas wrapper sized to its content so the canvas width is respected
- center the wrapper within the CatNap app layout to remove the exposed gutter while keeping the HUD overlay aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1fbe455e0832b9a2b3d41ca60f45a