### PR TITLE
chore: remove sortablejs from Zen Do

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Gif coming soon
 
 * **Day Switcher**: cycle through the week with animated transitions.
 * **CatPad**: cat-themed note editor with GitHub gist syncing.
-* **Zen Do**: manage tasks in a zen-styled weekly garden with focus mode, gist sync, and a rebuilt SortableJS drag system that clones tasks from the tree into weekly and focus buckets. 【F:src/apps/ZenDoApp/views/LandingView.js†L24-L91】【F:src/apps/ZenDoApp/views/TodayView.js†L34-L99】
+* **Zen Do**: manage tasks in a zen-styled weekly garden with focus mode, gist sync, and a custom pointer-driven drag system for moving cards between the task tree, weekly buckets, and focus lists. 【F:src/apps/ZenDoApp/views/LandingView.js†L1-L168】【F:src/apps/ZenDoApp/views/TodayView.js†L1-L126】
 * **N-Pomodoro**: orchestrate multi-activity pomodoro sessions.
 
 ### Games
@@ -177,7 +177,7 @@ g1/
 
 ### Utilities
 
-* SortableJS: drag-and-drop reordering in shared UIs
+* Custom pointer and HTML Drag and Drop controllers for Zen Do scheduling flows
 
 ### Cache Lab Subapp
 

--- a/docs/ZenDoApp.md
+++ b/docs/ZenDoApp.md
@@ -1,12 +1,12 @@
 # Zen Do Drag & Scheduling Reference
 
 ## Drag controller architecture
-- The landing view wires SortableJS to the root task tree and each weekly bucket. The task tree runs in clone-only mode so dragging a root task only spawns a preview while the source list stays untouched, and bucket containers accept both clones and reorders to persist assignments (see `views/LandingView.js`).
-- Today view builds three independent Sortable instances: one for the Today staging list that clears focus metadata on drop, and one for each Focus bucket that persists assignments and reorders within their columns. All controllers share the `zen-today` group to allow cross-column moves while maintaining clone behaviour (see `views/TodayView.js`).
+- The landing view relies on the shared `DragContext` hook. `TaskTree` kicks off pointer-based drags via `beginDrag`, while each weekly bucket listens for pointer movement and feeds hover metadata back through `setHoverTarget`. Drops resolve through the context-aware `onDrop` handler to keep `dayAssignments` in sync (see `views/LandingView.js`).
+- Today view uses a lightweight HTML Drag and Drop wrapper. `useSharedDragController` tracks the active card, placeholder index, and hovered bucket so `DroppableBucket` can render insertion hints and fire `onDrop` payloads with normalized indices (see `views/TodayView.js`).
 
 ## Preview overlay handling
-- Each Sortable instance opts into `fallbackOnBody` so pointer and touch drags render a floating ghost element anchored to the document body, which keeps long columns from clipping the preview.
-- Drag callbacks explicitly remove Sortable’s clones or placeholder nodes after a drop completes. Landing view prunes clones spawned from the task tree and weekly buckets, while Today view shares a `discardSortableClone` helper to clean up whichever element Sortable created for the gesture.
+- `DragPreview` renders a portal-based floating card that mirrors the pointer position supplied by the `DragContext`. Pointer offsets keep the preview aligned with the cursor or touch start, preventing clipping in tall columns.
+- `DroppableBucket` owns placeholder rendering and clears hover state when the pointer leaves a bucket. Because we control the DOM directly, no extra clone cleanup is required—cards are filtered from their source list until the drop is committed.
 
 ## Data callback lifecycle
 - Weekly drops call `onAssignTaskToDay` with the task id, target day, and position, then immediately compute the new DOM order so `onReorderDay` persists the schedule indices. Today view mirrors this by invoking `onAssignToBucket`, `onReorderBucket`, and `onClearBucket` depending on the drop target.
