### PR TITLE
Replace SortableJS with native drag handling in Zen Do

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -160,7 +160,7 @@ g1/
 
 ### Utilities
 
-* SortableJS: drag-and-drop reordering in shared UIs
+* Custom pointer-driven drag-and-drop utilities for shared planner UIs
 
 ### Cache Lab Subapp
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1",
-        "recharts": "^2.12.7",
-        "sortablejs": "^1.15.6"
+        "recharts": "^2.12.7"
       },
       "devDependencies": {
         "@babel/core": "^7.22.0",
@@ -15255,12 +15254,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",
-    "recharts": "^2.12.7",
-    "sortablejs": "^1.15.6"
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@babel/core": "^7.22.0",
@@ -41,8 +40,8 @@
     "@types/react-dom": "^18.2.25",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.0",
-    "copy-webpack-plugin": "^13.0.1",
     "concurrently": "^9.1.2",
+    "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^6.8.0",
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       recharts:
         specifier: ^2.12.7
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      sortablejs:
-        specifier: ^1.15.6
-        version: 1.15.6
     devDependencies:
       '@babel/core':
         specifier: ^7.22.0
@@ -42,6 +39,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.24.7
         version: 7.27.1(@babel/core@7.28.4)
+      '@eslint/js':
+        specifier: ^9.36.0
+        version: 9.36.0
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -4741,9 +4741,6 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
-
-  sortablejs@1.15.6:
-    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10765,8 +10762,6 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-
-  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -361,6 +361,20 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  cursor: grab;
+}
+
+.zen-week-card.is-dragging,
+.zen-focus-card.is-dragging {
+  opacity: 0.6;
+  cursor: grabbing;
+}
+
+.zen-week-bucket.is-drag-over,
+.zen-today-list.is-drag-over,
+.zen-focus-drop.is-drag-over {
+  outline: 2px dashed rgba(108, 161, 143, 0.6);
+  outline-offset: 4px;
 }
 
 .zen-card-title {

--- a/src/apps/ZenDoApp/components/TaskTree.js
+++ b/src/apps/ZenDoApp/components/TaskTree.js
@@ -27,14 +27,32 @@ const TaskNode = ({
   onAddSubtask,
   expandedIds,
   isRoot,
+  onDragStartTask,
+  onDragEndTask,
 }) => {
   const hasChildren = task.subtasks && task.subtasks.length > 0;
   const dueLabel = formatDueDate(task.dueDate);
+
+  const dragHandlers = {};
+  if (isRoot && onDragStartTask) {
+    dragHandlers.draggable = true;
+    dragHandlers.onDragStart = (event) => {
+      if (onDragStartTask) {
+        onDragStartTask(task, event);
+      }
+    };
+    dragHandlers.onDragEnd = (event) => {
+      if (onDragEndTask) {
+        onDragEndTask(task, event);
+      }
+    };
+  }
 
   return (
     <li
       className={`zen-task-node depth-${depth} ${task.completed ? 'is-complete' : ''} ${isRoot ? 'zen-root-task' : ''}`}
       data-task-id={task.id}
+      {...dragHandlers}
     >
       <div className="zen-task-row">
         <div className="zen-task-controls">
@@ -106,6 +124,8 @@ const TaskNode = ({
               onAddSubtask={onAddSubtask}
               expandedIds={expandedIds}
               isRoot={false}
+              onDragStartTask={onDragStartTask}
+              onDragEndTask={onDragEndTask}
             />
           ))}
         </ul>
@@ -122,6 +142,8 @@ const TaskTree = ({
   onDeleteTask,
   onCompleteTask,
   onAddSubtask,
+  onDragStartTask,
+  onDragEndTask,
 }) => {
   if (!tasks.length) {
     return (
@@ -146,6 +168,8 @@ const TaskTree = ({
           onAddSubtask={onAddSubtask}
           expandedIds={expandedIds}
           isRoot
+          onDragStartTask={onDragStartTask}
+          onDragEndTask={onDragEndTask}
         />
       ))}
     </ul>

--- a/src/apps/ZenDoApp/views/TodayView.js
+++ b/src/apps/ZenDoApp/views/TodayView.js
@@ -1,10 +1,17 @@
-import React, { useEffect, useRef } from 'react';
-import Sortable from 'sortablejs';
+import React, { useRef } from 'react';
 import { FOCUS_BUCKETS } from '../constants';
 
-const createSortable = (element, options) => {
-  if (!element) return null;
-  return Sortable.create(element, options);
+const getDropIndex = (container, clientY) => {
+  if (!container) return 0;
+  const items = Array.from(container.querySelectorAll('[data-task-id]:not(.is-dragging)'));
+  if (!items.length) return 0;
+  for (let index = 0; index < items.length; index += 1) {
+    const rect = items[index].getBoundingClientRect();
+    if (clientY < rect.top + rect.height / 2) {
+      return index;
+    }
+  }
+  return items.length;
 };
 
 const TodayView = ({
@@ -21,95 +28,131 @@ const TodayView = ({
   const todayRef = useRef(null);
   const priorityRef = useRef(null);
   const bonusRef = useRef(null);
-  const sortablesRef = useRef({});
+  const dragStateRef = useRef(null);
 
-  useEffect(() => {
-    const discardSortableClone = (evt) => {
-      const cloneNode = evt.clone || evt.item;
-      if (cloneNode && cloneNode.parentNode) {
-        cloneNode.parentNode.removeChild(cloneNode);
+  const getContainerForBucket = (bucket) => {
+    if (bucket === 'today') return todayRef.current;
+    if (bucket === 'priority') return priorityRef.current;
+    if (bucket === 'bonus') return bonusRef.current;
+    return null;
+  };
+
+  const getAssignmentsForBucket = (bucket) => {
+    if (bucket === 'today') return todayList;
+    if (bucket === 'priority') return priorityList;
+    if (bucket === 'bonus') return bonusList;
+    return [];
+  };
+
+  const clearHighlights = () => {
+    ['today', 'priority', 'bonus'].forEach((bucket) => {
+      const container = getContainerForBucket(bucket);
+      if (container) {
+        container.classList.remove('is-drag-over');
       }
-    };
-
-    sortablesRef.current.today = createSortable(todayRef.current, {
-      group: { name: 'zen-today', pull: 'clone', put: true },
-      animation: 150,
-      dataIdAttr: 'data-task-id',
-      fallbackOnBody: true,
-      onAdd: (evt) => {
-        const taskId = evt.item?.dataset?.taskId;
-        if (taskId) {
-          onClearBucket(taskId);
-          const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-          onReorderBucket('today', order);
-        }
-        discardSortableClone(evt);
-      },
-      onRemove: (evt) => {
-        const order = Array.from(evt.from.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-        onReorderBucket('today', order);
-      },
     });
+  };
 
-    sortablesRef.current.priority = createSortable(priorityRef.current, {
-      group: { name: 'zen-today', pull: 'clone', put: true },
-      animation: 150,
-      dataIdAttr: 'data-task-id',
-      fallbackOnBody: true,
-      onAdd: (evt) => {
-        const taskId = evt.item?.dataset?.taskId;
-        if (taskId) {
-          onAssignToBucket(taskId, 'priority', evt.newIndex);
-          const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-          onReorderBucket('priority', order);
+  const clearDragState = () => {
+    dragStateRef.current = null;
+    clearHighlights();
+  };
+
+  const handleCardDragStart = (bucket, task, index, event) => {
+    dragStateRef.current = { source: bucket, taskId: task.id, index };
+    if (event?.currentTarget) {
+      event.currentTarget.classList.add('is-dragging');
+    }
+    if (event?.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', task.id);
+    }
+  };
+
+  const handleCardDragEnd = (event) => {
+    if (event?.currentTarget) {
+      event.currentTarget.classList.remove('is-dragging');
+    }
+    clearDragState();
+  };
+
+  const handleListDragOver = (bucket, event) => {
+    if (!dragStateRef.current) return;
+    event.preventDefault();
+    const container = getContainerForBucket(bucket);
+    if (container) {
+      container.classList.add('is-drag-over');
+    }
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  };
+
+  const handleListDragLeave = (bucket, event) => {
+    const container = getContainerForBucket(bucket);
+    if (!container) return;
+    if (event?.relatedTarget && container.contains(event.relatedTarget)) {
+      return;
+    }
+    container.classList.remove('is-drag-over');
+  };
+
+  const handleListDrop = (bucket, event) => {
+    if (!dragStateRef.current) return;
+    event.preventDefault();
+    const container = getContainerForBucket(bucket);
+    if (container) {
+      container.classList.remove('is-drag-over');
+    }
+    const dropIndex = getDropIndex(container, event.clientY);
+    const { taskId, source } = dragStateRef.current;
+    clearDragState();
+
+    const currentOrder = getAssignmentsForBucket(bucket)
+      .map((task) => task.id)
+      .filter((id) => id !== taskId);
+    const insertionIndex = Math.min(dropIndex, currentOrder.length);
+    currentOrder.splice(insertionIndex, 0, taskId);
+
+    if (bucket === 'today') {
+      if (source === 'today') {
+        onReorderBucket('today', currentOrder);
+      } else if (source === 'priority' || source === 'bonus') {
+        onClearBucket(taskId);
+        onReorderBucket('today', currentOrder);
+        const sourceOrder = getAssignmentsForBucket(source)
+          .map((task) => task.id)
+          .filter((id) => id !== taskId);
+        onReorderBucket(source, sourceOrder);
+      }
+    } else if (bucket === 'priority' || bucket === 'bonus') {
+      if (source === bucket) {
+        onReorderBucket(bucket, currentOrder);
+      } else if (source === 'today' || source === 'priority' || source === 'bonus') {
+        onAssignToBucket(taskId, bucket, insertionIndex);
+        onReorderBucket(bucket, currentOrder);
+        if (source === 'today') {
+          const todayOrder = todayList.map((task) => task.id).filter((id) => id !== taskId);
+          onReorderBucket('today', todayOrder);
+        } else if (source === 'priority' || source === 'bonus') {
+          const sourceOrder = getAssignmentsForBucket(source)
+            .map((task) => task.id)
+            .filter((id) => id !== taskId);
+          onReorderBucket(source, sourceOrder);
         }
-        discardSortableClone(evt);
-      },
-      onUpdate: (evt) => {
-        const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-        onReorderBucket('priority', order);
-      },
-      onRemove: (evt) => {
-        const order = Array.from(evt.from.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-        onReorderBucket('priority', order);
-      },
-    });
+      }
+    }
+  };
 
-    sortablesRef.current.bonus = createSortable(bonusRef.current, {
-      group: { name: 'zen-today', pull: 'clone', put: true },
-      animation: 150,
-      dataIdAttr: 'data-task-id',
-      fallbackOnBody: true,
-      onAdd: (evt) => {
-        const taskId = evt.item?.dataset?.taskId;
-        if (taskId) {
-          onAssignToBucket(taskId, 'bonus', evt.newIndex);
-          const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-          onReorderBucket('bonus', order);
-        }
-        discardSortableClone(evt);
-      },
-      onUpdate: (evt) => {
-        const order = Array.from(evt.to.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-        onReorderBucket('bonus', order);
-      },
-      onRemove: (evt) => {
-        const order = Array.from(evt.from.querySelectorAll('[data-task-id]')).map((el) => el.dataset.taskId);
-        onReorderBucket('bonus', order);
-      },
-    });
-
-    return () => {
-      Object.values(sortablesRef.current).forEach((instance) => {
-        if (instance) {
-          instance.destroy();
-        }
-      });
-    };
-  }, [onAssignToBucket, onReorderBucket, onClearBucket]);
-
-  const renderCard = (task) => (
-    <div key={task.id} className="zen-focus-card" data-task-id={task.id}>
+  const renderCard = (task, bucket, index) => (
+    <div
+      key={task.id}
+      className="zen-focus-card"
+      data-task-id={task.id}
+      draggable
+      onDragStart={(event) => handleCardDragStart(bucket, task, index, event)}
+      onDragEnd={handleCardDragEnd}
+    >
       <div className="zen-card-title-row">
         <span>{task.title}</span>
         <input
@@ -132,11 +175,18 @@ const TodayView = ({
           </button>
           <h2>Today&apos;s Flow</h2>
         </header>
-        <div className="zen-today-list" ref={todayRef}>
+        <div
+          className="zen-today-list"
+          ref={todayRef}
+          onDragEnter={(event) => handleListDragOver('today', event)}
+          onDragOver={(event) => handleListDragOver('today', event)}
+          onDragLeave={(event) => handleListDragLeave('today', event)}
+          onDrop={(event) => handleListDrop('today', event)}
+        >
           {todayList.length === 0 ? (
             <p className="zen-empty-hint">Drag tasks from the week buckets or create something new.</p>
           ) : (
-            todayList.map(renderCard)
+            todayList.map((task, index) => renderCard(task, 'today', index))
           )}
         </div>
       </section>
@@ -147,14 +197,32 @@ const TodayView = ({
         <div className="zen-focus-grid">
           <div className="zen-focus-column">
             <h3>{FOCUS_BUCKETS.priority.title}</h3>
-            <div className="zen-focus-drop" ref={priorityRef}>
-              {priorityList.length === 0 ? <p className="zen-empty-hint">Set your core intentions here.</p> : priorityList.map(renderCard)}
+            <div
+              className="zen-focus-drop"
+              ref={priorityRef}
+              onDragEnter={(event) => handleListDragOver('priority', event)}
+              onDragOver={(event) => handleListDragOver('priority', event)}
+              onDragLeave={(event) => handleListDragLeave('priority', event)}
+              onDrop={(event) => handleListDrop('priority', event)}
+            >
+              {priorityList.length === 0
+                ? <p className="zen-empty-hint">Set your core intentions here.</p>
+                : priorityList.map((task, index) => renderCard(task, 'priority', index))}
             </div>
           </div>
           <div className="zen-focus-column">
             <h3>{FOCUS_BUCKETS.bonus.title}</h3>
-            <div className="zen-focus-drop" ref={bonusRef}>
-              {bonusList.length === 0 ? <p className="zen-empty-hint">Reserve bonus blooms for extra energy.</p> : bonusList.map(renderCard)}
+            <div
+              className="zen-focus-drop"
+              ref={bonusRef}
+              onDragEnter={(event) => handleListDragOver('bonus', event)}
+              onDragOver={(event) => handleListDragOver('bonus', event)}
+              onDragLeave={(event) => handleListDragLeave('bonus', event)}
+              onDrop={(event) => handleListDrop('bonus', event)}
+            >
+              {bonusList.length === 0
+                ? <p className="zen-empty-hint">Reserve bonus blooms for extra energy.</p>
+                : bonusList.map((task, index) => renderCard(task, 'bonus', index))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the SortableJS wiring in the Zen Do landing and today planners with custom drag-and-drop handlers that manage cross-list moves and reordering
- extend the shared TaskTree to expose drag start/end hooks and add styling feedback for drag states
- drop the SortableJS dependency from the project and update documentation to reflect the native implementation

## Testing
- npm test -- ZenDoApp

------
https://chatgpt.com/codex/tasks/task_e_68d206edce90832b85c67af6471639d9