### PR TITLE
Expand cosmos gravity control range

### DIFF
--- a/src/apps/cosmos/controls.js
+++ b/src/apps/cosmos/controls.js
@@ -3,6 +3,7 @@ import GUI from 'https://cdn.jsdelivr.net/npm/lil-gui@0.19/+esm';
 export const TIME_SPEED_RANGE = { min: 100, max: 1_000_000, step: 100 };
 export const TRAIL_LENGTH_RANGE = { min: 120, max: 720, step: 30 };
 export const DEFAULT_TRAIL_LENGTH = 720;
+export const GRAVITY_MULTIPLIER_RANGE = { min: 0, max: 150, step: 1 };
 
 export const DEFAULT_TIME_SPEED = Math.min(
   Math.max(4000, TIME_SPEED_RANGE.min),
@@ -27,6 +28,11 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     TIME_SPEED_RANGE.max,
   );
 
+  settings.gravityMultiplier = Math.min(
+    Math.max(settings.gravityMultiplier, GRAVITY_MULTIPLIER_RANGE.min),
+    GRAVITY_MULTIPLIER_RANGE.max,
+  );
+
   const gui = new GUI({ title: 'Cosmos Controls' });
   gui.domElement.classList.add('cosmos-gui');
 
@@ -42,7 +48,13 @@ export function setupControlPanel(bodies, handlers = {}, overrides = {}) {
     .onChange((value) => handlers.onTimeSpeedChange?.(value));
 
   gui
-    .add(settings, 'gravityMultiplier', 0, 3, 0.05)
+    .add(
+      settings,
+      'gravityMultiplier',
+      GRAVITY_MULTIPLIER_RANGE.min,
+      GRAVITY_MULTIPLIER_RANGE.max,
+      GRAVITY_MULTIPLIER_RANGE.step,
+    )
     .name('Gravity (×)')
     .onChange((value) => handlers.onGravityChange?.(value));
 


### PR DESCRIPTION
## Summary
- extend the cosmos control panel gravity multiplier slider to cover 0–150 with a step of 1
- clamp any provided gravity multiplier overrides to the expanded range before initializing the GUI

## Testing
- npm run lint *(fails: existing lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d244e897b4832b924ef0386bbf979a