### PR TITLE
Refactor TodayView drag handling

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -427,6 +427,17 @@
   overflow-y: auto;
 }
 
+.zen-today-list.is-hovered,
+.zen-focus-drop.is-hovered {
+  box-shadow: inset 0 0 0 2px rgba(108, 161, 143, 0.6);
+  background: rgba(214, 235, 225, 0.7);
+}
+
+.zen-today-list.has-placeholder,
+.zen-focus-drop.has-placeholder {
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
 .zen-focus-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -448,6 +459,13 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.zen-task-placeholder {
+  height: 3.2rem;
+  border-radius: 12px;
+  border: 2px dashed rgba(108, 161, 143, 0.65);
+  background: rgba(149, 217, 195, 0.25);
 }
 
 .zen-focus-footer {

--- a/src/apps/ZenDoApp/__tests__/TodayView.test.js
+++ b/src/apps/ZenDoApp/__tests__/TodayView.test.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import TodayView from '../views/TodayView';
+
+const createTask = (id, title, overrides = {}) => ({
+  id,
+  title,
+  completed: false,
+  ...overrides,
+});
+
+const createDataTransfer = () => {
+  const store = {};
+  return {
+    setData: jest.fn((key, value) => {
+      store[key] = value;
+    }),
+    getData: jest.fn((key) => store[key]),
+    effectAllowed: 'move',
+    dropEffect: 'move',
+  };
+};
+
+const mockBoundingRects = (container) => {
+  const nodes = container.querySelectorAll('[data-task-id]');
+  nodes.forEach((node, index) => {
+    Object.defineProperty(node, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        top: index * 60,
+        bottom: index * 60 + 60,
+        height: 60,
+        width: 240,
+        left: 0,
+        right: 240,
+      }),
+    });
+  });
+};
+
+describe('TodayView drag-and-drop', () => {
+  it('moves a task from priority to today and triggers callbacks once', () => {
+    const onAssignToBucket = jest.fn();
+    const onReorderBucket = jest.fn();
+    const onClearBucket = jest.fn();
+    const noop = jest.fn();
+    render(
+      <TodayView
+        todayList={[createTask('t-1', 'Today Task')]}
+        priorityList={[createTask('p-1', 'Priority Task')]}
+        bonusList={[]}
+        onAssignToBucket={onAssignToBucket}
+        onReorderBucket={onReorderBucket}
+        onClearBucket={onClearBucket}
+        onBackToLanding={noop}
+        onOpenFocus={noop}
+        onCompleteTask={noop}
+      />,
+    );
+
+    const priorityZone = screen.getByTestId('priority-drop-zone');
+    const todayZone = screen.getByTestId('today-drop-zone');
+    mockBoundingRects(priorityZone);
+    mockBoundingRects(todayZone);
+
+    const priorityCard = within(priorityZone).getByText('Priority Task');
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(priorityCard, { dataTransfer });
+
+    expect(priorityZone.querySelector('[data-placeholder="true"]')).toBeInTheDocument();
+
+    fireEvent.dragEnter(todayZone, { clientY: 10, dataTransfer });
+    mockBoundingRects(todayZone);
+    fireEvent.dragOver(todayZone, { clientY: 10, dataTransfer });
+
+    expect(todayZone.querySelector('[data-placeholder="true"]')).toBeInTheDocument();
+
+    fireEvent.drop(todayZone, { clientY: 10, dataTransfer });
+    fireEvent.dragEnd(priorityCard, { dataTransfer });
+
+    expect(onClearBucket).toHaveBeenCalledTimes(1);
+    expect(onClearBucket).toHaveBeenCalledWith('p-1');
+    expect(onAssignToBucket).not.toHaveBeenCalled();
+
+    expect(onReorderBucket).toHaveBeenCalledTimes(2);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(1, 'today', ['p-1', 't-1']);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(2, 'priority', []);
+
+    expect(priorityZone.querySelector('[data-placeholder="true"]')).not.toBeInTheDocument();
+    expect(todayZone.querySelector('[data-placeholder="true"]')).not.toBeInTheDocument();
+  });
+
+  it('assigns a task from today to bonus with correct index', () => {
+    const onAssignToBucket = jest.fn();
+    const onReorderBucket = jest.fn();
+    const onClearBucket = jest.fn();
+    const noop = jest.fn();
+    render(
+      <TodayView
+        todayList={[createTask('t-1', 'Today One'), createTask('t-2', 'Today Two')]}
+        priorityList={[]}
+        bonusList={[createTask('b-1', 'Bonus One')]}
+        onAssignToBucket={onAssignToBucket}
+        onReorderBucket={onReorderBucket}
+        onClearBucket={onClearBucket}
+        onBackToLanding={noop}
+        onOpenFocus={noop}
+        onCompleteTask={noop}
+      />,
+    );
+
+    const todayZone = screen.getByTestId('today-drop-zone');
+    const bonusZone = screen.getByTestId('bonus-drop-zone');
+    mockBoundingRects(todayZone);
+    mockBoundingRects(bonusZone);
+
+    const todayCard = within(todayZone).getByText('Today Two');
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(todayCard, { dataTransfer });
+    expect(todayZone.querySelector('[data-placeholder="true"]')).toBeInTheDocument();
+
+    fireEvent.dragEnter(bonusZone, { clientY: 10, dataTransfer });
+    mockBoundingRects(bonusZone);
+    fireEvent.dragOver(bonusZone, { clientY: 10, dataTransfer });
+
+    expect(bonusZone.querySelector('[data-placeholder="true"]')).toBeInTheDocument();
+
+    fireEvent.drop(bonusZone, { clientY: 120, dataTransfer });
+    fireEvent.dragEnd(todayCard, { dataTransfer });
+
+    expect(onAssignToBucket).toHaveBeenCalledTimes(1);
+    expect(onAssignToBucket).toHaveBeenCalledWith('t-2', 'bonus', 0);
+    expect(onClearBucket).not.toHaveBeenCalled();
+
+    expect(onReorderBucket).toHaveBeenCalledTimes(2);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(1, 'bonus', ['t-2', 'b-1']);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(2, 'today', ['t-1']);
+
+    expect(todayZone.querySelector('[data-placeholder="true"]')).not.toBeInTheDocument();
+    expect(bonusZone.querySelector('[data-placeholder="true"]')).not.toBeInTheDocument();
+  });
+});

