### PR TITLE
Add quick assign buttons to Today tasks

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -394,6 +394,57 @@
   color: #2f3b35;
 }
 
+.zen-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.zen-task-quick-actions {
+  display: flex;
+  gap: 0.35rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.zen-focus-card:hover .zen-task-quick-actions,
+.zen-focus-card:focus-within .zen-task-quick-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.zen-task-action-btn {
+  border: none;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.zen-task-action-btn:hover {
+  transform: translateY(-1px);
+}
+
+.zen-task-action-btn--priority {
+  background: linear-gradient(135deg, #2f6f5b, #3f846c);
+  color: #ffffff;
+  box-shadow: 0 4px 10px rgba(47, 111, 91, 0.35);
+}
+
+.zen-task-action-btn--bonus {
+  background: linear-gradient(135deg, #f6e8b1, #fde7a2);
+  color: #755d17;
+  box-shadow: 0 4px 10px rgba(221, 190, 90, 0.35);
+}
+
 .zen-card-meta {
   font-size: 0.75rem;
   color: #4a5f55;

--- a/src/apps/ZenDoApp/__tests__/TodayView.test.js
+++ b/src/apps/ZenDoApp/__tests__/TodayView.test.js
@@ -158,3 +158,80 @@ describe('TodayView drag-and-drop', () => {
     expect(bonusZone.querySelector('[data-placeholder="true"]')).not.toBeInTheDocument();
   });
 });
+
+describe('TodayView quick assign actions', () => {
+  const noop = jest.fn();
+
+  beforeEach(() => {
+    noop.mockReset();
+  });
+
+  it('quick assigns a today task to priority after hover', () => {
+    const onAssignToBucket = jest.fn();
+    const onReorderBucket = jest.fn();
+
+    render(
+      <TodayView
+        todayList={[createTask('t-1', 'Today Quick')]}
+        priorityList={[createTask('p-1', 'Existing Priority')]}
+        bonusList={[createTask('b-1', 'Existing Bonus')]}
+        onAssignToBucket={onAssignToBucket}
+        onReorderBucket={onReorderBucket}
+        onClearBucket={noop}
+        onBackToLanding={noop}
+        onOpenFocus={noop}
+      />,
+    );
+
+    const todayZone = screen.getByTestId('today-drop-zone');
+    const todayCardText = within(todayZone).getByText('Today Quick');
+    const card = todayCardText.closest('.zen-focus-card');
+    expect(card).not.toBeNull();
+
+    fireEvent.mouseEnter(card);
+
+    const quickPriority = within(card).getByLabelText(/quick assign to priority/i);
+    fireEvent.click(quickPriority);
+
+    expect(onAssignToBucket).toHaveBeenCalledTimes(1);
+    expect(onAssignToBucket).toHaveBeenCalledWith('t-1', 'priority', 1);
+
+    expect(onReorderBucket).toHaveBeenCalledTimes(2);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(1, 'priority', ['p-1', 't-1']);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(2, 'today', []);
+  });
+
+  it('quick assigns a today task to bonus after focus', () => {
+    const onAssignToBucket = jest.fn();
+    const onReorderBucket = jest.fn();
+
+    render(
+      <TodayView
+        todayList={[createTask('t-1', 'Focus Me'), createTask('t-2', 'Stay Put')]}
+        priorityList={[]}
+        bonusList={[]}
+        onAssignToBucket={onAssignToBucket}
+        onReorderBucket={onReorderBucket}
+        onClearBucket={noop}
+        onBackToLanding={noop}
+        onOpenFocus={noop}
+      />,
+    );
+
+    const todayZone = screen.getByTestId('today-drop-zone');
+    const todayCardText = within(todayZone).getByText('Focus Me');
+    const card = todayCardText.closest('.zen-focus-card');
+    expect(card).not.toBeNull();
+
+    const quickBonus = within(card).getByLabelText(/quick assign to bonus/i);
+    fireEvent.focus(quickBonus);
+    fireEvent.click(quickBonus);
+
+    expect(onAssignToBucket).toHaveBeenCalledTimes(1);
+    expect(onAssignToBucket).toHaveBeenCalledWith('t-1', 'bonus', 0);
+
+    expect(onReorderBucket).toHaveBeenCalledTimes(2);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(1, 'bonus', ['t-1']);
+    expect(onReorderBucket).toHaveBeenNthCalledWith(2, 'today', ['t-2']);
+  });
+});


### PR DESCRIPTION
## Summary
- add quick-assign buttons to Today task cards and forward their actions through the new handler
- update TodayView quick assign logic to compute insert positions, reorders, and removal from Today
- style the hover/focus action affordances and extend unit coverage for the new interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d24955f524832bb2cb795c52bbfc2d