### PR TITLE
Remove SortableJS dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1",
-        "recharts": "^2.12.7",
-        "sortablejs": "^1.15.6"
+        "recharts": "^2.12.7"
       },
       "devDependencies": {
         "@babel/core": "^7.22.0",
@@ -15255,12 +15254,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",
-    "recharts": "^2.12.7",
-    "sortablejs": "^1.15.6"
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@babel/core": "^7.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       recharts:
         specifier: ^2.12.7
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      sortablejs:
-        specifier: ^1.15.6
-        version: 1.15.6
     devDependencies:
       '@babel/core':
         specifier: ^7.22.0
@@ -42,6 +39,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.24.7
         version: 7.27.1(@babel/core@7.28.4)
+      '@eslint/js':
+        specifier: ^9.36.0
+        version: 9.36.0
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -4741,9 +4741,6 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
-
-  sortablejs@1.15.6:
-    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10765,8 +10762,6 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-
-  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- remove SortableJS from the root project dependencies
- regenerate npm and pnpm lockfiles so SortableJS is no longer installed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2123d1914832b8e3f3df0c2bf506a