--- a/src/apps/ZenDoApp/views/DroppableBucket.js
+++ b/src/apps/ZenDoApp/views/DroppableBucket.js
@@ -1,0 +1,131 @@
+import React, { useMemo } from 'react';
+
+const PLACEHOLDER_KEY = Symbol('placeholder');
+
+const computeInsertionIndex = (event, container) => {
+  const clientY = event.clientY ?? 0;
+  const elements = Array.from(container.querySelectorAll('[data-task-id]'));
+  for (let index = 0; index < elements.length; index += 1) {
+    const element = elements[index];
+    if (element.dataset.placeholder === 'true') {
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    const middleY = rect.top + rect.height / 2;
+    if (clientY <= middleY) {
+      return index;
+    }
+  }
+  return elements.length;
+};
+
+const DroppableBucket = ({
+  bucketId,
+  className,
+  emptyHint,
+  dragController,
+  items,
+  onDrop,
+  renderItem,
+  testId,
+}) => {
+  const { dragState, updatePlaceholder, clearHover, completeDrop } = dragController;
+  const isDragging = Boolean(dragState.activeTaskId);
+  const isActiveBucket = dragState.placeholder?.bucket === bucketId;
+  const isHovered = dragState.overBucket === bucketId && isDragging;
+
+  const itemEntries = useMemo(() => items.map((task, index) => ({ task, index })), [items]);
+
+  const visibleItems = useMemo(() => {
+    if (!isDragging || dragState.sourceBucket !== bucketId) {
+      return itemEntries;
+    }
+    return itemEntries.filter((entry) => entry.task.id !== dragState.activeTaskId);
+  }, [dragState.activeTaskId, dragState.sourceBucket, itemEntries, isDragging, bucketId]);
+
+  const placeholderIndex = isActiveBucket ? dragState.placeholder?.index ?? null : null;
+
+  const renderedItems = useMemo(() => {
+    if (placeholderIndex == null) {
+      return visibleItems;
+    }
+    const cappedIndex = Math.max(0, Math.min(placeholderIndex, visibleItems.length));
+    const next = visibleItems.slice();
+    next.splice(cappedIndex, 0, { task: PLACEHOLDER_KEY, index: cappedIndex });
+    return next;
+  }, [placeholderIndex, visibleItems]);
+
+  const handleDragOver = (event) => {
+    if (!isDragging) {
+      return;
+    }
+    event.preventDefault();
+    const container = event.currentTarget;
+    const nextIndex = computeInsertionIndex(event, container);
+    updatePlaceholder(bucketId, nextIndex, visibleItems.length);
+  };
+
+  const handleDragEnter = (event) => {
+    if (!isDragging) {
+      return;
+    }
+    event.preventDefault();
+    handleDragOver(event);
+  };
+
+  const handleDragLeave = (event) => {
+    if (!isDragging) {
+      return;
+    }
+    if (!event.currentTarget.contains(event.relatedTarget)) {
+      clearHover(bucketId);
+    }
+  };
+
+  const handleDrop = (event) => {
+    event.preventDefault();
+    const result = completeDrop(bucketId);
+    if (!result?.taskId) {
+      return;
+    }
+    const index = result.index != null ? result.index : visibleItems.length;
+    onDrop({ ...result, index });
+  };
+
+  const containerClassName = [className, isHovered ? 'is-hovered' : null, isActiveBucket ? 'has-placeholder' : null]
+    .filter(Boolean)
+    .join(' ');
+
+  const shouldShowHint = renderedItems.length === 0 && (!isDragging || dragState.sourceBucket !== bucketId);
+
+  return (
+    <div
+      className={containerClassName}
+      data-testid={testId}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {shouldShowHint ? (
+        <p className="zen-empty-hint">{emptyHint}</p>
+      ) : (
+        renderedItems.map((entry, displayIndex) => {
+          if (entry.task === PLACEHOLDER_KEY) {
+            return (
+              <div
+                key={`placeholder-${bucketId}`}
+                className="zen-task-placeholder"
+                data-placeholder="true"
+                data-testid="drag-placeholder"
+              />
+            );
+          }
+          return renderItem(entry.task, entry.index, bucketId, displayIndex);
+        })
+      )}
+    </div>
+  );
+};
+
+export default DroppableBucket;

--- a/src/apps/ZenDoApp/views/useSharedDragController.js
+++ b/src/apps/ZenDoApp/views/useSharedDragController.js
@@ -1,0 +1,113 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+const initialState = {
+  activeTaskId: null,
+  sourceBucket: null,
+  placeholder: null,
+  overBucket: null,
+};
+
+const clampIndex = (index, length) => {
+  if (Number.isNaN(index) || index < 0) return 0;
+  if (index > length) return length;
+  return index;
+};
+
+const useSharedDragController = () => {
+  const [dragState, setDragState] = useState(initialState);
+  const dragSnapshotRef = useRef(initialState);
+
+  const commitState = useCallback((next) => {
+    dragSnapshotRef.current = next;
+    setDragState(next);
+  }, []);
+
+  const beginDrag = useCallback((taskId, sourceBucket, initialIndex = 0) => {
+    if (!taskId) {
+      return;
+    }
+    const next = {
+      activeTaskId: taskId,
+      sourceBucket: sourceBucket || null,
+      placeholder: {
+        bucket: sourceBucket || null,
+        index: clampIndex(initialIndex, Number.MAX_SAFE_INTEGER),
+      },
+      overBucket: sourceBucket || null,
+    };
+    commitState(next);
+  }, [commitState]);
+
+  const resolveState = useCallback(() => {
+    return dragState.activeTaskId ? dragState : dragSnapshotRef.current;
+  }, [dragState]);
+
+  const updatePlaceholder = useCallback((bucket, index, count = Number.POSITIVE_INFINITY) => {
+    const base = resolveState();
+    if (!base.activeTaskId) {
+      return;
+    }
+    const next = {
+      ...base,
+      placeholder: {
+        bucket,
+        index: clampIndex(index, Number.isFinite(count) ? count : index ?? 0),
+      },
+      overBucket: bucket,
+    };
+    commitState(next);
+  }, [commitState, resolveState]);
+
+  const clearHover = useCallback((bucket) => {
+    const base = resolveState();
+    if (!base.activeTaskId) {
+      return;
+    }
+    if (base.placeholder?.bucket !== bucket) {
+      const next = {
+        ...base,
+        overBucket: base.overBucket === bucket ? null : base.overBucket,
+      };
+      commitState(next);
+      return;
+    }
+    const next = {
+      ...base,
+      placeholder: null,
+      overBucket: base.overBucket === bucket ? null : base.overBucket,
+    };
+    commitState(next);
+  }, [commitState, resolveState]);
+
+  const completeDrop = useCallback((bucket) => {
+    const base = resolveState();
+    if (!base.activeTaskId) {
+      return null;
+    }
+    const index = base.placeholder?.bucket === bucket ? base.placeholder.index : null;
+    dragSnapshotRef.current = initialState;
+    setDragState(initialState);
+    return {
+      taskId: base.activeTaskId,
+      sourceBucket: base.sourceBucket,
+      index,
+    };
+  }, [resolveState]);
+
+  const cancelDrag = useCallback(() => {
+    setDragState(initialState);
+  }, []);
+
+  const value = useMemo(() => ({
+    dragState,
+    beginDrag,
+    updatePlaceholder,
+    clearHover,
+    completeDrop,
+    cancelDrag,
+  }), [dragState, beginDrag, updatePlaceholder, clearHover, completeDrop, cancelDrag]);
+
+  return value;
+};
+
+export default useSharedDragController;


### PR DESCRIPTION
## Summary
- replace the Sortable.js hooks in TodayView with a shared drag controller and a DroppableBucket component that renders placeholders
- highlight active drop zones and show inline placeholders while dragging to avoid mutating task arrays until drop
- add Jest tests covering drag flows to today, priority, and bonus buckets to ensure callbacks fire once and placeholders toggle correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d206ebf8a0832b8509c2beb8d560a8