### PR TITLE
Add collapsible controls legend to Cosmos

### DIFF
--- a/src/apps/cosmos/index.html
+++ b/src/apps/cosmos/index.html
@@ -29,6 +29,61 @@
         </ul>
       </header>
       <section class="cosmos-viewport">
+        <aside class="cosmos-legend">
+          <button
+            class="cosmos-legend__toggle"
+            type="button"
+            aria-expanded="true"
+            aria-controls="cosmos-legend-panel"
+          >
+            <span id="cosmos-legend-title" class="cosmos-legend__title">Legend</span>
+            <span class="cosmos-legend__toggle-text cosmos-legend__toggle-text--expanded">Hide tips</span>
+            <span class="cosmos-legend__toggle-text cosmos-legend__toggle-text--collapsed">Show tips</span>
+            <span class="cosmos-legend__chevron" aria-hidden="true">▾</span>
+          </button>
+          <div
+            class="cosmos-legend__panel"
+            id="cosmos-legend-panel"
+            role="region"
+            aria-labelledby="cosmos-legend-title"
+          >
+            <div class="cosmos-legend__section">
+              <h2 class="cosmos-legend__heading">Mouse</h2>
+              <dl class="cosmos-legend__bindings">
+                <div class="cosmos-legend__binding">
+                  <dt>Left drag</dt>
+                  <dd>Orbit around the focused body.</dd>
+                </div>
+                <div class="cosmos-legend__binding">
+                  <dt>Right drag</dt>
+                  <dd>Pan the camera laterally through space.</dd>
+                </div>
+                <div class="cosmos-legend__binding">
+                  <dt>Scroll</dt>
+                  <dd>Zoom in or out to inspect the system.</dd>
+                </div>
+              </dl>
+            </div>
+            <div class="cosmos-legend__section">
+              <h2 class="cosmos-legend__heading">Keyboard</h2>
+              <dl class="cosmos-legend__bindings">
+                <div class="cosmos-legend__binding">
+                  <dt>R</dt>
+                  <dd>Reset the camera to the default solar view.</dd>
+                </div>
+              </dl>
+            </div>
+            <div class="cosmos-legend__section">
+              <h2 class="cosmos-legend__heading">Control panel</h2>
+              <ul class="cosmos-legend__tips">
+                <li>Use <strong>Time speed</strong> to fast-forward or slow the simulation.</li>
+                <li>Adjust <strong>Gravity</strong> to exaggerate or mellow orbital motion.</li>
+                <li>Toggle <strong>Show trails</strong> to reveal each body's orbit history.</li>
+                <li>Open <strong>Camera</strong> to teleport to any planet or reset the view.</li>
+              </ul>
+            </div>
+          </div>
+        </aside>
         <div class="cosmos-loader">Loading solar system…</div>
       </section>
       <footer class="cosmos-footer">

--- a/src/apps/cosmos/main.js
+++ b/src/apps/cosmos/main.js
@@ -6,6 +6,11 @@ import { setupControlPanel } from './controls.js';
 
 const viewport = document.querySelector('.cosmos-viewport');
 const statusEl = document.querySelector('.cosmos-loader');
+const legendEl = document.querySelector('.cosmos-legend');
+const legendToggle = legendEl?.querySelector('.cosmos-legend__toggle');
+const legendPanel = legendEl?.querySelector('.cosmos-legend__panel');
+
+const LEGEND_STORAGE_KEY = 'cosmos.legend.collapsed';
 
 let renderer;
 let camera;
@@ -117,6 +122,43 @@ function teleportCameraTo(name) {
   controls.update();
 }
 
