### PR TITLE
Replace cosmos planet textures with vector art

### DIFF
--- a/src/apps/cosmos/data/bodies.json
+++ b/src/apps/cosmos/data/bodies.json
@@ -7,14 +7,7 @@
     "velocity": [0, 0, 0],
     "color": {
       "base": "#f7c84b",
-      "gradient": {
-        "orientation": "radial",
-        "stops": [
-          { "offset": 0, "color": "#fff7d9" },
-          { "offset": 0.45, "color": "#fcd16b" },
-          { "offset": 1, "color": "#f28e1c" }
-        ]
-      }
+      "texture": "./data/textures/sun.svg"
     }
   },
   {
@@ -25,13 +18,9 @@
     "velocity": [0, 47400, 0],
     "color": {
       "base": "#97897b",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#c3b6ac" },
-          { "offset": 1, "color": "#6f6258" }
-        ]
-      }
+      "texture": "./data/textures/mercury.svg",
+      "roughness": 0.85,
+      "metalness": 0.08
     }
   },
   {
@@ -42,14 +31,9 @@
     "velocity": [0, 35000, 0],
     "color": {
       "base": "#d0a25f",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#f3d59b" },
-          { "offset": 0.6, "color": "#d0a25f" },
-          { "offset": 1, "color": "#b58448" }
-        ]
-      }
+      "texture": "./data/textures/venus.svg",
+      "roughness": 0.82,
+      "metalness": 0.06
     }
   },
   {
@@ -75,17 +59,9 @@
     ],
     "color": {
       "base": "#2f7fd6",
-      "gradient": {
-        "orientation": "horizontal",
-        "stops": [
-          { "offset": 0, "color": "#2f7fd6" },
-          { "offset": 0.35, "color": "#2a65a0" },
-          { "offset": 0.55, "color": "#3da86c" },
-          { "offset": 0.7, "color": "#98c264" },
-          { "offset": 0.9, "color": "#d7e7f6" },
-          { "offset": 1, "color": "#2f7fd6" }
-        ]
-      }
+      "texture": "./data/textures/earth.svg",
+      "roughness": 0.68,
+      "metalness": 0.18
     }
   },
   {
@@ -124,14 +100,9 @@
     ],
     "color": {
       "base": "#c24f34",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#f1a06f" },
-          { "offset": 0.4, "color": "#d0603a" },
-          { "offset": 1, "color": "#82281f" }
-        ]
-      }
+      "texture": "./data/textures/mars.svg",
+      "roughness": 0.78,
+      "metalness": 0.07
     }
   },
   {
@@ -202,19 +173,10 @@
     },
     "color": {
       "base": "#c79b6e",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#f3d9b5" },
-          { "offset": 0.12, "color": "#b27d4d" },
-          { "offset": 0.24, "color": "#f4d7aa" },
-          { "offset": 0.36, "color": "#a06438" },
-          { "offset": 0.5, "color": "#f0d0a0" },
-          { "offset": 0.64, "color": "#a46b3f" },
-          { "offset": 0.78, "color": "#e9c596" },
-          { "offset": 1, "color": "#8d5a33" }
-        ]
-      }
+      "texture": "./data/textures/jupiter.svg",
+      "roughness": 0.52,
+      "metalness": 0.12,
+      "emissiveIntensity": 0.45
     }
   },
   {
@@ -272,14 +234,9 @@
     },
     "color": {
       "base": "#d8bc83",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#f5e2b9" },
-          { "offset": 0.5, "color": "#d8bc83" },
-          { "offset": 1, "color": "#b7935f" }
-        ]
-      }
+      "texture": "./data/textures/saturn.svg",
+      "roughness": 0.56,
+      "metalness": 0.1
     }
   },
   {
@@ -324,14 +281,9 @@
     },
     "color": {
       "base": "#74d0e2",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#a9f1fb" },
-          { "offset": 0.55, "color": "#74d0e2" },
-          { "offset": 1, "color": "#3a9bbf" }
-        ]
-      }
+      "texture": "./data/textures/uranus.svg",
+      "roughness": 0.62,
+      "metalness": 0.08
     }
   },
   {
@@ -363,14 +315,9 @@
     },
     "color": {
       "base": "#3e59d4",
-      "gradient": {
-        "orientation": "vertical",
-        "stops": [
-          { "offset": 0, "color": "#6f8bf4" },
-          { "offset": 0.45, "color": "#3e59d4" },
-          { "offset": 1, "color": "#1f377e" }
-        ]
-      }
+      "texture": "./data/textures/neptune.svg",
+      "roughness": 0.6,
+      "metalness": 0.09
     }
   }
 ]

