### PR TITLE
Refactor ZenDo weekly buckets into list layout

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -301,13 +301,16 @@
   padding: 1.5rem;
 }
 
-.zen-week-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+.zen-week-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
-.zen-week-column {
+.zen-week-row {
   background: rgba(255, 255, 255, 0.85);
   border-radius: 16px;
   padding: 0.75rem;
@@ -315,9 +318,10 @@
   flex-direction: column;
   gap: 0.75rem;
   box-shadow: inset 0 0 0 1px rgba(160, 204, 185, 0.3);
+  width: 100%;
 }
 
-.zen-week-column.is-today {
+.zen-week-row.is-today {
   box-shadow: 0 0 0 2px rgba(92, 168, 137, 0.6);
 }
 
@@ -345,6 +349,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  width: 100%;
 }
 
 .zen-week-card,

--- a/src/apps/ZenDoApp/views/LandingView.js
+++ b/src/apps/ZenDoApp/views/LandingView.js
@@ -114,12 +114,13 @@ const LandingView = ({
       </section>
       <section className="zen-column zen-week">
         <h2 className="zen-section-header">Weekly Buckets</h2>
-        <div className="zen-week-grid">
+        <ul className="zen-week-list">
           {DAY_ORDER.map((dayKey) => {
             const isToday = dayKey === todayKey;
             const assignments = dayAssignments[dayKey] || [];
+            const rowClassName = `zen-week-row${isToday ? ' is-today' : ''}`;
             return (
-              <div key={dayKey} className={`zen-week-column ${isToday ? 'is-today' : ''}`}>
+              <li key={dayKey} className={rowClassName}>
                 <div className="zen-week-header">
                   <span className="zen-weekday">{DAY_LABELS[dayKey]}</span>
                   {isToday && (
@@ -136,10 +137,10 @@ const LandingView = ({
                     </div>
                   ))}
                 </div>
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- render ZenDo weekly buckets as a semantic list of full-width rows while preserving drag-and-drop hooks
- refresh ZenDo weekly styling for stacked layout and ensure drop targets span the container

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d201700608832bb61a8efe423eda32