### PR TITLE
Fix ZenDo bucket drop cleanup for cloned tasks

### DIFF
--- a/src/apps/ZenDoApp/views/LandingView.js
+++ b/src/apps/ZenDoApp/views/LandingView.js
@@ -67,7 +67,19 @@ const LandingView = ({
             const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
             onReorderDay(day, order);
           }
-          evt.item.remove();
+          const cameFromClone =
+            evt.pullMode === 'clone' ||
+            evt.clone ||
+            evt.from?.classList?.contains('zen-task-tree');
+          if (cameFromClone) {
+            requestAnimationFrame(() => {
+              if (evt.item?.parentNode) {
+                evt.item.parentNode.removeChild(evt.item);
+              } else {
+                evt.item?.remove();
+              }
+            });
+          }
         },
         onUpdate: (evt) => {
           const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);


### PR DESCRIPTION
## Summary
- only remove DOM nodes in ZenDo bucket drops when the source item is a cloned task
- defer clone cleanup with requestAnimationFrame so Sortable can finish its internal bookkeeping

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d20171befc832bbad9a752a6082232