--- a/src/apps/cosmos/data/textures/earth.svg
+++ b/src/apps/cosmos/data/textures/earth.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="earth-ocean" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#72c2ff"/>
+      <stop offset="55%" stop-color="#2c7dd1"/>
+      <stop offset="100%" stop-color="#0f3c8a"/>
+    </radialGradient>
+    <linearGradient id="earth-clouds" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.45"/>
+      <stop offset="40%" stop-color="#eaf4ff" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#94b8e6" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#earth-ocean)"/>
+  <g fill="#4cb062">
+    <path d="M120 180c40-50 120-90 170-70s80 90 20 120-120 30-170-10c-16-12-26-26-20-40z"/>
+    <path d="M300 210c34 8 76 42 90 72s-4 70-48 74-92-24-96-64 20-80 54-82z"/>
+    <path d="M140 340c18-14 54-14 80 10s36 70-10 88-104-10-106-42 18-42 36-56z"/>
+  </g>
+  <g fill="#9ed49b">
+    <path d="M150 210c18-20 58-40 86-32s34 36-8 48-70 6-78-16z"/>
+    <path d="M312 248c24 6 56 32 60 50s-18 34-44 30-48-30-38-52 20-28 22-28z"/>
+  </g>
+  <rect width="512" height="512" fill="url(#earth-clouds)" opacity="0.35"/>
+</svg>

--- a/src/apps/cosmos/data/textures/jupiter.svg
+++ b/src/apps/cosmos/data/textures/jupiter.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="jupiter-shade" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#f4ddc0"/>
+      <stop offset="60%" stop-color="#c99f72"/>
+      <stop offset="100%" stop-color="#8d5b3c"/>
+    </radialGradient>
+    <linearGradient id="jupiter-bands" x1="0%" y1="40%" x2="100%" y2="60%">
+      <stop offset="0%" stop-color="#f3d0a6" stop-opacity="0.8"/>
+      <stop offset="50%" stop-color="#cfa27a" stop-opacity="0.65"/>
+      <stop offset="100%" stop-color="#8a5b3a" stop-opacity="0.85"/>
+    </linearGradient>
+    <radialGradient id="jupiter-storm" cx="68%" cy="58%" r="18%">
+      <stop offset="0%" stop-color="#fce3c4"/>
+      <stop offset="60%" stop-color="#d7864a"/>
+      <stop offset="100%" stop-color="#853f29"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#jupiter-shade)"/>
+  <g>
+    <rect y="70" width="512" height="60" fill="#ffffff" opacity="0.22"/>
+    <rect y="130" width="512" height="60" fill="url(#jupiter-bands)"/>
+    <rect y="200" width="512" height="70" fill="#ffffff" opacity="0.15"/>
+    <rect y="270" width="512" height="80" fill="url(#jupiter-bands)" opacity="0.85"/>
+    <rect y="350" width="512" height="60" fill="#ffffff" opacity="0.1"/>
+    <rect y="410" width="512" height="50" fill="url(#jupiter-bands)" opacity="0.9"/>
+  </g>
+  <ellipse cx="360" cy="320" rx="120" ry="80" fill="url(#jupiter-storm)" opacity="0.9"/>
+</svg>

