### PR TITLE
Enhance LangMath parsing for advanced math words

### DIFF
--- a/src/apps/lang-math/index.html
+++ b/src/apps/lang-math/index.html
@@ -469,7 +469,7 @@
           divided_by: '/',
         };
 
-        const skipTokens = new Set(['and']);
+        const skipTokens = new Set(['and', 'of', 'the', 'a', 'an']);
 
         const onesMap = {
           zero: 0,
@@ -504,6 +504,28 @@
           eighty: 80,
           ninety: 90,
         };
+
+        const constantsMap = {
+          pi: 'pi',
+          tau: 'tau',
+        };
+
+        const functionNameMap = {
+          sqrt: 'sqrt',
+          exp: 'exp',
+          log10: 'log10',
+          log2: 'log2',
+          ln: 'log',
+          sin: 'sin',
+          cos: 'cos',
+          tan: 'tan',
+          factorial: 'factorial',
+        };
+
+        const allowedIdentifiers = new Set([
+          ...Object.values(functionNameMap),
+          ...Object.values(constantsMap),
+        ]);
 
         const historyEntries = [];
 
@@ -601,7 +623,19 @@
         };
 
         const sanitizeExpression = (expression) => {
-          return /^[\d\s+\-*/]+$/.test(expression);
+          if (!expression || !/^[0-9+\-*/().\sA-Za-z_]+$/.test(expression)) {
+            return false;
+          }
+
+          const identifierPattern = /[A-Za-z_][A-Za-z0-9_]*/g;
+          let match;
+          while ((match = identifierPattern.exec(expression)) !== null) {
+            if (!allowedIdentifiers.has(match[0])) {
+              return false;
+            }
+          }
+
+          return true;
         };
 
         const consumeNumber = (tokens, startIndex) => {
@@ -642,20 +676,22 @@
 
         const parseQuery = (raw) => {
           if (!raw) {
-            return null;
+            return { error: 'No input provided', steps: [] };
           }
 
           let prepared = raw
             .toLowerCase()
             .replace(/[^a-z0-9\s-]/g, ' ')
             .replace(/-/g, ' ')
+            .replace(/\b(open|left|opening)\s+(?:parenthesis|parentheses|paren|bracket|brackets)\b/g, 'open_paren')
+            .replace(/\b(close|right|closing)\s+(?:parenthesis|parentheses|paren|bracket|brackets)\b/g, 'close_paren')
             .replace(/multiplied\s+by/g, 'multiplied_by')
             .replace(/divided\s+by/g, 'divided_by')
             .replace(/\s+/g, ' ')
             .trim();
 
           if (!prepared) {
-            return null;
+            return { error: 'Could not understand the request', steps: [] };
           }
 
           const steps = [];
@@ -663,56 +699,150 @@
 
           const tokens = prepared.split(' ').filter(Boolean);
           if (!tokens.length) {
-            return null;
+            return { error: 'Could not parse query', steps };
           }
 
           steps.push(`Tokenize → [${tokens.map(formatTokenDisplay).join(', ')}]`);
 
-          const pieces = [];
-          const convertedPieces = [];
-          let expectingNumber = true;
-          let index = 0;
+          const filteredTokens = tokens.filter((token) => !skipTokens.has(token));
 
-          while (index < tokens.length) {
-            const token = tokens[index];
-
-            if (skipTokens.has(token)) {
-              index += 1;
-              continue;
-            }
-
-            if (expectingNumber) {
-              const numberResult = consumeNumber(tokens, index);
-              if (!numberResult) {
-                return null;
-              }
-              pieces.push(String(numberResult.value));
-              convertedPieces.push(numberResult.value);
-              index += numberResult.consumed;
-              expectingNumber = false;
-              continue;
-            }
-
-            if (!Object.prototype.hasOwnProperty.call(operatorMap, token)) {
-              return null;
-            }
-
-            const operatorSymbol = operatorMap[token];
-            pieces.push(operatorSymbol);
-            convertedPieces.push(operatorSymbol);
-            index += 1;
-            expectingNumber = true;
+          if (!filteredTokens.length) {
+            steps.push('Filter filler words → []');
+            return { error: 'Need a number, constant, or function to evaluate', steps };
           }
 
-          if (!pieces.length || expectingNumber) {
-            return null;
+          if (filteredTokens.length !== tokens.length) {
+            steps.push(`Filter filler words → [${filteredTokens.map(formatTokenDisplay).join(', ')}]`);
+          }
+
+          const normalizedTokens = filteredTokens.map((token) => {
+            if (token === 'open_paren') {
+              return '(';
+            }
+            if (token === 'close_paren') {
+              return ')';
+            }
+            return token;
+          });
+
+          if (
+            normalizedTokens.length !== filteredTokens.length ||
+            normalizedTokens.some((token, index) => token !== filteredTokens[index])
+          ) {
+            steps.push(
+              `Replace bracket phrases → [${normalizedTokens.map(formatTokenDisplay).join(', ')}]`
+            );
+          }
+
+          let position = 0;
+
+          const parseValue = () => {
+            if (position >= normalizedTokens.length) {
+              throw new Error('Expected a value but reached the end of the query');
+            }
+
+            const current = normalizedTokens[position];
+
+            if (current === ')') {
+              throw new Error('Unexpected closing bracket');
+            }
+
+            if (current === '(') {
+              position += 1;
+              const inner = parseExpression();
+              if (position >= normalizedTokens.length || normalizedTokens[position] !== ')') {
+                throw new Error('Missing closing bracket for "("');
+              }
+              position += 1;
+              return `(${inner})`;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(functionNameMap, current)) {
+              const functionName = functionNameMap[current];
+              position += 1;
+              if (position >= normalizedTokens.length) {
+                throw new Error(`Function "${current}" needs a value or bracketed expression`);
+              }
+              const argument = parseValue();
+              if (argument.startsWith('(') && argument.endsWith(')')) {
+                return `${functionName}${argument}`;
+              }
+              return `${functionName}(${argument})`;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(constantsMap, current)) {
+              position += 1;
+              return constantsMap[current];
+            }
+
+            const numberResult = consumeNumber(normalizedTokens, position);
+            if (numberResult) {
+              position += numberResult.consumed;
+              return String(numberResult.value);
+            }
+
+            throw new Error(`Unrecognized token "${current}"`);
+          };
+
+          const parseExpression = () => {
+            const firstValue = parseValue();
+            const segments = [firstValue];
+
+            while (position < normalizedTokens.length) {
+              const nextToken = normalizedTokens[position];
+              if (nextToken === ')') {
+                break;
+              }
+
+              if (!Object.prototype.hasOwnProperty.call(operatorMap, nextToken)) {
+                throw new Error(`Expected an operator but found "${nextToken}"`);
+              }
+
+              const operatorSymbol = operatorMap[nextToken];
+              position += 1;
+              const nextValue = parseValue();
+              segments.push(operatorSymbol, nextValue);
+            }
+
+            return segments.join(' ');
+          };
+
+          let expression;
+          try {
+            expression = parseExpression();
+          } catch (error) {
+            return { error: error.message || 'Could not parse query', steps };
+          }
+
+          if (!expression) {
+            return { error: 'Could not parse query', steps };
+          }
+
+          if (position < normalizedTokens.length) {
+            const remaining = normalizedTokens[position];
+            if (remaining === ')') {
+              return { error: 'Missing opening bracket for ")"', steps };
+            }
+            return { error: `Unexpected token "${remaining}"`, steps };
+          }
+
+          const expressionTokenPattern = /(log10|log2|factorial|sqrt|exp|sin|cos|tan|log|pi|tau|\d+|[()+\-*/])/g;
+
+          const convertedPieces = [];
+          let match;
+          while ((match = expressionTokenPattern.exec(expression)) !== null) {
+            const piece = match[1];
+            if (/^\d+$/.test(piece)) {
+              convertedPieces.push(Number.parseInt(piece, 10));
+            } else {
+              convertedPieces.push(piece);
+            }
           }
 
           steps.push(`Convert words → [${convertedPieces.map(formatConvertedDisplay).join(', ')}]`);
 
-          const expression = pieces.join(' ');
           if (!sanitizeExpression(expression)) {
-            return null;
+            return { error: 'Expression contains unsupported content', steps };
           }
 
           steps.push(`Build expression → ${expression}`);
@@ -742,9 +872,13 @@
           }
 
           const parsed = parseQuery(query);
-          if (!parsed) {
-            clearSteps();
-            setResult('Could not parse query', 'error');
+          if (!parsed || parsed.error) {
+            if (parsed && parsed.steps) {
+              renderSteps(parsed.steps);
+            } else {
+              clearSteps();
+            }
+            setResult(parsed?.error || 'Could not parse query', 'error');
             return;
           }
 
@@ -801,6 +935,10 @@
               { input: 'thirteen minus eight', expected: '5' },
               { input: 'six times seven', expected: '42' },
               { input: 'forty divided by five', expected: '8' },
+              { input: 'sqrt four', expected: '2' },
+              { input: 'log2 eight', expected: '3' },
+              { input: 'factorial three', expected: '6' },
+              { input: 'SIN pi', expected: '0' },
             ];
 
             smokeTests.forEach((test) => {


### PR DESCRIPTION
## Summary
- extend the LangMath parser to recognize constants, unary math functions, and spoken bracket phrases while tightening expression sanitization
- add detailed parsing steps and targeted error messages for malformed function or parenthesis usage
- surface parse failures in the UI and expand smoke tests to cover the new math vocabulary and case-insensitive input

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d2142c8980832b8aaea5426796ec83