@@ -14,8 +14,8 @@
 - The utilities coerce schedules to a normalized shape so moving a task between days clears old focus assignments, and moving between focus buckets preserves order indexes per container. This logic lives in `assignTaskToDay`, `reorderDayAssignments`, `assignFocusBucket`, `reorderFocusBucket`, `removeFocusBucket`, and `removeDayAssignment` in `taskUtils.js`.
 
 ## Manual QA checklist
-1. **Weekly planning drag loop** – With a mouse or touchpad, drag a root task from *All Tasks* into a weekly bucket and back again. Confirm the source list still contains the item (clone-only pull) and the bucket cards reorder to match the drop position.
-2. **Today view promotions** – Drag a card from a weekly bucket into the Today column, then into Priority/Bonus. Verify the ghost preview tracks the pointer, the target column reorders correctly, and leaving the Today list clears any prior focus bucket metadata.
+1. **Weekly planning drag loop** – With a mouse or touchpad, drag a root task from *All Tasks* into a weekly bucket and back again. Confirm the source list still contains the item and the bucket cards reorder to match the drop position supplied by the hover index.
+2. **Today view promotions** – Drag a card from a weekly bucket into the Today column, then into Priority/Bonus. Verify the placeholder tracks the pointer, the target column reorders correctly, and leaving the Today list clears any prior focus bucket metadata.
 3. **Keyboard fallback** – Use Tab/Shift+Tab to reach the “+ New Task” button, press Enter to launch the editor, and save a task. Expand/collapse it with the toggle buttons and mark it complete via the checkbox to confirm core flows remain accessible without drag gestures.
-4. **Touch and clone cleanup** – On a touch device or emulator, flick a task between buckets and ensure the preview disappears after release without leaving orphaned DOM nodes or duplicate cards. The cleanup hooks in both views remove Sortable’s clones post-drop.
+4. **Touch responsiveness** – On a touch device or emulator, flick a task between buckets and ensure the preview disappears after release without leaving orphaned DOM nodes or duplicate cards. The shared controllers reset hover state and drag snapshots on pointer cancel events.
 5. **State regression guardrails** – After moving tasks across days and focus buckets, reload the app to confirm schedules persist via the normalized task utilities. The Jest suite covers null schedule migrations for both day assignments and focus buckets; run `npm test -- src/apps/ZenDoApp/__tests__/taskUtils.test.js` to verify.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.30.1",
-        "recharts": "^2.12.7",
-        "sortablejs": "^1.15.6"
+        "recharts": "^2.12.7"
       },
       "devDependencies": {
         "@babel/core": "^7.22.0",
@@ -15255,12 +15254,6 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
-    },
-    "node_modules/sortablejs": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
-      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
-      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.1",
-    "recharts": "^2.12.7",
-    "sortablejs": "^1.15.6"
+    "recharts": "^2.12.7"
   },
   "devDependencies": {
     "@babel/core": "^7.22.0",
@@ -41,8 +40,8 @@
     "@types/react-dom": "^18.2.25",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.0",
-    "copy-webpack-plugin": "^13.0.1",
     "concurrently": "^9.1.2",
+    "copy-webpack-plugin": "^13.0.1",
     "css-loader": "^6.8.0",
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       recharts:
         specifier: ^2.12.7
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      sortablejs:
-        specifier: ^1.15.6
-        version: 1.15.6
     devDependencies:
       '@babel/core':
         specifier: ^7.22.0
@@ -42,6 +39,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.24.7
         version: 7.27.1(@babel/core@7.28.4)
+      '@eslint/js':
+        specifier: ^9.36.0
+        version: 9.36.0
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -4741,9 +4741,6 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
-
-  sortablejs@1.15.6:
-    resolution: {integrity: sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10765,8 +10762,6 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-
-  sortablejs@1.15.6: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- remove the unused SortableJS dependency and refresh both npm and pnpm lockfiles
- document the new pointer-driven drag controllers in the Zen Do docs and README

## Testing
- npm test -- ZenDoApp
- npx jest ZenDoApp --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d216e9ec94832b8575dbb9da02ccf9