### PR TITLE
Refine cosmos trail length control

### DIFF
--- a/src/apps/cosmos/controls.js
+++ b/src/apps/cosmos/controls.js
@@ -45,15 +45,6 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     });
 
   trailLengthController = gui
-    .add(settings, 'trailLength', 0, 720, 10)
-    .name('Trail length')
-    .onChange((value) => handlers.onTrailLengthChange?.(value));
-
-  if (!settings.showTrails) {
-    trailLengthController.disable();
-  }
-
-  gui
     .add(
       settings,
       'trailLength',
@@ -63,6 +54,10 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     )
     .name('Trail length')
     .onChange((value) => handlers.onTrailLengthChange?.(value));
+
+  if (!settings.showTrails) {
+    trailLengthController.disable();
+  }
 
   const cameraFolder = gui.addFolder('Camera');
   bodies.forEach((body) => {


### PR DESCRIPTION
## Summary
- remove the duplicate trail length control in the cosmos control panel
- ensure the remaining slider uses the shared range constants and stays tied to the trails toggle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d242247750832b903ee8bdffe9111d