### PR TITLE
Expand cosmos time speed range

### DIFF
--- a/src/apps/cosmos/controls.js
+++ b/src/apps/cosmos/controls.js
@@ -1,11 +1,16 @@
 import GUI from 'https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm';
 
-export const TIME_SPEED_RANGE = { min: 100, max: 20000, step: 100 };
+export const TIME_SPEED_RANGE = { min: 100, max: 1_000_000, step: 100 };
 export const TRAIL_LENGTH_RANGE = { min: 120, max: 720, step: 30 };
 export const DEFAULT_TRAIL_LENGTH = 720;
 
+export const DEFAULT_TIME_SPEED = Math.min(
+  Math.max(4000, TIME_SPEED_RANGE.min),
+  TIME_SPEED_RANGE.max,
+);
+
 const DEFAULTS = {
-  timeSpeed: 4000,
+  timeSpeed: DEFAULT_TIME_SPEED,
   gravityMultiplier: 1,
   showTrails: true,
   trailLength: DEFAULT_TRAIL_LENGTH,
@@ -16,6 +21,11 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     ...DEFAULTS,
     ...overrides,
   };
+
+  settings.timeSpeed = Math.min(
+    Math.max(settings.timeSpeed, TIME_SPEED_RANGE.min),
+    TIME_SPEED_RANGE.max,
+  );
 
   const gui = new GUI({ title: 'Cosmos Controls' });
   gui.domElement.classList.add('cosmos-gui');

--- a/src/apps/cosmos/main.js
+++ b/src/apps/cosmos/main.js
@@ -2,7 +2,12 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { loadBodyData, createBodyMeshes, createSunLight, updateBodyMeshes } from './bodies.js';
 import { SolarSystemSimulation, SCALE } from './simulation.js';
-import { setupControlPanel, TIME_SPEED_RANGE, DEFAULT_TRAIL_LENGTH } from './controls.js';
+import {
+  setupControlPanel,
+  TIME_SPEED_RANGE,
+  DEFAULT_TRAIL_LENGTH,
+  DEFAULT_TIME_SPEED,
+} from './controls.js';
 
 const viewport = document.querySelector('.cosmos-viewport');
 const statusEl = document.querySelector('.cosmos-loader');
@@ -30,7 +35,7 @@ let simulation;
 let visuals;
 let moonGroups = new Map();
 let showTrails = true;
-let timeSpeed = 4000;
+let timeSpeed = DEFAULT_TIME_SPEED;
 let gravityMultiplier = 1;
 let trailLength = DEFAULT_TRAIL_LENGTH;
 let accumulatedSimSeconds = 0;
@@ -419,7 +424,8 @@ async function init() {
         if (!Number.isFinite(value)) {
           return;
         }
-        timeSpeed = value;
+        const clamped = Math.min(Math.max(value, TIME_SPEED_RANGE.min), TIME_SPEED_RANGE.max);
+        timeSpeed = clamped;
         updateTimerColor(timeSpeed);
       },
       onGravityChange: (value) => { gravityMultiplier = value; },


### PR DESCRIPTION
## Summary
- raise the cosmos time speed slider maximum to 1,000,000× and clamp defaults accordingly
- export and reuse a shared default time speed so initialization stays within the expanded range
- clamp runtime updates to the configured bounds to keep timer coloring consistent

## Testing
- npm run lint *(fails: existing lint errors across unrelated apps)*

------
https://chatgpt.com/codex/tasks/task_e_68d243098b50832ba63e08201b38e9ea