### PR TITLE
Enhance cosmos body materials and colors

### DIFF
--- a/src/apps/cosmos/bodies.js
+++ b/src/apps/cosmos/bodies.js
@@ -3,6 +3,203 @@ import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.162/build/three.mod
 const TRAIL_LIMIT = 720;
 const MIN_RENDER_RADIUS = 0.35;
 
+const gradientTextureCache = new Map();
+const textureLoader = new THREE.TextureLoader();
+const textureCache = new Map();
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(Math.max(value, 0), 1);
+}
+
+function normaliseStops(stops) {
+  if (!Array.isArray(stops) || stops.length === 0) {
+    return [];
+  }
+
+  return stops
+    .map((stop) => ({
+      offset: clamp01(stop?.offset ?? 0),
+      color: new THREE.Color(stop?.color ?? '#ffffff'),
+    }))
+    .sort((a, b) => a.offset - b.offset);
+}
+
+function sampleGradient(stops, t, targetColor) {
+  if (stops.length === 0) {
+    targetColor.set('#ffffff');
+    return targetColor;
+  }
+
+  const value = clamp01(t);
+
+  if (value <= stops[0].offset) {
+    targetColor.copy(stops[0].color);
+    return targetColor;
+  }
+
+  if (value >= stops[stops.length - 1].offset) {
+    targetColor.copy(stops[stops.length - 1].color);
+    return targetColor;
+  }
+
+  for (let i = 0; i < stops.length - 1; i += 1) {
+    const current = stops[i];
+    const next = stops[i + 1];
+    if (value >= current.offset && value <= next.offset) {
+      const span = Math.max(next.offset - current.offset, 1e-6);
+      const localT = (value - current.offset) / span;
+      targetColor.copy(current.color).lerp(next.color, clamp01(localT));
+      return targetColor;
+    }
+  }
+
+  targetColor.copy(stops[stops.length - 1].color);
+  return targetColor;
+}
+
+function createGradientTexture(gradient) {
+  if (!gradient) {
+    return null;
+  }
+
+  const key = JSON.stringify(gradient);
+  if (gradientTextureCache.has(key)) {
+    return gradientTextureCache.get(key);
+  }
+
+  const stops = normaliseStops(gradient.stops);
+  if (stops.length === 0) {
+    return null;
+  }
+
+  const size = 256;
+  const width = size;
+  const height = size;
+  const orientation = gradient.orientation ?? 'vertical';
+  const data = new Uint8Array(width * height * 4);
+  const color = new THREE.Color();
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      let t;
+      if (orientation === 'horizontal') {
+        t = width === 1 ? 0 : x / (width - 1);
+      } else if (orientation === 'radial') {
+        const nx = width === 1 ? 0 : x / (width - 1);
+        const ny = height === 1 ? 0 : y / (height - 1);
+        const dx = nx - 0.5;
+        const dy = ny - 0.5;
+        t = Math.min(Math.sqrt(dx * dx + dy * dy) / 0.5, 1);
+      } else {
+        t = height === 1 ? 0 : y / (height - 1);
+      }
+
+      sampleGradient(stops, t, color);
+      const index = (y * width + x) * 4;
+      data[index] = Math.round(color.r * 255);
+      data[index + 1] = Math.round(color.g * 255);
+      data[index + 2] = Math.round(color.b * 255);
+      data[index + 3] = 255;
+    }
+  }
+
+  const texture = new THREE.DataTexture(data, width, height, THREE.RGBAFormat);
+  texture.needsUpdate = true;
+  texture.wrapS = THREE.ClampToEdgeWrapping;
+  texture.wrapT = THREE.ClampToEdgeWrapping;
+
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+
+  gradientTextureCache.set(key, texture);
+  return texture;
+}
+
+function loadTexture(url) {
+  if (!url) {
+    return null;
+  }
+
+  if (textureCache.has(url)) {
+    return textureCache.get(url);
+  }
+
+  const texture = textureLoader.load(url);
+
+  if ('colorSpace' in texture) {
+    texture.colorSpace = THREE.SRGBColorSpace;
+  } else {
+    texture.encoding = THREE.sRGBEncoding;
+  }
+
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.anisotropy = 4;
+
+  textureCache.set(url, texture);
+  return texture;
+}
+
+function resolveBaseColor(colorDefinition) {
+  if (typeof colorDefinition === 'string') {
+    return colorDefinition;
+  }
+
+  if (!colorDefinition || typeof colorDefinition !== 'object') {
+    return '#ffffff';
+  }
+
+  if (typeof colorDefinition.base === 'string') {
+    return colorDefinition.base;
+  }
+
+  if (colorDefinition.gradient && Array.isArray(colorDefinition.gradient.stops)) {
+    const stops = colorDefinition.gradient.stops;
+    if (stops.length > 0 && typeof stops[0].color === 'string') {
+      return stops[0].color;
+    }
+  }
+
+  if (Array.isArray(colorDefinition.stops) && colorDefinition.stops.length > 0) {
+    const first = colorDefinition.stops[0];
+    if (typeof first.color === 'string') {
+      return first.color;
+    }
+  }
+
+  if (typeof colorDefinition.color === 'string') {
+    return colorDefinition.color;
+  }
+
+  return '#ffffff';
+}
+
+function extractMaterialMap(colorDefinition) {
+  if (!colorDefinition || typeof colorDefinition !== 'object') {
+    return null;
+  }
+
+  if (colorDefinition.texture) {
+    return loadTexture(colorDefinition.texture);
+  }
+
+  if (colorDefinition.gradient) {
+    return createGradientTexture(colorDefinition.gradient);
+  }
+
+  if (Array.isArray(colorDefinition.stops)) {
+    return createGradientTexture({ stops: colorDefinition.stops, orientation: colorDefinition.orientation });
+  }
+
+  return null;
+}
+
 export async function loadBodyData(url = './data/bodies.json') {
   const response = await fetch(url);
 
@@ -14,28 +211,44 @@ export async function loadBodyData(url = './data/bodies.json') {
 }
 
 function createMaterial(color, isSun) {
-  if (isSun) {
-    return new THREE.MeshStandardMaterial({
-      emissive: new THREE.Color('#fff4d3'),
-      emissiveIntensity: 1.6,
-      color: new THREE.Color(color),
-    });
-  }
-
-  return new THREE.MeshStandardMaterial({
-    color: new THREE.Color(color),
+  const baseColor = resolveBaseColor(color);
+  const materialConfig = {
+    color: new THREE.Color(baseColor),
     roughness: 0.6,
     metalness: 0.1,
-  });
+  };
+
+  const map = extractMaterialMap(color);
+  if (map) {
+    materialConfig.map = map;
+  }
+
+  if (color && typeof color === 'object') {
+    if (typeof color.roughness === 'number') {
+      materialConfig.roughness = clamp01(color.roughness);
+    }
+
+    if (typeof color.metalness === 'number') {
+      materialConfig.metalness = clamp01(color.metalness);
+    }
+  }
+
+  if (isSun) {
+    materialConfig.emissive = new THREE.Color('#fff4d3');
+    materialConfig.emissiveIntensity = 1.6;
+  }
+
+  return new THREE.MeshStandardMaterial(materialConfig);
 }
 
-function createTrail(color) {
+function createTrail(colorDefinition) {
+  const baseColor = resolveBaseColor(colorDefinition);
   const geometry = new THREE.BufferGeometry();
   const positions = new Float32Array(TRAIL_LIMIT * 3);
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   geometry.setDrawRange(0, 0);
 
-  const tint = new THREE.Color(color).lerp(new THREE.Color('#ffffff'), 0.35);
+  const tint = new THREE.Color(baseColor).lerp(new THREE.Color('#ffffff'), 0.35);
 
   const material = new THREE.LineBasicMaterial({
     color: tint,

--- a/src/apps/cosmos/data/bodies.json
+++ b/src/apps/cosmos/data/bodies.json
@@ -5,7 +5,17 @@
     "radius": 6.9634e8,
     "position": [0, 0, 0],
     "velocity": [0, 0, 0],
-    "color": "yellow"
+    "color": {
+      "base": "#f7c84b",
+      "gradient": {
+        "orientation": "radial",
+        "stops": [
+          { "offset": 0, "color": "#fff7d9" },
+          { "offset": 0.45, "color": "#fcd16b" },
+          { "offset": 1, "color": "#f28e1c" }
+        ]
+      }
+    }
   },
   {
     "name": "Mercury",
@@ -13,7 +23,16 @@
     "radius": 2.439e6,
     "position": [5.79e10, 0, 0],
     "velocity": [0, 47400, 0],
-    "color": "gray"
+    "color": {
+      "base": "#97897b",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#c3b6ac" },
+          { "offset": 1, "color": "#6f6258" }
+        ]
+      }
+    }
   },
   {
     "name": "Venus",
@@ -21,7 +40,17 @@
     "radius": 6.052e6,
     "position": [1.082e11, 0, 0],
     "velocity": [0, 35000, 0],
-    "color": "orange"
+    "color": {
+      "base": "#d0a25f",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#f3d59b" },
+          { "offset": 0.6, "color": "#d0a25f" },
+          { "offset": 1, "color": "#b58448" }
+        ]
+      }
+    }
   },
   {
     "name": "Earth",
@@ -29,7 +58,38 @@
     "radius": 6.371e6,
     "position": [1.496e11, 0, 0],
     "velocity": [0, 29780, 0],
-    "color": "blue"
+    "color": {
+      "base": "#2f7fd6",
+      "gradient": {
+        "orientation": "horizontal",
+        "stops": [
+          { "offset": 0, "color": "#2f7fd6" },
+          { "offset": 0.35, "color": "#2a65a0" },
+          { "offset": 0.55, "color": "#3da86c" },
+          { "offset": 0.7, "color": "#98c264" },
+          { "offset": 0.9, "color": "#d7e7f6" },
+          { "offset": 1, "color": "#2f7fd6" }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Moon",
+    "mass": 7.342e22,
+    "radius": 1.7374e6,
+    "position": [1.499844e11, 0, 0],
+    "velocity": [0, 30802, 0],
+    "color": {
+      "base": "#d0c7bd",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#f0e9e1" },
+          { "offset": 0.5, "color": "#d0c7bd" },
+          { "offset": 1, "color": "#9e948a" }
+        ]
+      }
+    }
   },
   {
     "name": "Mars",
@@ -37,7 +97,17 @@
     "radius": 3.389e6,
     "position": [2.279e11, 0, 0],
     "velocity": [0, 24100, 0],
-    "color": "red"
+    "color": {
+      "base": "#c24f34",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#f1a06f" },
+          { "offset": 0.4, "color": "#d0603a" },
+          { "offset": 1, "color": "#82281f" }
+        ]
+      }
+    }
   },
   {
     "name": "Jupiter",
@@ -45,7 +115,22 @@
     "radius": 6.9911e7,
     "position": [7.785e11, 0, 0],
     "velocity": [0, 13070, 0],
-    "color": "orange"
+    "color": {
+      "base": "#c79b6e",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#f3d9b5" },
+          { "offset": 0.12, "color": "#b27d4d" },
+          { "offset": 0.24, "color": "#f4d7aa" },
+          { "offset": 0.36, "color": "#a06438" },
+          { "offset": 0.5, "color": "#f0d0a0" },
+          { "offset": 0.64, "color": "#a46b3f" },
+          { "offset": 0.78, "color": "#e9c596" },
+          { "offset": 1, "color": "#8d5a33" }
+        ]
+      }
+    }
   },
   {
     "name": "Saturn",
@@ -53,7 +138,17 @@
     "radius": 5.8232e7,
     "position": [1.433e12, 0, 0],
     "velocity": [0, 9680, 0],
-    "color": "goldenrod"
+    "color": {
+      "base": "#d8bc83",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#f5e2b9" },
+          { "offset": 0.5, "color": "#d8bc83" },
+          { "offset": 1, "color": "#b7935f" }
+        ]
+      }
+    }
   },
   {
     "name": "Uranus",
@@ -61,7 +156,17 @@
     "radius": 2.5362e7,
     "position": [2.872e12, 0, 0],
     "velocity": [0, 6800, 0],
-    "color": "lightblue"
+    "color": {
+      "base": "#74d0e2",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#a9f1fb" },
+          { "offset": 0.55, "color": "#74d0e2" },
+          { "offset": 1, "color": "#3a9bbf" }
+        ]
+      }
+    }
   },
   {
     "name": "Neptune",
@@ -69,6 +174,16 @@
     "radius": 2.4622e7,
     "position": [4.495e12, 0, 0],
     "velocity": [0, 5430, 0],
-    "color": "darkblue"
+    "color": {
+      "base": "#3e59d4",
+      "gradient": {
+        "orientation": "vertical",
+        "stops": [
+          { "offset": 0, "color": "#6f8bf4" },
+          { "offset": 0.45, "color": "#3e59d4" },
+          { "offset": 1, "color": "#1f377e" }
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- enrich the cosmos body dataset with unique hex palettes, banded gradients, and a lunar entry for improved differentiation
- extend material creation to derive textures from gradient or texture definitions while preserving solar emissive behaviour
- derive orbit trails from the new base colour metadata for consistent visuals

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d203695034832b84604df024245757