### PR TITLE
Refine HexaSnake grid layout

### DIFF
--- a/src/apps/HexaSnakeApp/HexaSnakeApp.js
+++ b/src/apps/HexaSnakeApp/HexaSnakeApp.js
@@ -181,7 +181,7 @@ pygame_stub.install_stub()
 
         await pyodide.runPythonAsync(`
 from hexa_snake_game import HexaSnakeGame
-game = HexaSnakeGame(canvas_id='${canvas?.id}', pixel_width=${width}, pixel_height=${height})
+game = HexaSnakeGame(canvas_id='${canvas?.id}', pixel_width=${width}, pixel_height=${height}, radius=6)
 `);
         if (cancelled) return;
 


### PR DESCRIPTION
## Summary
- rebuild the Hexa-Snake grid from axial coordinates using a configurable radius and track membership with a set
- initialise the snake at the origin-based axial south chain and update honey spawning and bounds checks accordingly
- pass the new radius argument when instantiating the game from the Pyodide bootstrap code

## Testing
- python -m compileall src/apps/hexa-snake/hexa_snake_game.py

------
https://chatgpt.com/codex/tasks/task_e_68d243471154832b85fc0accf04b55e2