### PR TITLE
Remove TodayView completion toggle

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.js
+++ b/src/apps/ZenDoApp/ZenDoApp.js
@@ -319,7 +319,6 @@ const ZenDoApp = ({ onBack }) => {
             onClearBucket={handleClearFocus}
             onBackToLanding={() => setCurrentView('landing')}
             onOpenFocus={() => setCurrentView('focus')}
-            onCompleteTask={completeTask}
           />
         )}
 

--- a/src/apps/ZenDoApp/__tests__/TodayView.drag-drop.test.js
+++ b/src/apps/ZenDoApp/__tests__/TodayView.drag-drop.test.js
@@ -7,7 +7,6 @@ describe('TodayView drag and drop behaviour', () => {
     onClearBucket: jest.fn(),
     onBackToLanding: jest.fn(),
     onOpenFocus: jest.fn(),
-    onCompleteTask: jest.fn(),
   };
 
   const createDataTransfer = () => {

--- a/src/apps/ZenDoApp/__tests__/TodayView.test.js
+++ b/src/apps/ZenDoApp/__tests__/TodayView.test.js
@@ -39,6 +39,24 @@ const mockBoundingRects = (container) => {
 };
 
 describe('TodayView drag-and-drop', () => {
+  it('renders task cards without completion controls', () => {
+    render(
+      <TodayView
+        todayList={[createTask('t-1', 'Today Task')]}
+        priorityList={[createTask('p-1', 'Priority Task')]}
+        bonusList={[createTask('b-1', 'Bonus Task')]}
+        onAssignToBucket={jest.fn()}
+        onReorderBucket={jest.fn()}
+        onClearBucket={jest.fn()}
+        onBackToLanding={jest.fn()}
+        onOpenFocus={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+    expect(screen.queryByLabelText(/toggle completion/i)).toBeNull();
+  });
+
   it('moves a task from priority to today and triggers callbacks once', () => {
     const onAssignToBucket = jest.fn();
     const onReorderBucket = jest.fn();
@@ -54,7 +72,6 @@ describe('TodayView drag-and-drop', () => {
         onClearBucket={onClearBucket}
         onBackToLanding={noop}
         onOpenFocus={noop}
-        onCompleteTask={noop}
       />,
     );
 
@@ -106,7 +123,6 @@ describe('TodayView drag-and-drop', () => {
         onClearBucket={onClearBucket}
         onBackToLanding={noop}
         onOpenFocus={noop}
-        onCompleteTask={noop}
       />,
     );
 

--- a/src/apps/ZenDoApp/views/TodayView.js
+++ b/src/apps/ZenDoApp/views/TodayView.js
@@ -17,7 +17,7 @@ const getBucketList = (bucket, lists) => {
   return [];
 };
 
-const TaskCard = ({ bucketId, dragController, index, onCompleteTask, task }) => {
+const TaskCard = ({ bucketId, dragController, index, task }) => {
   const handleDragStart = useCallback((event) => {
     if (event.dataTransfer) {
       try {
@@ -44,12 +44,6 @@ const TaskCard = ({ bucketId, dragController, index, onCompleteTask, task }) => 
     >
       <div className="zen-card-title-row">
         <span>{task.title}</span>
-        <input
-          type="checkbox"
-          checked={task.completed}
-          onChange={() => onCompleteTask(task.id, !task.completed)}
-          aria-label="Toggle completion"
-        />
       </div>
       {task.dueDate && <div className="zen-card-meta">Due {task.dueDate}</div>}
     </div>
@@ -65,7 +59,6 @@ const TodayView = ({
   onClearBucket,
   onBackToLanding,
   onOpenFocus,
-  onCompleteTask,
 }) => {
   const dragController = useSharedDragController();
 
@@ -106,9 +99,8 @@ const TodayView = ({
       index={index}
       bucketId={bucketId}
       dragController={dragController}
-      onCompleteTask={onCompleteTask}
     />
-  ), [dragController, onCompleteTask]);
+  ), [dragController]);
 
   return (
     <div className="zen-today-layout">


### PR DESCRIPTION
## Summary
- strip the completion checkbox from Today view task cards so they only support drag placement
- leave Landing and Focus views as the locations that still expose completion toggles
- add a regression test confirming the Today view renders without any completion controls

## Testing
- CI=1 npm test -- --runTestsByPath src/apps/ZenDoApp/__tests__/TodayView.test.js src/apps/ZenDoApp/__tests__/TodayView.drag-drop.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d23e6e87ac832bb20533ede0d55bd2