### PR TITLE
Add cosmos HUD timer and trail controls

### DIFF
--- a/src/apps/cosmos/bodies.js
+++ b/src/apps/cosmos/bodies.js
@@ -390,8 +390,10 @@ export function updateBodyMeshes(visuals, simulationBodies, { scale, showTrails 
     } else if (showTrails) {
       const history = body.history;
       const { trailPositions, trailGeometry, trail } = visual;
+      const availablePoints = trailPositions.length / 3;
+      const drawCount = Math.min(history.length, availablePoints);
 
-      for (let i = 0; i < history.length; i += 1) {
+      for (let i = 0; i < drawCount; i += 1) {
         const entry = history[i];
         const offset = i * 3;
         trailPositions[offset] = entry.x * scale;
@@ -400,9 +402,11 @@ export function updateBodyMeshes(visuals, simulationBodies, { scale, showTrails 
       }
 
       trailGeometry.attributes.position.needsUpdate = true;
-      trailGeometry.setDrawRange(0, history.length);
-      trailGeometry.computeBoundingSphere();
-      trail.visible = history.length > 1;
+      trailGeometry.setDrawRange(0, drawCount);
+      if (drawCount > 0) {
+        trailGeometry.computeBoundingSphere();
+      }
+      trail.visible = drawCount > 1;
     } else {
       visual.trailGeometry.setDrawRange(0, 0);
       visual.trail.visible = false;

--- a/src/apps/cosmos/controls.js
+++ b/src/apps/cosmos/controls.js
@@ -1,9 +1,14 @@
 import GUI from 'https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm';
 
+export const TIME_SPEED_RANGE = { min: 100, max: 20000, step: 100 };
+export const TRAIL_LENGTH_RANGE = { min: 120, max: 720, step: 30 };
+export const DEFAULT_TRAIL_LENGTH = 720;
+
 const DEFAULTS = {
   timeSpeed: 4000,
   gravityMultiplier: 1,
   showTrails: true,
+  trailLength: DEFAULT_TRAIL_LENGTH,
 };
 
 export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
@@ -16,7 +21,7 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
   gui.domElement.classList.add('cosmos-gui');
 
   gui
-    .add(settings, 'timeSpeed', 100, 20000, 100)
+    .add(settings, 'timeSpeed', TIME_SPEED_RANGE.min, TIME_SPEED_RANGE.max, TIME_SPEED_RANGE.step)
     .name('Time speed (×)')
     .onChange((value) => handlers.onTimeSpeedChange?.(value));
 
@@ -29,6 +34,17 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     .add(settings, 'showTrails')
     .name('Show trails')
     .onChange((value) => handlers.onTrailsToggle?.(value));
+
+  gui
+    .add(
+      settings,
+      'trailLength',
+      TRAIL_LENGTH_RANGE.min,
+      TRAIL_LENGTH_RANGE.max,
+      TRAIL_LENGTH_RANGE.step,
+    )
+    .name('Trail length')
+    .onChange((value) => handlers.onTrailLengthChange?.(value));
 
   const cameraFolder = gui.addFolder('Camera');
   bodies.forEach((body) => {
@@ -81,6 +97,7 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
   handlers.onTimeSpeedChange?.(settings.timeSpeed);
   handlers.onGravityChange?.(settings.gravityMultiplier);
   handlers.onTrailsToggle?.(settings.showTrails);
+  handlers.onTrailLengthChange?.(settings.trailLength);
 
   return { gui, settings };
 }

--- a/src/apps/cosmos/index.html
+++ b/src/apps/cosmos/index.html
@@ -84,6 +84,10 @@
             </div>
           </div>
         </aside>
+        <div class="cosmos-timer" aria-live="polite">
+          <span class="cosmos-timer__label">Sim time</span>
+          <span class="cosmos-timer__value">0.0000&#8239;Myr</span>
+        </div>
         <div class="cosmos-loader">Loading solar system…</div>
       </section>
       <footer class="cosmos-footer">

--- a/src/apps/cosmos/styles.css
+++ b/src/apps/cosmos/styles.css
@@ -70,6 +70,42 @@ body {
   height: 100%;
 }
 
+.cosmos-timer {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(6, 18, 18, 0.78), rgba(12, 28, 24, 0.62));
+  border: 1px solid rgba(48, 124, 90, 0.45);
+  box-shadow: 0 16px 32px rgba(2, 10, 12, 0.45);
+  backdrop-filter: blur(12px);
+  color: var(--timer-color, #0f9458);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 11;
+}
+
+.cosmos-timer__label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  opacity: 0.75;
+}
+
+.cosmos-timer__value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: inherit;
+}
+
 .cosmos-loader {
   position: absolute;
   inset: 50% auto auto 50%;


### PR DESCRIPTION
## Summary
- add a HUD timer element to the Cosmos viewport and style it with a glassmorphic card
- track simulated time, colourise the timer based on time speed, and expose the value in Myr
- add a trail length control that trims simulation history and skips drawing when trails are hidden

## Testing
- npm run lint *(fails: existing lint errors outside the Cosmos app)*
- npx eslint src/apps/cosmos/main.js


------
https://chatgpt.com/codex/tasks/task_e_68d2188897a0832b8afca44ebfc183ad