### PR TITLE
Refine CatNap drowsiness progression

### DIFF
--- a/src/apps/CatNapLeapApp/CatNapLeapApp.js
+++ b/src/apps/CatNapLeapApp/CatNapLeapApp.js
@@ -240,6 +240,7 @@ const createInitialState = (width, height, highScore, catAppearance, kittenMode 
       perfects: 0,
     },
     drowsiness: 0,
+    drowsinessProgress: 0,
     lastReason: 'Tap or press space to wake Noodle the cat.',
     highScore,
     effects: {
@@ -491,6 +492,7 @@ const CatNapLeapApp = () => {
     state.stats.score = 0;
     state.stats.perfects = 0;
     state.drowsiness = 8;
+    state.drowsinessProgress = 0;
     state.lastReason = '';
     state.effects.yarnUntil = 0;
     state.effects.catnipUntil = 0;
@@ -522,6 +524,7 @@ const CatNapLeapApp = () => {
         switch (type) {
           case 'coffee':
             state.drowsiness = 0;
+            state.drowsinessProgress = 0;
             indicatorLabels.push(`Morning Brew ×${count}`);
             break;
           case 'yarn':
@@ -598,6 +601,7 @@ const CatNapLeapApp = () => {
     switch (powerup.type) {
       case 'coffee':
         state.drowsiness = 0;
+        state.drowsinessProgress = 0;
         break;
       case 'yarn':
         state.effects.yarnUntil = now + 4000;
@@ -727,7 +731,7 @@ const CatNapLeapApp = () => {
       state.cat.vy += gravity * delta;
       state.cat.y += state.cat.vy * delta;
 
-      const drowsinessRate = (5.5 + state.stats.score * 0.03) * (state.kittenMode ? 0.2 : 1);
+      const drowsinessRate = (5.5 + state.drowsinessProgress * 0.03) * (state.kittenMode ? 0.2 : 1);
       state.drowsiness = clamp(state.drowsiness + drowsinessRate * delta, 0, 100);
 
       state.pillowTimer += deltaMs;
@@ -781,6 +785,8 @@ const CatNapLeapApp = () => {
         if (!pillow.scored && pillow.x + pillow.width < state.cat.x - state.cat.radius) {
           pillow.scored = true;
           state.stats.score += 1;
+          const progressIncrement = 1 / Math.max(speedMultiplier, 1);
+          state.drowsinessProgress += progressIncrement;
           const centerDistance = Math.abs(state.cat.y - pillow.gapCenter);
           if (centerDistance <= pillow.gapHeight * 0.18) {
             state.stats.perfects += 1;


### PR DESCRIPTION
## Summary
- add a dedicated drowsinessProgress accumulator to the CatNap Leap state and reset it alongside drowsiness
- tie drowsiness growth to the new accumulator and dampen pillow increments when yarn speed boosts are active

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d2125792e8832b9c16a0fff7625967