--- a/src/apps/cosmos/data/textures/mars.svg
+++ b/src/apps/cosmos/data/textures/mars.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="mars-base" cx="45%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#f6a274"/>
+      <stop offset="55%" stop-color="#c65b33"/>
+      <stop offset="100%" stop-color="#7a271a"/>
+    </radialGradient>
+    <linearGradient id="mars-bands" x1="0%" y1="30%" x2="100%" y2="70%">
+      <stop offset="0%" stop-color="#ffcea9" stop-opacity="0.25"/>
+      <stop offset="40%" stop-color="#d77445" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#8a3d27" stop-opacity="0.35"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#mars-base)"/>
+  <g fill="url(#mars-bands)">
+    <path d="M-10 180c110-70 280-80 350-40s100 120 160 146v60c-90-8-146-56-220-72s-170 6-290 78z"/>
+  </g>
+  <g fill="#f5cbaa" opacity="0.35">
+    <ellipse cx="180" cy="180" rx="140" ry="70"/>
+    <ellipse cx="360" cy="260" rx="160" ry="60"/>
+  </g>
+  <g fill="#7f3924" opacity="0.45">
+    <path d="M60 360c40-46 140-74 220-46s140 62 172 58v40c-80 24-164 18-232-12s-132-32-160-40z"/>
+  </g>
+</svg>

--- a/src/apps/cosmos/data/textures/mercury.svg
+++ b/src/apps/cosmos/data/textures/mercury.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="mercury-base" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f5f1eb"/>
+      <stop offset="45%" stop-color="#c4bbae"/>
+      <stop offset="100%" stop-color="#6f6458"/>
+    </radialGradient>
+    <linearGradient id="mercury-strata" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.15"/>
+      <stop offset="40%" stop-color="#b9b2a6" stop-opacity="0.1"/>
+      <stop offset="100%" stop-color="#423f3c" stop-opacity="0.45"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#mercury-base)"/>
+  <g fill="url(#mercury-strata)">
+    <ellipse cx="180" cy="190" rx="160" ry="120"/>
+    <ellipse cx="350" cy="280" rx="200" ry="150"/>
+    <ellipse cx="260" cy="360" rx="110" ry="70"/>
+  </g>
+  <g fill="#d8d1c6" opacity="0.45">
+    <circle cx="210" cy="140" r="46"/>
+    <circle cx="330" cy="210" r="58"/>
+    <circle cx="250" cy="280" r="36"/>
+    <circle cx="356" cy="360" r="42"/>
+  </g>
+</svg>

--- a/src/apps/cosmos/data/textures/neptune.svg
+++ b/src/apps/cosmos/data/textures/neptune.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="neptune-base" cx="50%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#8cc6ff"/>
+      <stop offset="55%" stop-color="#386dd8"/>
+      <stop offset="100%" stop-color="#163485"/>
+    </radialGradient>
+    <linearGradient id="neptune-bands" x1="0%" y1="45%" x2="100%" y2="55%">
+      <stop offset="0%" stop-color="#b1d8ff" stop-opacity="0.35"/>
+      <stop offset="40%" stop-color="#4a7be0" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#1f3f9b" stop-opacity="0.4"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#neptune-base)"/>
+  <g fill="url(#neptune-bands)">
+    <rect y="130" width="512" height="70" opacity="0.9"/>
+    <rect y="220" width="512" height="60" opacity="0.75"/>
+    <rect y="310" width="512" height="70" opacity="0.85"/>
+  </g>
+  <ellipse cx="360" cy="260" rx="120" ry="80" fill="#9dc2ff" opacity="0.28"/>
+</svg>

--- a/src/apps/cosmos/data/textures/saturn.svg
+++ b/src/apps/cosmos/data/textures/saturn.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="saturn-base" cx="50%" cy="40%" r="70%">
+      <stop offset="0%" stop-color="#f3e0b7"/>
+      <stop offset="55%" stop-color="#d3b177"/>
+      <stop offset="100%" stop-color="#8f6a3d"/>
+    </radialGradient>
+    <linearGradient id="saturn-bands" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#f9e9ce" stop-opacity="0.8"/>
+      <stop offset="40%" stop-color="#d7b88a" stop-opacity="0.65"/>
+      <stop offset="100%" stop-color="#87643a" stop-opacity="0.85"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#saturn-base)"/>
+  <g>
+    <rect y="90" width="512" height="48" fill="url(#saturn-bands)" opacity="0.9"/>
+    <rect y="150" width="512" height="60" fill="#ffffff" opacity="0.18"/>
+    <rect y="220" width="512" height="70" fill="url(#saturn-bands)" opacity="0.85"/>
+    <rect y="300" width="512" height="60" fill="#ffffff" opacity="0.14"/>
+    <rect y="360" width="512" height="54" fill="url(#saturn-bands)" opacity="0.95"/>
+  </g>
+  <g fill="#fef6d6" opacity="0.3">
+    <ellipse cx="256" cy="130" rx="220" ry="32"/>
+    <ellipse cx="256" cy="240" rx="240" ry="40"/>
+    <ellipse cx="256" cy="340" rx="210" ry="34"/>
+  </g>
+</svg>

