### PR TITLE
feat(zendo): replace weekly drag with context-driven controller

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -352,6 +352,12 @@
   width: 100%;
 }
 
+.zen-week-bucket.is-hovered {
+  background: rgba(149, 217, 195, 0.22);
+  border-radius: 14px;
+  box-shadow: inset 0 0 0 2px rgba(108, 161, 143, 0.45);
+}
+
 .zen-week-card,
 .zen-focus-card {
   background: rgba(149, 217, 195, 0.35);
@@ -361,6 +367,26 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+}
+
+.zen-week-card {
+  cursor: grab;
+}
+
+.zen-week-card.is-drag-source {
+  opacity: 0.45;
+  cursor: grabbing;
+}
+
+.zen-week-card.placeholder {
+  border: 2px dashed rgba(108, 161, 143, 0.5);
+  background: rgba(149, 217, 195, 0.12);
+  min-height: 2.75rem;
+  pointer-events: none;
+}
+
+.zen-root-task > .zen-task-row {
+  cursor: grab;
 }
 
 .zen-card-title {
@@ -402,6 +428,21 @@
   border-radius: 999px;
   cursor: pointer;
   font-size: 0.75rem;
+}
+
+.zen-drag-preview {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 999;
+  transform-origin: top left;
+  transition: transform 0.03s ease;
+}
+
+.zen-drag-card {
+  box-shadow: 0 16px 32px rgba(67, 117, 99, 0.28);
+  opacity: 0.95;
 }
 
 .zen-today-layout {

--- a/src/apps/ZenDoApp/ZenDoApp.js
+++ b/src/apps/ZenDoApp/ZenDoApp.js
@@ -9,6 +9,8 @@ import useZenDoState from './useZenDoState';
 import { DAY_ORDER } from './constants';
 import { flattenTasks, sortTasksByDueDate } from './taskUtils';
 import { writeGlobalGistSettings } from '../../state/globalGistSettings';
+import { DragProvider } from './drag/DragContext';
+import DragPreview from './components/DragPreview';
 
 const VIEW_TABS = [
   { id: 'landing', label: 'Landing' },
@@ -201,8 +203,9 @@ const ZenDoApp = ({ onBack }) => {
   const gistFilename = gistConfig.filename || 'zen-do-data.json';
 
   return (
-    <div className="zen-app-shell">
-      <header className="zen-app-header">
+    <DragProvider>
+      <div className="zen-app-shell">
+        <header className="zen-app-header">
         <div className="zen-header-left">
           {onBack && (
             <button type="button" className="zen-inline-btn zen-back-btn" onClick={onBack}>
@@ -334,14 +337,16 @@ const ZenDoApp = ({ onBack }) => {
         )}
       </main>
 
-      <TaskEditorModal
-        open={editorState.open}
-        onClose={closeEditor}
-        onSave={handleSaveTask}
-        initialTask={editorState.task}
-        parentTitle={editorState.parentTitle}
-      />
-    </div>
+        <TaskEditorModal
+          open={editorState.open}
+          onClose={closeEditor}
+          onSave={handleSaveTask}
+          initialTask={editorState.task}
+          parentTitle={editorState.parentTitle}
+        />
+      </div>
+      <DragPreview />
+    </DragProvider>
   );
 };
 

--- a/src/apps/ZenDoApp/__tests__/LandingView.drag.test.js
+++ b/src/apps/ZenDoApp/__tests__/LandingView.drag.test.js
@@ -1,0 +1,173 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import LandingView from '../views/LandingView';
+import { DragProvider } from '../drag/DragContext';
+import DragPreview from '../components/DragPreview';
+
+const baseTasks = [
+  {
+    id: 'task-backlog',
+    title: 'Backlog Task',
+    completed: false,
+    subtasks: [],
+  },
+];
+
+const mondayAssignments = [
+  { id: 'task-monday-1', title: 'Existing Monday', completed: false },
+  { id: 'task-monday-2', title: 'Second Monday', completed: false },
+];
+
+const renderLanding = (overrideProps = {}) => {
+  const props = {
+    tasks: baseTasks,
+    expandedIds: new Set(),
+    onToggleExpand: jest.fn(),
+    onEditTask: jest.fn(),
+    onDeleteTask: jest.fn(),
+    onCompleteTask: jest.fn(),
+    onAddSubtask: jest.fn(),
+    onAddRootTask: jest.fn(),
+    dayAssignments: { mon: mondayAssignments, tue: [] },
+    onAssignTaskToDay: jest.fn(),
+    onReorderDay: jest.fn(),
+    onLaunchToday: jest.fn(),
+    ...overrideProps,
+  };
+
+  const utils = render(
+    <DragProvider>
+      <>
+        <LandingView {...props} />
+        <DragPreview />
+      </>
+    </DragProvider>,
+  );
+
+  return { ...utils, props };
+};
+
+const setRect = (element, rect) => {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    value: () => ({
+      width: rect.width,
+      height: rect.height,
+      top: rect.top,
+      left: rect.left,
+      right: rect.right ?? rect.left + rect.width,
+      bottom: rect.bottom ?? rect.top + rect.height,
+    }),
+    configurable: true,
+  });
+};
+
+const emitPointerEvent = (type, init) => {
+  const EventCtor = window.PointerEvent || window.MouseEvent;
+  const event = new EventCtor(type, { bubbles: true, cancelable: true, ...init });
+  window.dispatchEvent(event);
+};
+
+const startBacklogDrag = (pointer = { x: 40, y: 20 }) => {
+  const row = screen.getByText('Backlog Task').closest('.zen-task-row');
+  if (!row) {
+    throw new Error('Backlog row not found');
+  }
+  setRect(row, { left: 0, top: 0, width: 260, height: 64 });
+  act(() => {
+    fireEvent.pointerDown(row, {
+      pointerId: 1,
+      clientX: pointer.x,
+      clientY: pointer.y,
+      button: 0,
+    });
+  });
+  return row;
+};
+
+const configureBucketRects = (bucketKey = 'mon') => {
+  const bucket = screen.getByTestId(`bucket-${bucketKey}`);
+  setRect(bucket, {
+    left: 320,
+    top: 0,
+    width: 260,
+    height: 320,
+  });
+  const cards = bucket.querySelectorAll('[data-task-id]');
+  cards.forEach((card, index) => {
+    setRect(card, {
+      left: 320,
+      top: 16 + (index * 72),
+      width: 260,
+      height: 64,
+    });
+  });
+  return bucket;
+};
+
+describe('LandingView drag interactions', () => {
+  it('creates a floating preview when starting a backlog drag', () => {
+    renderLanding();
+    startBacklogDrag();
+
+    const preview = document.body.querySelector('.zen-drag-preview');
+    expect(preview).toBeInTheDocument();
+    expect(preview?.querySelector('.zen-card-title')).toHaveTextContent('Backlog Task');
+
+    act(() => {
+      emitPointerEvent('pointerup', { pointerId: 1, clientX: 50, clientY: 40 });
+    });
+  });
+
+  it('marks hovered bucket and renders a placeholder during drag', async () => {
+    renderLanding();
+    startBacklogDrag();
+    const bucket = configureBucketRects('mon');
+
+    act(() => {
+      emitPointerEvent('pointermove', { pointerId: 1, clientX: 350, clientY: 30 });
+    });
+
+    await waitFor(() => expect(bucket).toHaveClass('is-hovered'));
+    expect(bucket.querySelector('.zen-week-card.placeholder')).toBeInTheDocument();
+
+    act(() => {
+      emitPointerEvent('pointerup', { pointerId: 1, clientX: 350, clientY: 30 });
+    });
+  });
+
+  it('only invokes assignment callbacks once on drop', async () => {
+    const onAssignTaskToDay = jest.fn();
+    const onReorderDay = jest.fn();
+    renderLanding({ onAssignTaskToDay, onReorderDay });
+
+    startBacklogDrag({ x: 30, y: 18 });
+    const bucket = configureBucketRects('mon');
+
+    act(() => {
+      emitPointerEvent('pointermove', { pointerId: 1, clientX: 340, clientY: 25 });
+    });
+    await waitFor(() => expect(bucket).toHaveClass('is-hovered'));
+
+    act(() => {
+      emitPointerEvent('pointerup', { pointerId: 1, clientX: 340, clientY: 25 });
+    });
+
+    await waitFor(() => expect(onAssignTaskToDay).toHaveBeenCalledTimes(1));
+    expect(onAssignTaskToDay).toHaveBeenCalledWith('task-backlog', 'mon', 0);
+
+    expect(onReorderDay).toHaveBeenCalledTimes(1);
+    expect(onReorderDay).toHaveBeenCalledWith('mon', [
+      'task-backlog',
+      'task-monday-1',
+      'task-monday-2',
+    ]);
+
+    await waitFor(() => expect(bucket).not.toHaveClass('is-hovered'));
+  });
+});

--- a/src/apps/ZenDoApp/components/DragPreview.js
+++ b/src/apps/ZenDoApp/components/DragPreview.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { useDragContext } from '../drag/DragContext';
+
+const DragPreview = () => {
+  const { dragState } = useDragContext();
+  const { isDragging, pointerPosition, pointerOffset, previewSize, previewData } = dragState;
+
+  if (typeof document === 'undefined' || !isDragging || !pointerPosition) {
+    return null;
+  }
+
+  const offsetX = pointerOffset?.x ?? 0;
+  const offsetY = pointerOffset?.y ?? 0;
+  const width = previewSize?.width || 260;
+  const height = previewSize?.height || undefined;
+  const left = pointerPosition.x - offsetX;
+  const top = pointerPosition.y - offsetY;
+  const task = previewData?.task ?? previewData ?? null;
+
+  const preview = (
+    <div className="zen-drag-preview" style={{ transform: `translate3d(${left}px, ${top}px, 0)`, width, height }} aria-hidden="true">
+      <div className="zen-week-card zen-drag-card">
+        <div className="zen-card-title">{task?.title || ''}</div>
+        {task?.dueDate && <div className="zen-card-meta">Due {task.dueDate}</div>}
+      </div>
+    </div>
+  );
+
+  return createPortal(preview, document.body);
+};
+
+export default DragPreview;

--- a/src/apps/ZenDoApp/components/TaskTree.js
+++ b/src/apps/ZenDoApp/components/TaskTree.js
@@ -27,16 +27,31 @@ const TaskNode = ({
   onAddSubtask,
   expandedIds,
   isRoot,
+  onStartRootDrag,
 }) => {
   const hasChildren = task.subtasks && task.subtasks.length > 0;
   const dueLabel = formatDueDate(task.dueDate);
+
+  const handlePointerDown = (event) => {
+    if (!isRoot || typeof onStartRootDrag !== 'function') {
+      return;
+    }
+    if (typeof event.button === 'number' && event.button !== 0) {
+      return;
+    }
+    const interactive = event.target.closest('button, input, a, textarea, select, label');
+    if (interactive) {
+      return;
+    }
+    onStartRootDrag(event, task);
+  };
 
   return (
     <li
       className={`zen-task-node depth-${depth} ${task.completed ? 'is-complete' : ''} ${isRoot ? 'zen-root-task' : ''}`}
       data-task-id={task.id}
     >
-      <div className="zen-task-row">
+      <div className="zen-task-row" onPointerDown={handlePointerDown}>
         <div className="zen-task-controls">
           {hasChildren ? (
             <button
@@ -106,6 +121,7 @@ const TaskNode = ({
               onAddSubtask={onAddSubtask}
               expandedIds={expandedIds}
               isRoot={false}
+              onStartRootDrag={onStartRootDrag}
             />
           ))}
         </ul>
@@ -122,6 +138,7 @@ const TaskTree = ({
   onDeleteTask,
   onCompleteTask,
   onAddSubtask,
+  onStartRootDrag,
 }) => {
   if (!tasks.length) {
     return (
@@ -146,6 +163,7 @@ const TaskTree = ({
           onAddSubtask={onAddSubtask}
           expandedIds={expandedIds}
           isRoot
+          onStartRootDrag={onStartRootDrag}
         />
       ))}
     </ul>

--- a/src/apps/ZenDoApp/drag/DragContext.js
+++ b/src/apps/ZenDoApp/drag/DragContext.js
@@ -1,0 +1,23 @@
+import React, { createContext, useContext } from 'react';
+import useDragController from './useDragController';
+
+const DragContext = createContext(null);
+
+export const DragProvider = ({ children }) => {
+  const controller = useDragController();
+  return (
+    <DragContext.Provider value={controller}>
+      {children}
+    </DragContext.Provider>
+  );
+};
+
+export const useDragContext = () => {
+  const value = useContext(DragContext);
+  if (!value) {
+    throw new Error('useDragContext must be used within a DragProvider');
+  }
+  return value;
+};
+
+export default DragContext;

--- a/src/apps/ZenDoApp/drag/useDragController.js
+++ b/src/apps/ZenDoApp/drag/useDragController.js
@@ -1,0 +1,216 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+const INITIAL_STATE = {
+  isDragging: false,
+  activeTaskId: null,
+  sourceBucket: null,
+  pointerPosition: null,
+  pointerOffset: { x: 0, y: 0 },
+  previewSize: { width: 0, height: 0 },
+  previewData: null,
+  hoverTarget: null,
+};
+
+const clampIndex = (index, length) => {
+  if (Number.isNaN(index) || index == null) {
+    return length;
+  }
+  return Math.max(0, Math.min(index, length));
+};
+
+const useDragController = () => {
+  const [dragState, setDragState] = useState(INITIAL_STATE);
+  const stateRef = useRef(INITIAL_STATE);
+  const dropHandlerRef = useRef(null);
+  const pointerIdRef = useRef(null);
+  const listenersRef = useRef(null);
+
+  const updateState = useCallback((updater) => {
+    setDragState((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      stateRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const removeListeners = useCallback(() => {
+    const listeners = listenersRef.current;
+    if (!listeners) {
+      return;
+    }
+    window.removeEventListener('pointermove', listeners.move);
+    window.removeEventListener('pointerup', listeners.up);
+    window.removeEventListener('pointercancel', listeners.cancel);
+    listenersRef.current = null;
+  }, []);
+
+  const resetDrag = useCallback(() => {
+    removeListeners();
+    pointerIdRef.current = null;
+    dropHandlerRef.current = null;
+    updateState(INITIAL_STATE);
+  }, [removeListeners, updateState]);
+
+  const cancelDrag = useCallback(() => {
+    resetDrag();
+  }, [resetDrag]);
+
+  const beginDrag = useCallback((event, {
+    taskId,
+    sourceBucket = null,
+    previewData = null,
+    onDrop = null,
+  } = {}) => {
+    if (!event || !taskId || stateRef.current.isDragging) {
+      return;
+    }
+
+    const rect = typeof event.currentTarget?.getBoundingClientRect === 'function'
+      ? event.currentTarget.getBoundingClientRect()
+      : null;
+
+    const clientX = event.clientX ?? rect?.left ?? 0;
+    const clientY = event.clientY ?? rect?.top ?? 0;
+    const offsetX = rect ? clientX - rect.left : 0;
+    const offsetY = rect ? clientY - rect.top : 0;
+
+    pointerIdRef.current = event.pointerId ?? 'default';
+    dropHandlerRef.current = onDrop;
+
+    const isMatchingPointer = (pointerEvent) => {
+      if (pointerIdRef.current == null) {
+        return true;
+      }
+      if (pointerIdRef.current === 'default') {
+        return true;
+      }
+      return pointerEvent.pointerId === pointerIdRef.current;
+    };
+
+    const handleMove = (moveEvent) => {
+      if (!isMatchingPointer(moveEvent)) {
+        return;
+      }
+      updateState((prev) => {
+        if (!prev.isDragging) {
+          return prev;
+        }
+        if (prev.pointerPosition && prev.pointerPosition.x === moveEvent.clientX && prev.pointerPosition.y === moveEvent.clientY) {
+          return prev;
+        }
+        return {
+          ...prev,
+          pointerPosition: { x: moveEvent.clientX, y: moveEvent.clientY },
+        };
+      });
+    };
+
+    const finalize = (shouldDrop, endEvent) => {
+      const snapshot = stateRef.current;
+      const dropHandler = dropHandlerRef.current;
+      removeListeners();
+      pointerIdRef.current = null;
+      dropHandlerRef.current = null;
+      updateState(INITIAL_STATE);
+      if (shouldDrop && dropHandler && snapshot.isDragging) {
+        const pointerPosition = endEvent
+          ? { x: endEvent.clientX, y: endEvent.clientY }
+          : snapshot.pointerPosition;
+        dropHandler({ ...snapshot, pointerPosition });
+      }
+    };
+
+    const handleUp = (upEvent) => {
+      if (!isMatchingPointer(upEvent)) {
+        return;
+      }
+      finalize(true, upEvent);
+    };
+
+    const handleCancel = (cancelEvent) => {
+      if (!isMatchingPointer(cancelEvent)) {
+        return;
+      }
+      finalize(false, cancelEvent);
+    };
+
+    listenersRef.current = {
+      move: handleMove,
+      up: handleUp,
+      cancel: handleCancel,
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleCancel);
+
+    event.preventDefault();
+
+    updateState({
+      isDragging: true,
+      activeTaskId: taskId,
+      sourceBucket,
+      pointerPosition: { x: clientX, y: clientY },
+      pointerOffset: { x: offsetX, y: offsetY },
+      previewSize: {
+        width: rect?.width ?? 0,
+        height: rect?.height ?? 0,
+      },
+      previewData,
+      hoverTarget: null,
+    });
+  }, [removeListeners, updateState]);
+
+  const setHoverTarget = useCallback((target) => {
+    updateState((prev) => {
+      if (!prev.isDragging) {
+        return prev;
+      }
+      if (!target) {
+        if (prev.hoverTarget === null) {
+          return prev;
+        }
+        return {
+          ...prev,
+          hoverTarget: null,
+        };
+      }
+      const nextIndex = clampIndex(target.index, target.lengthHint ?? Infinity);
+      if (prev.hoverTarget && prev.hoverTarget.bucketId === target.bucketId && prev.hoverTarget.index === nextIndex) {
+        return prev;
+      }
+      return {
+        ...prev,
+        hoverTarget: {
+          bucketId: target.bucketId,
+          index: nextIndex,
+        },
+      };
+    });
+  }, [updateState]);
+
+  const clearHoverTarget = useCallback((bucketId = null) => {
+    updateState((prev) => {
+      if (!prev.isDragging || !prev.hoverTarget) {
+        return prev;
+      }
+      if (bucketId && prev.hoverTarget.bucketId !== bucketId) {
+        return prev;
+      }
+      return {
+        ...prev,
+        hoverTarget: null,
+      };
+    });
+  }, [updateState]);
+
+  return useMemo(() => ({
+    dragState,
+    beginDrag,
+    setHoverTarget,
+    clearHoverTarget,
+    cancelDrag,
+  }), [dragState, beginDrag, setHoverTarget, clearHoverTarget, cancelDrag]);
+};
+
+export default useDragController;


### PR DESCRIPTION
## Summary
- add a drag controller/context and floating DragPreview so drag state is managed without touching the DOM tree
- rewrite LandingView to use the drag context instead of Sortable.js, show placeholders, and defer updates until drop
- style the new drag states and cover the interactions with Jest tests for drag start, hover feedback, and drop callbacks

## Testing
- npm test -- LandingView.drag.test.js
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d206ea4c6c832bb47673a27e67461f