+function setupLegend() {
+  if (!legendEl || !legendToggle || !legendPanel) {
+    return;
+  }
+
+  const readStoredPreference = () => {
+    try {
+      return localStorage.getItem(LEGEND_STORAGE_KEY) === '1';
+    } catch {
+      return false;
+    }
+  };
+
+  const setLegendCollapsed = (collapsed, { persist = true } = {}) => {
+    legendEl.classList.toggle('cosmos-legend--collapsed', collapsed);
+    legendToggle.setAttribute('aria-expanded', String(!collapsed));
+    legendPanel.setAttribute('aria-hidden', String(collapsed));
+
+    if (persist) {
+      try {
+        localStorage.setItem(LEGEND_STORAGE_KEY, collapsed ? '1' : '0');
+      } catch {
+        // Ignore persistence errors (e.g., storage disabled).
+      }
+    }
+  };
+
+  const initialCollapsed = readStoredPreference();
+  setLegendCollapsed(initialCollapsed, { persist: false });
+  legendEl.classList.add('cosmos-legend--ready');
+
+  legendToggle.addEventListener('click', () => {
+    const nextState = !legendEl.classList.contains('cosmos-legend--collapsed');
+    setLegendCollapsed(nextState);
+  });
+}
+
 async function init() {
   if (!viewport) {
     return;
@@ -135,6 +177,27 @@ async function init() {
   resizeRenderer();
 
   window.addEventListener('resize', resizeRenderer);
+  window.addEventListener('keydown', (event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const target = event.target;
+    if (target instanceof HTMLElement) {
+      if (target.isContentEditable) {
+        return;
+      }
+
+      const focusable = target.closest('input, textarea, select, button');
+      if (focusable) {
+        return;
+      }
+    }
+
+    if (event.key === 'r' || event.key === 'R') {
+      resetCamera();
+    }
+  });
 
   try {
     const bodies = await loadBodyData('./data/bodies.json');
@@ -178,4 +241,5 @@ async function init() {
   }
 }
 
+setupLegend();
 init();

--- a/src/apps/cosmos/styles.css
+++ b/src/apps/cosmos/styles.css
@@ -107,6 +107,195 @@ body {
   color: #051635 !important;
 }
 
+.cosmos-legend {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  width: min(320px, calc(100% - 48px));
+  padding: 12px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(18, 38, 86, 0.82), rgba(9, 22, 51, 0.72));
+  border: 1px solid rgba(100, 142, 214, 0.35);
+  box-shadow: 0 16px 32px rgba(4, 10, 24, 0.48);
+  backdrop-filter: blur(14px);
+  color: #eef5ff;
+  z-index: 12;
+  box-sizing: border-box;
+  transition: background 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.cosmos-legend--collapsed {
+  background: rgba(15, 32, 70, 0.55);
+  border-color: rgba(100, 142, 214, 0.2);
+  box-shadow: 0 10px 24px rgba(3, 8, 22, 0.38);
+}
+
+.cosmos-legend__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 12px;
+  background: rgba(18, 45, 96, 0.35);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 160ms ease, box-shadow 160ms ease, color 160ms ease;
+}
+
+.cosmos-legend__toggle:hover,
+.cosmos-legend__toggle:focus-visible {
+  background: rgba(36, 90, 166, 0.45);
+  color: #ffffff;
+}
+
+.cosmos-legend__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(148, 190, 255, 0.68);
+}
+
+.cosmos-legend__title {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+}
+
+.cosmos-legend__toggle-text {
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: rgba(210, 223, 255, 0.74);
+}
+
+.cosmos-legend__toggle-text--collapsed {
+  display: none;
+}
+
+.cosmos-legend--collapsed .cosmos-legend__toggle-text--expanded {
+  display: none;
+}
+
+.cosmos-legend--collapsed .cosmos-legend__toggle-text--collapsed {
+  display: inline;
+}
+
+.cosmos-legend__chevron {
+  font-size: 0.9rem;
+  transition: transform 220ms ease;
+}
+
+.cosmos-legend--collapsed .cosmos-legend__chevron {
+  transform: rotate(-90deg);
+}
+
+.cosmos-legend__panel {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(8, 23, 52, 0.55);
+  border: 1px solid rgba(107, 152, 222, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(120, 170, 255, 0.12);
+  font-size: 0.85rem;
+  line-height: 1.55;
+  max-height: 520px;
+  opacity: 1;
+  overflow: hidden;
+  transition: max-height 240ms ease, opacity 200ms ease, margin 200ms ease, padding 200ms ease, border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.cosmos-legend:not(.cosmos-legend--ready) .cosmos-legend__panel {
+  transition: none;
+}
+
+.cosmos-legend--collapsed .cosmos-legend__panel {
+  max-height: 0;
+  opacity: 0;
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-color: transparent;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.cosmos-legend__section + .cosmos-legend__section {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(120, 170, 255, 0.16);
+}
+
+.cosmos-legend__heading {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(204, 218, 255, 0.88);
+}
+
+.cosmos-legend__bindings {
+  margin: 10px 0 0;
+  padding: 0;
+}
+
+.cosmos-legend__binding {
+  display: grid;
+  grid-template-columns: minmax(120px, auto) 1fr;
+  column-gap: 12px;
+  row-gap: 4px;
+  align-items: start;
+}
+
+.cosmos-legend__binding + .cosmos-legend__binding {
+  margin-top: 8px;
+}
+
+.cosmos-legend__binding dt {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #f5f8ff;
+}
+
+.cosmos-legend__binding dd {
+  margin: 0;
+  color: rgba(206, 219, 255, 0.8);
+}
+
+.cosmos-legend__tips {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.cosmos-legend__tips li {
+  position: relative;
+  padding-left: 16px;
+  color: rgba(206, 221, 255, 0.84);
+}
+
+.cosmos-legend__tips li::before {
+  content: '';
+  position: absolute;
+  top: 0.6em;
+  left: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #85b2ff, #d1e2ff);
+  box-shadow: 0 0 6px rgba(136, 184, 255, 0.85);
+}
+
+.cosmos-legend strong {
+  color: #ffffff;
+  font-weight: 600;
+}
+
 @media (max-width: 900px) {
   .cosmos-gui {
     position: static;
@@ -115,11 +304,36 @@ body {
 }
 
 @media (max-width: 720px) {
+  .cosmos-legend {
+    left: 12px;
+    top: 12px;
+    width: calc(100% - 24px);
+    padding: 10px;
+  }
+
+  .cosmos-legend__panel {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .cosmos-legend__binding {
+    grid-template-columns: minmax(100px, auto) 1fr;
+  }
+
   .cosmos-header p {
     font-size: 0.95rem;
   }
 
   .cosmos-viewport {
     min-height: 420px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cosmos-legend,
+  .cosmos-legend__toggle,
+  .cosmos-legend__panel,
+  .cosmos-legend__chevron {
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- add a floating Cosmos legend with mouse, keyboard, and control panel tips plus a collapse toggle
- persist the legend open/closed state, update accessibility attributes, and add an `R` keyboard shortcut that matches the copy
- style the legend to blend with the Cosmos aesthetic and keep the canvas clear when collapsed

## Testing
- npm run lint *(fails: existing lint errors in legacy app code outside Cosmos)*

------
https://chatgpt.com/codex/tasks/task_e_68d2039915ec832ba890b1ac81bd0047