--- a/src/apps/cosmos/data/textures/sun.svg
+++ b/src/apps/cosmos/data/textures/sun.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="sun-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff3b0"/>
+      <stop offset="50%" stop-color="#fcd352"/>
+      <stop offset="80%" stop-color="#f28c2b"/>
+      <stop offset="100%" stop-color="#d8541f"/>
+    </radialGradient>
+    <radialGradient id="sun-plasma" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.6"/>
+      <stop offset="60%" stop-color="#ffd656" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#f07820" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#sun-core)"/>
+  <g fill="none" stroke="#ffffff" stroke-opacity="0.12" stroke-width="22">
+    <circle cx="256" cy="256" r="140"/>
+    <circle cx="256" cy="256" r="188"/>
+    <circle cx="256" cy="256" r="230"/>
+  </g>
+  <g fill="url(#sun-plasma)">
+    <circle cx="172" cy="198" r="120"/>
+    <circle cx="336" cy="152" r="86"/>
+    <circle cx="340" cy="320" r="112"/>
+    <circle cx="180" cy="344" r="98"/>
+  </g>
+</svg>

--- a/src/apps/cosmos/data/textures/uranus.svg
+++ b/src/apps/cosmos/data/textures/uranus.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="uranus-base" cx="50%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#b6f0ff"/>
+      <stop offset="60%" stop-color="#6bd0e6"/>
+      <stop offset="100%" stop-color="#2f8bad"/>
+    </radialGradient>
+    <linearGradient id="uranus-bands" x1="0%" y1="40%" x2="100%" y2="60%">
+      <stop offset="0%" stop-color="#dffaff" stop-opacity="0.35"/>
+      <stop offset="50%" stop-color="#9be0ef" stop-opacity="0.22"/>
+      <stop offset="100%" stop-color="#3a9abc" stop-opacity="0.35"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#uranus-base)"/>
+  <g fill="url(#uranus-bands)">
+    <rect y="110" width="512" height="70" opacity="0.7"/>
+    <rect y="220" width="512" height="80" opacity="0.85"/>
+    <rect y="340" width="512" height="70" opacity="0.75"/>
+  </g>
+  <g fill="#e9fbff" opacity="0.28">
+    <ellipse cx="260" cy="150" rx="220" ry="40"/>
+    <ellipse cx="240" cy="320" rx="240" ry="36"/>
+  </g>
+</svg>

--- a/src/apps/cosmos/data/textures/venus.svg
+++ b/src/apps/cosmos/data/textures/venus.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="venus-base" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f8d9a1"/>
+      <stop offset="45%" stop-color="#dfa96c"/>
+      <stop offset="100%" stop-color="#a96a3b"/>
+    </radialGradient>
+    <linearGradient id="venus-clouds" x1="0%" y1="20%" x2="100%" y2="80%">
+      <stop offset="0%" stop-color="#fff3d2" stop-opacity="0.4"/>
+      <stop offset="50%" stop-color="#f0c283" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#b97840" stop-opacity="0.35"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#venus-base)"/>
+  <g fill="url(#venus-clouds)">
+    <path d="M-20 180c90-40 210-58 340-34s180 94 230 120v60c-60 14-132 6-206-24s-160-32-274 20z"/>
+    <path d="M-10 330c110-60 220-70 330-40s190 40 220 36v70c-60 24-160 20-246-10s-156-28-284 8z" opacity="0.8"/>
+  </g>
+  <g fill="#f7e2b6" opacity="0.35">
+    <ellipse cx="220" cy="150" rx="210" ry="60"/>
+    <ellipse cx="340" cy="260" rx="220" ry="48"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace each cosmos planet PNG with a scalable SVG texture built from layered gradients and shapes
- point the cosmos body definitions at the new SVG assets so the renderer loads the vector artwork

## Testing
- npm test *(fails: existing Sudoku solver expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68d2450e88bc832bbee89d046afb9c2f