### PR TITLE
Add reset support to cosmos simulation controls

### DIFF
--- a/src/apps/cosmos/controls.js
+++ b/src/apps/cosmos/controls.js
@@ -20,6 +20,12 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
   const gui = new GUI({ title: 'Cosmos Controls' });
   gui.domElement.classList.add('cosmos-gui');
 
+  const simulationActions = {
+    resetSimulation: () => handlers.onSimulationReset?.(),
+  };
+
+  gui.add(simulationActions, 'resetSimulation').name('Reset simulation');
+
   gui
     .add(settings, 'timeSpeed', TIME_SPEED_RANGE.min, TIME_SPEED_RANGE.max, TIME_SPEED_RANGE.step)
     .name('Time speed (×)')


### PR DESCRIPTION
## Summary
- cache the original solar system body definitions and add a simulation reset helper
- expose a Reset simulation control in the Cosmos GUI that rebuilds the simulation and clears trails
- wire the control panel to refresh the timer display after resets

## Testing
- npm test
- npm start (manual verification via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68d23eefaa74832b856b9eb99ed57bb9