### PR TITLE
Make cat typing test start immediately

### DIFF
--- a/src/apps/cat-typing-speed-test/index.html
+++ b/src/apps/cat-typing-speed-test/index.html
@@ -11,54 +11,8 @@
       <header class="app-header">
         <h1>Cat Typing Speed Test</h1>
         <p>Warm up your paws and measure typing speed with Kimchi, Rythm, and Siella.</p>
-        <p class="alias-display" id="alias-display" hidden>
-          Alias ready: <span id="current-alias"></span>
-        </p>
       </header>
-
-      <section id="login-screen" aria-hidden="false">
-        <div class="card login-card" id="login-panel">
-          <h2>Sign in with your alias</h2>
-          <p class="login-intro">
-            Enter an alias to track your scores. Provide the GitHub Gist ID and a Personal Access Token with the
-            <code>gist</code> scope so results can sync.
-          </p>
-          <form id="login-form" class="login-grid">
-            <label class="field" for="alias-input">
-              <span>Alias</span>
-              <input id="alias-input" type="text" placeholder="e.g. whisker-wizard" autocomplete="username" spellcheck="false" required />
-            </label>
-            <label class="field" for="gist-id-input">
-              <span>GitHub Gist ID</span>
-              <input id="gist-id-input" type="text" placeholder="Paste the gist ID" autocomplete="off" spellcheck="false" required />
-            </label>
-            <label class="field" for="token-input">
-              <span>GitHub Token</span>
-              <input id="token-input" type="password" placeholder="ghp_..." autocomplete="off" spellcheck="false" required />
-            </label>
-            <div class="login-actions">
-              <button type="submit" class="login-submit" id="login-button">Login</button>
-              <button type="button" class="login-logout" id="logout-button">Logout</button>
-            </div>
-          </form>
-          <p class="login-note">
-            Tokens are stored only for this browser tab using session storage. Create a public or secret gist that contains a
-            <code>cat-typing-speed-test.json</code> file with <code>{}</code> to get started.
-          </p>
-          <p class="status-message" id="login-status" aria-live="polite"></p>
-        </div>
-      </section>
-
-      <section class="card hidden" id="start-screen" data-screen aria-hidden="true">
-        <h2>Choose a test duration</h2>
-        <div class="duration-options" role="group" aria-label="Test duration">
-          <button type="button" class="duration-btn" data-duration="15">15 seconds</button>
-          <button type="button" class="duration-btn" data-duration="30">30 seconds</button>
-        </div>
-        <p class="start-hint" id="start-hint">Each test pulls fresh sentences from the cat chronicles.</p>
-      </section>
-
-      <section class="card hidden" id="test-screen" data-screen aria-hidden="true">
+      <section class="card" id="test-screen" data-screen aria-hidden="false">
         <div class="test-meta">
           <div class="timer" id="timer" aria-live="assertive">00:15</div>
           <dl class="stat-line" aria-label="Live typing statistics">
@@ -86,7 +40,6 @@
 
         <div class="actions">
           <button type="button" class="secondary" id="restart-btn">↺ Restart</button>
-          <button type="button" class="ghost" id="back-btn">← Back to menu</button>
         </div>
       </section>
 
@@ -109,7 +62,7 @@
         <p class="results-note" id="results-note"></p>
         <div class="score-history" id="score-history" aria-live="polite">
           <h3>Score history</h3>
-          <p class="history-empty" id="history-empty">Log in to view saved scores.</p>
+          <p class="history-empty" id="history-empty">Connect GitHub access from the global settings to sync your scores.</p>
           <table class="history-table hidden" id="history-table">
             <thead>
               <tr>
@@ -124,7 +77,6 @@
         </div>
         <div class="actions">
           <button type="button" class="primary" id="results-retry">Try again</button>
-          <button type="button" class="ghost" id="results-menu">Back to menu</button>
         </div>
       </section>
     </main>

--- a/src/apps/cat-typing-speed-test/main.js
+++ b/src/apps/cat-typing-speed-test/main.js
@@ -1,6 +1,6 @@
 (() => {
-  const loginScreen = document.getElementById('login-screen');
-  const startScreen = document.getElementById('start-screen');
+  const DEFAULT_DURATION = 15;
+
   const testScreen = document.getElementById('test-screen');
   const resultsScreen = document.getElementById('results-screen');
   const timerEl = document.getElementById('timer');
@@ -10,522 +10,172 @@
   const textDisplay = document.getElementById('text-display');
   const typingInput = document.getElementById('typing-input');
   const restartBtn = document.getElementById('restart-btn');
-  const backBtn = document.getElementById('back-btn');
   const finalWpm = document.getElementById('final-wpm');
   const finalCpm = document.getElementById('final-cpm');
   const finalAccuracy = document.getElementById('final-accuracy');
   const resultsNote = document.getElementById('results-note');
   const resultsRetry = document.getElementById('results-retry');
-  const resultsMenu = document.getElementById('results-menu');
 
-  const durationButtons = Array.from(document.querySelectorAll('.duration-btn'));
+  if (!testScreen || !resultsScreen || !typingInput) {
+    return;
+  }
 
-  const parseDurationValue = (button) => {
-    if (!button) return null;
-    const value = Number(button.dataset.duration);
-    if (!Number.isFinite(value) || value <= 0) {
-      return null;
-    }
-    return value;
+  const screenRegistry = {
+    test: {
+      element: testScreen,
+      getDefaultFocus: () => typingInput,
+    },
+    results: {
+      element: resultsScreen,
+      getDefaultFocus: () => resultsRetry,
+    },
   };
 
-  const defaultDuration = (() => {
-    for (let index = 0; index < durationButtons.length; index += 1) {
-      const parsed = parseDurationValue(durationButtons[index]);
-      if (parsed !== null) {
-        return parsed;
-      }
-    }
-    return null;
-  })();
-
-  let lastSelectedDuration = defaultDuration;
-
-  const loginForm = document.getElementById('login-form');
-  const aliasInput = document.getElementById('alias-input');
-  const loginButton = document.getElementById('login-button');
-  const logoutButton = document.getElementById('logout-button');
-  const loginStatus = document.getElementById('login-status');
-  const aliasDisplayRow = document.getElementById('alias-display');
-  const currentAliasEl = document.getElementById('current-alias');
-  const historyEmpty = document.getElementById('history-empty');
-  const historyTable = document.getElementById('history-table');
-  const historyRows = document.getElementById('history-rows');
-  const startHint = document.getElementById('start-hint');
-
-  const GIST_FILENAME = 'cat-typing-speed-test.json';
-  const STORAGE_KEY = 'catTypingSettings';
-  const SESSION_TOKEN_KEY = 'catTypingSessionToken';
-  const GIST_SETTINGS_COOKIE = 'g1_gist_settings';
-  const GIST_SETTINGS_MESSAGE = 'g1-gist-settings-update';
-  const gistSettingsChannel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('g1-gist-settings') : null;
-
-  const sanitizeGistSettings = (value = {}) => {
-    const gistId = typeof value.gistId === 'string' ? value.gistId.trim() : '';
-    const gistToken = typeof value.gistToken === 'string'
-      ? value.gistToken.trim()
-      : typeof value.token === 'string'
-        ? value.token.trim()
-        : '';
-
-    return { gistId, gistToken };
-  };
-
-  const readGistSettingsCookie = () => {
-    if (typeof document === 'undefined') {
-      return { gistId: '', gistToken: '' };
-    }
-
-    try {
-      const cookies = document.cookie ? document.cookie.split(';') : [];
-      for (let index = 0; index < cookies.length; index += 1) {
-        const cookie = cookies[index];
-        const [rawName, ...rest] = cookie.split('=');
-        if (!rawName || rawName.trim() !== GIST_SETTINGS_COOKIE) {
-          continue;
-        }
-        const rawValue = rest.join('=');
-        if (!rawValue) {
-          return { gistId: '', gistToken: '' };
-        }
-        const decoded = decodeURIComponent(rawValue);
-        const parsed = JSON.parse(decoded);
-        return sanitizeGistSettings(parsed);
-      }
-    } catch (error) {
-      console.warn('Unable to read gist settings cookie.', error);
-    }
-
-    return { gistId: '', gistToken: '' };
-  };
-
-  const readSharedGistSettings = () => {
-    let embeddedSettings = null;
-
-    if (typeof window !== 'undefined') {
-      const candidates = [window];
-      if (window.parent && window.parent !== window) {
-        candidates.push(window.parent);
-      }
-
-      for (let index = 0; index < candidates.length; index += 1) {
-        const scope = candidates[index];
-        if (!scope) {
-          continue;
-        }
-
-        try {
-          if (typeof scope.readGlobalGistSettings === 'function') {
-            embeddedSettings = scope.readGlobalGistSettings();
-            break;
-          }
-        } catch (error) {
-          console.warn('Unable to read embedded global gist settings.', error);
-        }
-      }
-    }
-
-    if (embeddedSettings) {
-      const sanitized = sanitizeGistSettings(embeddedSettings);
-      if (sanitized.gistId || sanitized.gistToken) {
-        return sanitized;
-      }
-    }
-
-    return readGistSettingsCookie();
-  };
-
-  const defaultStartHint = startHint ? startHint.textContent : '';
-  const keyboardShortcutHint = 'Tip: Press 1 or 2 (\u2190/\u2192) to launch instantly, hit Esc to return to the menu, and tap R or Space to restart mid-test or from results.';
+  const focusableSelector = [
+    'button:not([disabled])',
+    '[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ');
 
   let corpusCache = null;
   let corpusPromise = null;
-  let countdownSeconds = 0;
-  let testDuration = 0;
+  let countdownSeconds = DEFAULT_DURATION;
+  let testDuration = DEFAULT_DURATION;
   let timerId = null;
   let startTimestamp = null;
   let targetText = '';
   let charSpans = [];
   let correctChars = 0;
   let typedChars = 0;
-  let activeScreen = startScreen;
+  let activeScreen = testScreen;
 
-  const setActiveDuration = (duration) => {
-    let appliedDuration = null;
-    durationButtons.forEach((button) => {
-      const parsed = parseDurationValue(button);
-      if (parsed === null) {
-        button.removeAttribute('data-active');
-        return;
-      }
-      const isActive = parsed === duration;
-      if (isActive) {
-        appliedDuration = parsed;
-        button.setAttribute('data-active', 'true');
-      } else {
-        button.removeAttribute('data-active');
-      }
-    });
-
-    if (appliedDuration !== null) {
-      lastSelectedDuration = appliedDuration;
-    }
-
-    return appliedDuration;
-  };
-
-  const getDurationByIndex = (index) => {
-    if (index < 0 || index >= durationButtons.length) {
-      return null;
-    }
-    return parseDurationValue(durationButtons[index]);
-  };
-
-  const getCurrentDurationIndex = () => {
-    if (!Number.isFinite(lastSelectedDuration)) {
-      return -1;
-    }
-    for (let index = 0; index < durationButtons.length; index += 1) {
-      if (parseDurationValue(durationButtons[index]) === lastSelectedDuration) {
-        return index;
-      }
-    }
-    return -1;
-  };
-
-  const focusActiveDurationButton = () => {
-    const activeButton = durationButtons.find((button) => button.hasAttribute('data-active'));
-    if (activeButton) {
-      activeButton.focus();
-    }
-  };
-
-  const getPreferredDuration = () => {
-    if (Number.isFinite(testDuration) && testDuration > 0) {
-      return testDuration;
-    }
-    if (Number.isFinite(lastSelectedDuration) && lastSelectedDuration > 0) {
-      return lastSelectedDuration;
-    }
-    if (Number.isFinite(defaultDuration) && defaultDuration > 0) {
-      return defaultDuration;
-    }
-    return null;
-  };
-
-  const startDuration = (duration) => {
-    const applied = setActiveDuration(duration);
-    if (!Number.isFinite(applied) || applied <= 0) {
-      return;
-    }
-    countdownSeconds = applied;
-    beginTest(applied);
-  };
-
-  const startDurationByIndex = (index) => {
-    const parsed = getDurationByIndex(index);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      return;
-    }
-    startDuration(parsed);
-  };
-
-  if (Number.isFinite(lastSelectedDuration) && lastSelectedDuration > 0) {
-    setActiveDuration(lastSelectedDuration);
-  }
-
-  const isTextEntryElement = (element) => {
-    if (!element) return false;
-    if (element.isContentEditable) return true;
-    const tagName = element.tagName;
-    if (!tagName) return false;
-    const normalized = tagName.toUpperCase();
-    return normalized === 'INPUT' || normalized === 'TEXTAREA' || normalized === 'SELECT';
-  };
-
-  let gistStore = {};
-  let currentAlias = '';
-  let gistId = '';
-  let gistToken = '';
-  let isLoggedIn = false;
-  let syncInFlight = false;
-  let syncPending = false;
-
-  const loadStoredSettings = () => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return { alias: '' };
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object') {
-        return { alias: '' };
-      }
-
-      const alias = typeof parsed.alias === 'string' ? parsed.alias : '';
-      return { alias };
-    } catch (error) {
-      console.warn('Unable to parse stored Cat Typing settings.', error);
-      return { alias: '' };
-    }
-  };
-
-  const persistLocalSettings = (aliasValue) => {
-    try {
-      const payload = { alias: aliasValue || '' };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-    } catch (error) {
-      console.warn('Unable to persist Cat Typing settings.', error);
-    }
-  };
-
-  const getSessionToken = () => {
-    try {
-      return sessionStorage.getItem(SESSION_TOKEN_KEY) || '';
-    } catch (error) {
-      console.warn('Session storage unavailable.', error);
-      return '';
-    }
-  };
-
-  const setSessionToken = (value) => {
-    try {
-      if (value) {
-        sessionStorage.setItem(SESSION_TOKEN_KEY, value);
-      } else {
-        sessionStorage.removeItem(SESSION_TOKEN_KEY);
-      }
-    } catch (error) {
-      console.warn('Unable to persist session token.', error);
-    }
-  };
-
-  const setLoginStatus = (message, tone = 'info') => {
-    if (!loginStatus) return;
-    loginStatus.textContent = message;
-    loginStatus.dataset.tone = tone;
-  };
-
-  const updateAliasBadge = () => {
-    if (!aliasDisplayRow || !currentAliasEl) return;
-    if (currentAlias) {
-      currentAliasEl.textContent = currentAlias;
-      aliasDisplayRow.hidden = false;
+  const scheduleNextFrame = (callback) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(callback);
     } else {
-      currentAliasEl.textContent = '';
-      aliasDisplayRow.hidden = true;
+      setTimeout(callback, 0);
     }
   };
 
-  const updateStartHint = (canSync) => {
-    if (!startHint) return;
-
-    if (canSync) {
-      startHint.textContent = defaultStartHint;
-    } else {
-      startHint.textContent = 'Connect GitHub access from the global settings to sync your scores. You can still practice without signing in.';
-    }
-
+  const findFirstFocusable = (container) => {
+    if (!container) return null;
+    return container.querySelector(focusableSelector);
   };
 
-  const setLoginState = (loggedIn) => {
-    if (logoutButton) {
-      logoutButton.disabled = !loggedIn;
-    }
-    const canSync = Boolean(loggedIn && gistId && gistToken);
-    updateStartHint(canSync);
-  };
-
-  const ensureAliasHistory = () => {
-    if (!gistStore || typeof gistStore !== 'object') {
-      gistStore = {};
-    }
-    if (!currentAlias) {
-      return [];
-    }
-    if (!Array.isArray(gistStore[currentAlias])) {
-      gistStore[currentAlias] = [];
-    }
-    return gistStore[currentAlias];
-  };
-
-  const renderScoreHistory = () => {
-    if (!historyTable || !historyRows || !historyEmpty) return;
-    historyRows.innerHTML = '';
-
-    if (!currentAlias) {
-      historyTable.classList.add('hidden');
-      historyEmpty.classList.remove('hidden');
-      historyEmpty.textContent = 'Log in to view saved scores.';
+  const setScreen = (screenName, { focusTarget, focus = true } = {}) => {
+    const config = screenRegistry[screenName];
+    if (!config || !config.element) {
       return;
     }
 
-    const history = ensureAliasHistory()
-      .slice()
-      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    Object.values(screenRegistry).forEach(({ element }) => {
+      if (!element) return;
+      const isActive = element === config.element;
+      element.classList.toggle('hidden', !isActive);
+      element.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
 
-    if (!history.length) {
-      historyTable.classList.add('hidden');
-      historyEmpty.classList.remove('hidden');
-      historyEmpty.textContent = 'No scores yet — finish a test to record your first run.';
+    activeScreen = config.element;
+
+    if (!focus) {
       return;
     }
 
-    historyEmpty.classList.add('hidden');
-    historyTable.classList.remove('hidden');
+    scheduleNextFrame(() => {
+      const resolvedFocusTarget = typeof focusTarget === 'function' ? focusTarget() : focusTarget;
 
-    const formatter = new Intl.DateTimeFormat(undefined, {
-      dateStyle: 'short',
-      timeStyle: 'short',
-    });
-
-    history.forEach((entry) => {
-      const row = document.createElement('tr');
-
-      const dateCell = document.createElement('td');
-      const entryDate = entry && entry.date ? new Date(entry.date) : null;
-      dateCell.textContent = entryDate && !Number.isNaN(entryDate.getTime())
-        ? formatter.format(entryDate)
-        : 'Unknown';
-      row.appendChild(dateCell);
-
-      const durationCell = document.createElement('td');
-      const durationValue = Number(entry && entry.duration);
-      durationCell.textContent = Number.isFinite(durationValue) ? `${durationValue}s` : '—';
-      row.appendChild(durationCell);
-
-      const wpmCell = document.createElement('td');
-      const wpmValue = Number(entry && entry.wpm);
-      wpmCell.textContent = Number.isFinite(wpmValue) ? wpmValue.toFixed(1) : '0.0';
-      row.appendChild(wpmCell);
-
-      const accuracyCell = document.createElement('td');
-      const accuracyValue = Number(entry && entry.accuracy);
-      accuracyCell.textContent = Number.isFinite(accuracyValue)
-        ? `${accuracyValue.toFixed(1)}%`
-        : '0.0%';
-      row.appendChild(accuracyCell);
-
-      historyRows.appendChild(row);
-    });
-  };
-
-  const fetchGistFromGitHub = async () => {
-    if (!gistId || !gistToken) {
-      throw new Error('Missing GitHub configuration.');
-    }
-
-    // GitHub API: Fetch the gist that stores typing score history for all aliases.
-    const response = await fetch(`https://api.github.com/gists/${gistId}`, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `token ${gistToken}`,
-      },
-    });
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        gistStore = {};
-        throw new Error('GitHub gist not found. Double-check the ID.');
+      let target = resolvedFocusTarget || (config.getDefaultFocus && config.getDefaultFocus());
+      if (!target) {
+        target = findFirstFocusable(config.element);
       }
-      throw new Error(`GitHub API error (${response.status}).`);
-    }
 
-    const payload = await response.json();
-    const file = payload.files && payload.files[GIST_FILENAME];
-
-    if (file && typeof file.content === 'string') {
-      try {
-        const parsed = JSON.parse(file.content);
-        gistStore = parsed && typeof parsed === 'object' ? parsed : {};
-      } catch (error) {
-        console.warn('Gist content is not valid JSON. Starting with an empty history.', error);
-        gistStore = {};
-      }
-    } else {
-      gistStore = {};
-    }
-
-    ensureAliasHistory();
-  };
-
-  const syncGist = async () => {
-    if (!gistId || !gistToken) {
-      throw new Error('Missing GitHub credentials for syncing.');
-    }
-
-    const body = JSON.stringify({
-      files: {
-        [GIST_FILENAME]: {
-          content: JSON.stringify(gistStore, null, 2),
-        },
-      },
-    });
-
-    // GitHub API: Persist the updated score history to the configured gist file.
-    const response = await fetch(`https://api.github.com/gists/${gistId}`, {
-      method: 'PATCH',
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `token ${gistToken}`,
-        'Content-Type': 'application/json',
-      },
-      body,
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to sync with GitHub (${response.status}).`);
-    }
-
-    await response.json().catch(() => null);
-  };
-
-  const queueSync = () => {
-    if (!currentAlias) return;
-
-    if (!gistId || !gistToken) {
-      setLoginStatus('GitHub access missing. Open the global settings to reconnect before syncing scores.', 'info');
-      return;
-    }
-
-    if (syncInFlight) {
-      syncPending = true;
-      return;
-    }
-
-    syncInFlight = true;
-    setLoginStatus('Saving score to GitHub…');
-
-    syncGist()
-      .then(() => {
-        setLoginStatus('Score synced to GitHub.', 'success');
-      })
-      .catch((error) => {
-        console.error(error);
-        setLoginStatus(error.message || 'Unable to sync with GitHub.', 'error');
-      })
-      .finally(() => {
-        syncInFlight = false;
-        if (syncPending) {
-          syncPending = false;
-          queueSync();
+      if (target && typeof target.focus === 'function') {
+        try {
+          target.focus({ preventScroll: true });
+        } catch (error) {
+          target.focus();
         }
-      });
+      }
+    });
   };
 
-  const persistResult = (result) => {
-    if (!currentAlias) {
-      setLoginStatus('Result not saved — enter your alias after reconnecting GitHub access to store your history.', 'error');
-      return;
-    }
+  const isScreenActive = (element) => element === activeScreen;
 
-    const history = ensureAliasHistory();
-    history.push(result);
-    history.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-    if (history.length > 50) {
-      history.length = 50;
-    }
+  const formatTime = (seconds) => {
+    const safeSeconds = Math.max(0, Math.floor(seconds));
+    const mins = Math.floor(safeSeconds / 60)
+      .toString()
+      .padStart(2, '0');
+    const secs = (safeSeconds % 60).toString().padStart(2, '0');
+    return `${mins}:${secs}`;
+  };
 
-    renderScoreHistory();
-    queueSync();
+  const resetStats = () => {
+    correctChars = 0;
+    typedChars = 0;
+    if (wpmEl) wpmEl.textContent = '0';
+    if (cpmEl) cpmEl.textContent = '0';
+    if (accuracyEl) accuracyEl.textContent = '100%';
+  };
+
+  const renderTargetText = (text) => {
+    if (!textDisplay) return;
+    textDisplay.innerHTML = '';
+    charSpans = [];
+    [...text].forEach((char) => {
+      const span = document.createElement('span');
+      span.textContent = char;
+      textDisplay.appendChild(span);
+      charSpans.push(span);
+    });
+
+    if (charSpans.length) {
+      charSpans[0].classList.add('current');
+    }
+  };
+
+  const updateHighlights = (value) => {
+    correctChars = 0;
+    typedChars = value.length;
+
+    charSpans.forEach((span, index) => {
+      span.classList.remove('correct', 'incorrect', 'current');
+      if (index < value.length) {
+        if (value[index] === targetText[index]) {
+          span.classList.add('correct');
+          correctChars += 1;
+        } else {
+          span.classList.add('incorrect');
+        }
+      }
+    });
+
+    const nextIndex = value.length;
+    if (nextIndex < charSpans.length && charSpans[nextIndex]) {
+      charSpans[nextIndex].classList.add('current');
+    }
+  };
+
+  const updateLiveStats = () => {
+    if (!startTimestamp) return;
+    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
+    const minutes = elapsedSeconds / 60;
+    const words = correctChars / 5;
+    const cpm = (correctChars / elapsedSeconds) * 60;
+    const accuracy = typedChars === 0 ? 100 : (correctChars / typedChars) * 100;
+
+    if (wpmEl) {
+      wpmEl.textContent = Math.round(words / minutes || 0).toString();
+    }
+    if (cpmEl) {
+      cpmEl.textContent = Math.round(cpm || 0).toString();
+    }
+    if (accuracyEl) {
+      accuracyEl.textContent = `${Math.max(0, Math.min(100, accuracy)).toFixed(0)}%`;
+    }
   };
 
   const applyInputWidth = () => {
@@ -545,321 +195,6 @@
       observer.observe(textDisplay);
     } else {
       window.addEventListener('resize', applyInputWidth);
-    }
-  };
-
-  const handleLogin = async (isAuto = false) => {
-    if (!loginForm) return;
-
-    const aliasValue = aliasInput ? aliasInput.value.trim() : '';
-    const sharedSettings = readSharedGistSettings();
-    const normalizedGistId = sharedSettings.gistId;
-    const normalizedToken = sharedSettings.gistToken;
-
-    if (!aliasValue) {
-      setLoginStatus('Enter an alias to continue.', 'error');
-      return;
-    }
-
-    gistId = normalizedGistId;
-    gistToken = normalizedToken;
-
-    if (!normalizedGistId || !normalizedToken) {
-      setLoginStatus('Connect a GitHub gist in the global settings to sync your scores.', 'error');
-      return;
-    }
-
-    if (loginButton) {
-      loginButton.disabled = true;
-    }
-    setLoginStatus('Loading score history…');
-
-    currentAlias = aliasValue;
-
-    try {
-      await fetchGistFromGitHub();
-      persistLocalSettings(aliasValue);
-      setSessionToken(normalizedToken);
-      isLoggedIn = true;
-      setLoginState(true);
-      updateAliasBadge();
-      renderScoreHistory();
-      setLoginStatus(`Signed in as ${aliasValue}.`, 'success');
-    } catch (error) {
-      console.error(error);
-      gistStore = {};
-      currentAlias = '';
-      gistToken = '';
-      setSessionToken('');
-      setLoginState(false);
-      updateAliasBadge();
-      renderScoreHistory();
-      setLoginStatus(error.message || 'Login failed.', 'error');
-      if (!isAuto && aliasInput) {
-        aliasInput.focus();
-      }
-      isLoggedIn = false;
-      setScreen('login-screen');
-    } finally {
-      if (loginButton) {
-        loginButton.disabled = false;
-      }
-    }
-  };
-
-  const performLogout = ({ statusMessage, statusTone } = {}) => {
-    const normalizedAlias = aliasInput ? aliasInput.value.trim() : '';
-    persistLocalSettings(normalizedAlias);
-    setSessionToken('');
-    gistStore = {};
-    currentAlias = '';
-    syncInFlight = false;
-    syncPending = false;
-    isLoggedIn = false;
-    setLoginState(false);
-    updateAliasBadge();
-    renderScoreHistory();
-    setLoginStatus(statusMessage || 'Signed out. Enter your alias after reconnecting GitHub access to sync again.', statusTone || 'info');
-  };
-
-  const handleLogout = () => {
-    performLogout({});
-  };
-
-  const handleSharedGistSettingsUpdate = (raw) => {
-    if (!raw || typeof raw !== 'object') {
-      return;
-    }
-
-    const previousGistId = gistId;
-    const previousGistToken = gistToken;
-    const sanitized = sanitizeGistSettings(raw);
-    const hasChanged = sanitized.gistId !== previousGistId || sanitized.gistToken !== previousGistToken;
-
-    gistId = sanitized.gistId;
-    gistToken = sanitized.gistToken;
-
-    if (!hasChanged) {
-      return;
-    }
-
-    if (sanitized.gistToken) {
-      setSessionToken(sanitized.gistToken);
-      if (!isLoggedIn && currentAlias) {
-        if (aliasInput && !aliasInput.value.trim()) {
-          aliasInput.value = currentAlias;
-        }
-        handleLogin(true);
-        return;
-      }
-      if (isLoggedIn) {
-        setLoginStatus('Refreshing GitHub history…');
-        fetchGistFromGitHub()
-          .then(() => {
-            renderScoreHistory();
-            setLoginStatus(`Signed in as ${currentAlias}.`, 'success');
-          })
-          .catch((error) => {
-            console.warn('Unable to refresh GitHub history from broadcast.', error);
-            setLoginStatus('Unable to refresh GitHub history.', 'error');
-          });
-      }
-    } else {
-      setSessionToken('');
-      const hadAlias = Boolean(currentAlias);
-      if (isLoggedIn) {
-        isLoggedIn = false;
-      }
-      setLoginState(hadAlias);
-      if (hadAlias) {
-        setLoginStatus('GitHub access removed in another tab. Open the global settings to reconnect before syncing again.', 'info');
-      }
-      updateAliasBadge();
-      renderScoreHistory();
-    }
-  };
-
-  if (gistSettingsChannel) {
-    gistSettingsChannel.addEventListener('message', (event) => {
-      if (!event || typeof event.data !== 'object') {
-        return;
-      }
-      handleSharedGistSettingsUpdate(event.data);
-    });
-  }
-
-  window.addEventListener('message', (event) => {
-    if (!event || typeof event.data !== 'object') {
-      return;
-    }
-    if (event.data.type !== GIST_SETTINGS_MESSAGE) {
-      return;
-    }
-    handleSharedGistSettingsUpdate(event.data);
-  });
-
-  const formatTime = (seconds) => {
-    const safeSeconds = Math.max(0, Math.floor(seconds));
-    const mins = Math.floor(safeSeconds / 60)
-      .toString()
-      .padStart(2, '0');
-    const secs = (safeSeconds % 60).toString().padStart(2, '0');
-    return `${mins}:${secs}`;
-  };
-
-  const focusableSelector = [
-    'button:not([disabled])',
-    '[href]',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(', ');
-
-  const findFirstFocusable = (container) => {
-    if (!container) return null;
-    return container.querySelector(focusableSelector);
-  };
-
-  const screenRegistry = {
-    'login-screen': {
-      element: loginScreen,
-      getDefaultFocus: () => aliasInput || findFirstFocusable(loginScreen),
-    },
-    'start-screen': {
-      element: startScreen,
-      getDefaultFocus: () =>
-        (startScreen && startScreen.querySelector('.duration-btn')) || findFirstFocusable(startScreen),
-    },
-    'test-screen': {
-      element: testScreen,
-      getDefaultFocus: () => typingInput || findFirstFocusable(testScreen),
-    },
-    'results-screen': {
-      element: resultsScreen,
-      getDefaultFocus: () => resultsRetry || findFirstFocusable(resultsScreen),
-    },
-  };
-
-  const setScreen = (screenId, options = {}) => {
-    const config = screenRegistry[screenId];
-    if (!config || !config.element) {
-      return;
-    }
-
-    Object.values(screenRegistry).forEach(({ element }) => {
-      if (!element) return;
-      const isActive = element === config.element;
-      element.classList.toggle('hidden', !isActive);
-      element.setAttribute('aria-hidden', isActive ? 'false' : 'true');
-    });
-
-    if (typeof options.onShow === 'function') {
-      options.onShow(config.element);
-    }
-
-    if (options.focus === false) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      let target = null;
-      if (typeof options.focusTarget === 'function') {
-        target = options.focusTarget();
-      } else if (options.focusTarget) {
-        target = options.focusTarget;
-      }
-
-      if (!target && typeof config.getDefaultFocus === 'function') {
-        target = config.getDefaultFocus();
-      }
-
-      if (!target) {
-        target = findFirstFocusable(config.element);
-      }
-
-      if (target && typeof target.focus === 'function') {
-        target.focus();
-      }
-    });
-  };
-
-  const isScreenActive = (screen) => {
-    if (!screen) return false;
-    const isHidden = screen.classList.contains('hidden');
-    const ariaHidden = screen.getAttribute('aria-hidden');
-    return !isHidden && ariaHidden !== 'true';
-  };
-
-  const scheduleNextFrame = (callback) => {
-    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(callback);
-    } else {
-      setTimeout(callback, 0);
-    }
-  };
-
-  const focusTypingInput = ({ selectEnd = true } = {}) => {
-    if (!typingInput || !isScreenActive(testScreen)) {
-      return;
-    }
-
-    scheduleNextFrame(() => {
-      if (!typingInput || typingInput.disabled || !isScreenActive(testScreen)) {
-        return;
-      }
-
-      if (typeof typingInput.focus === 'function') {
-        try {
-          typingInput.focus({ preventScroll: true });
-        } catch (error) {
-          typingInput.focus();
-        }
-      }
-
-      if (selectEnd && typeof typingInput.setSelectionRange === 'function') {
-        const end = typingInput.value.length;
-        try {
-          typingInput.setSelectionRange(end, end);
-        } catch (error) {
-          // Ignore selection errors in unsupported environments.
-        }
-      }
-    });
-    activeScreen = screen;
-  };
-
-  const focusStartScreenControl = () => {
-    if (!isScreenActive(startScreen)) {
-      return;
-    }
-
-    const aliasTarget = !isLoggedIn && aliasInput && !aliasInput.disabled ? aliasInput : null;
-    if (aliasTarget) {
-      if (typeof aliasTarget.focus === 'function') {
-        aliasTarget.focus({ preventScroll: true });
-      }
-      return;
-    }
-
-    const desiredDuration = Number.isFinite(testDuration) && testDuration > 0 ? testDuration : null;
-    const activeButton = durationButtons.find((button) => {
-      if (!button || button.disabled || desiredDuration === null) {
-        return false;
-      }
-      const value = Number(button.dataset.duration);
-      return Number.isFinite(value) && value === desiredDuration;
-    });
-
-    const fallbackButton = activeButton || durationButtons.find((button) => button && !button.disabled);
-
-    if (fallbackButton && typeof fallbackButton.focus === 'function') {
-      fallbackButton.focus({ preventScroll: true });
-      return;
-    }
-
-    if (aliasInput && typeof aliasInput.focus === 'function' && !aliasInput.disabled) {
-      aliasInput.focus({ preventScroll: true });
     }
   };
 
@@ -917,67 +252,38 @@
     return passage.trim();
   };
 
-  const renderTargetText = (text) => {
-    textDisplay.innerHTML = '';
-    charSpans = [];
-    [...text].forEach((char) => {
-      const span = document.createElement('span');
-      span.textContent = char;
-      textDisplay.appendChild(span);
-      charSpans.push(span);
-    });
-
-    if (charSpans.length) {
-      charSpans[0].classList.add('current');
+  const focusTypingInput = ({ selectEnd = true } = {}) => {
+    if (!typingInput || !isScreenActive(testScreen)) {
+      return;
     }
-  };
 
-  const resetStats = () => {
-    correctChars = 0;
-    typedChars = 0;
-    wpmEl.textContent = '0';
-    cpmEl.textContent = '0';
-    accuracyEl.textContent = '100%';
-  };
+    scheduleNextFrame(() => {
+      if (!typingInput || typingInput.disabled || !isScreenActive(testScreen)) {
+        return;
+      }
 
-  const updateHighlights = (value) => {
-    correctChars = 0;
-    typedChars = value.length;
+      try {
+        typingInput.focus({ preventScroll: true });
+      } catch (error) {
+        typingInput.focus();
+      }
 
-    charSpans.forEach((span, index) => {
-      span.classList.remove('correct', 'incorrect', 'current');
-      if (index < value.length) {
-        if (value[index] === targetText[index]) {
-          span.classList.add('correct');
-          correctChars += 1;
-        } else {
-          span.classList.add('incorrect');
+      if (selectEnd && typeof typingInput.setSelectionRange === 'function') {
+        const end = typingInput.value.length;
+        try {
+          typingInput.setSelectionRange(end, end);
+        } catch (error) {
+          // Ignore selection errors in unsupported environments.
         }
       }
     });
-
-    const nextIndex = value.length;
-    if (nextIndex < charSpans.length && charSpans[nextIndex]) {
-      charSpans[nextIndex].classList.add('current');
-    }
-  };
-
-  const updateLiveStats = () => {
-    if (!startTimestamp) return;
-    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
-    const minutes = elapsedSeconds / 60;
-    const words = correctChars / 5;
-    const cpm = (correctChars / elapsedSeconds) * 60;
-    const accuracy = typedChars === 0 ? 100 : (correctChars / typedChars) * 100;
-
-    wpmEl.textContent = Math.round(words / minutes || 0).toString();
-    cpmEl.textContent = Math.round(cpm || 0).toString();
-    accuracyEl.textContent = `${Math.max(0, Math.min(100, accuracy)).toFixed(0)}%`;
   };
 
   const handleTick = () => {
     countdownSeconds -= 1;
-    timerEl.textContent = formatTime(countdownSeconds);
+    if (timerEl) {
+      timerEl.textContent = formatTime(countdownSeconds);
+    }
 
     if (countdownSeconds <= 0) {
       finishTest('time');
@@ -994,39 +300,6 @@
     timerId = null;
   };
 
-  const finishTest = (reason) => {
-    if (!startTimestamp) return;
-    stopTimer();
-    typingInput.disabled = true;
-    countdownSeconds = 0;
-
-    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
-    const minutes = elapsedSeconds / 60;
-    const words = correctChars / 5;
-    const wpmValue = minutes > 0 ? words / minutes : 0;
-    const cpmValue = elapsedSeconds > 0 ? (correctChars / elapsedSeconds) * 60 : 0;
-    const accuracyValue = typedChars === 0 ? 0 : (correctChars / typedChars) * 100;
-
-    finalWpm.textContent = wpmValue.toFixed(1);
-    finalCpm.textContent = Math.round(cpmValue || 0).toString();
-    finalAccuracy.textContent = `${Math.max(0, Math.min(100, accuracyValue)).toFixed(1)}%`;
-
-    const summary = reason === 'completed'
-      ? 'Purrfect focus! You finished the story before the timer ran out.'
-      : "Time's up! Scroll back for another lap with the cats.";
-    resultsNote.textContent = summary;
-
-    persistResult({
-      date: new Date().toISOString(),
-      duration: Number.isFinite(testDuration) ? Number(testDuration) : 0,
-      wpm: Number.isFinite(wpmValue) ? Number(wpmValue.toFixed(1)) : 0,
-      accuracy: Number.isFinite(accuracyValue) ? Number(Math.max(0, Math.min(100, accuracyValue)).toFixed(1)) : 0,
-    });
-
-    setScreen('results-screen', { focusTarget: resultsRetry });
-    startTimestamp = null;
-  };
-
   const resetTestState = () => {
     stopTimer();
     typingInput.value = '';
@@ -1036,13 +309,59 @@
     targetText = '';
     charSpans = [];
     resetStats();
+    countdownSeconds = testDuration;
+  };
+
+  const finishTest = (reason) => {
+    if (!startTimestamp) return;
+    stopTimer();
+    typingInput.disabled = true;
     countdownSeconds = 0;
-    testDuration = 0;
+    if (timerEl) {
+      timerEl.textContent = formatTime(countdownSeconds);
+    }
+
+    const elapsedSeconds = Math.max((performance.now() - startTimestamp) / 1000, 0.1);
+    const minutes = elapsedSeconds / 60;
+    const words = correctChars / 5;
+    const wpmValue = minutes > 0 ? words / minutes : 0;
+    const cpmValue = elapsedSeconds > 0 ? (correctChars / elapsedSeconds) * 60 : 0;
+    const accuracyValue = typedChars === 0 ? 0 : (correctChars / typedChars) * 100;
+
+    if (finalWpm) {
+      finalWpm.textContent = wpmValue.toFixed(1);
+    }
+    if (finalCpm) {
+      finalCpm.textContent = Math.round(cpmValue || 0).toString();
+    }
+    if (finalAccuracy) {
+      finalAccuracy.textContent = `${Math.max(0, Math.min(100, accuracyValue)).toFixed(1)}%`;
+    }
+
+    if (resultsNote) {
+      const summary = reason === 'completed'
+        ? 'Purrfect focus! You finished the story before the timer ran out.'
+        : "Time's up! Scroll back for another lap with the cats.";
+      resultsNote.textContent = summary;
+    }
+
+    setScreen('results', { focusTarget: resultsRetry });
+    startTimestamp = null;
   };
 
   const beginTest = async (duration) => {
     try {
-      testDuration = Number(duration);
+      testDuration = Number(duration) > 0 ? Number(duration) : DEFAULT_DURATION;
+      countdownSeconds = testDuration;
+
+      resetTestState();
+      typingInput.disabled = true;
+      if (timerEl) {
+        timerEl.textContent = formatTime(countdownSeconds);
+      }
+
+      setScreen('test', { focus: false });
+
       const sentences = await loadCorpus();
       targetText = pickPassage(sentences);
       renderTargetText(targetText);
@@ -1050,24 +369,20 @@
       typingInput.value = '';
       typingInput.disabled = false;
 
-      countdownSeconds = testDuration;
       updateHighlights('');
-      timerEl.textContent = formatTime(countdownSeconds);
+      if (timerEl) {
+        timerEl.textContent = formatTime(countdownSeconds);
+      }
 
-      setScreen(testScreen);
-      focusTypingInput();
+      focusTypingInput({ selectEnd: false });
       scheduleNextFrame(() => {
         applyInputWidth();
       });
 
       startTimestamp = performance.now();
       setupTimer();
-      timerEl.textContent = formatTime(countdownSeconds);
     } catch (error) {
       resetTestState();
-      setScreen(startScreen);
-      focusStartScreenControl();
-
       alert('Unable to load the cat corpus. Please refresh and try again.');
       console.error(error);
     }
@@ -1083,185 +398,22 @@
     }
   };
 
-  if (loginForm) {
-    loginForm.addEventListener('submit', (event) => {
-      event.preventDefault();
-      handleLogin();
-    });
-  }
-
-  if (logoutButton) {
-    logoutButton.addEventListener('click', handleLogout);
-  }
-
-  durationButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      const duration = parseDurationValue(button);
-      if (!Number.isFinite(duration) || duration <= 0) return;
-      startDuration(duration);
-    });
-  });
-
-  restartBtn.addEventListener('click', () => {
-    const preferredDuration = Number.isFinite(testDuration) && testDuration > 0
-      ? testDuration
-      : getPreferredDuration();
-    if (!Number.isFinite(preferredDuration) || preferredDuration <= 0) {
-      setScreen(startScreen);
-      requestAnimationFrame(() => {
-        focusActiveDurationButton();
-      });
-      return;
-
-    }
-    startDuration(preferredDuration);
-  });
-
-  backBtn.addEventListener('click', () => {
-    resetTestState();
-    setScreen(startScreen);
-    requestAnimationFrame(() => {
-      focusActiveDurationButton();
-    });
-
-  });
-
   typingInput.addEventListener('input', handleInput);
 
-  resultsRetry.addEventListener('click', () => {
-    const preferredDuration = getPreferredDuration();
-    if (!Number.isFinite(preferredDuration) || preferredDuration <= 0) {
-      setScreen(startScreen);
-      requestAnimationFrame(() => {
-        focusActiveDurationButton();
-      });
-
-      return;
-    }
-    startDuration(preferredDuration);
-  });
-
-  resultsMenu.addEventListener('click', () => {
-    resetTestState();
-    setScreen(startScreen);
-    requestAnimationFrame(() => {
-      focusActiveDurationButton();
+  if (restartBtn) {
+    restartBtn.addEventListener('click', () => {
+      beginTest(testDuration || DEFAULT_DURATION);
     });
-  });
+  }
 
-  window.addEventListener('keydown', (event) => {
-    if (event.defaultPrevented || event.repeat) {
-      return;
-    }
-
-    const { key } = event;
-    const activeElement = document.activeElement;
-    const lowerKey = typeof key === 'string' ? key.toLowerCase() : '';
-    const restartKey = lowerKey === 'r' || key === ' ' || key === 'Spacebar';
-    const isMenuActive = activeScreen === startScreen;
-    const isTestOrResults = activeScreen === testScreen || activeScreen === resultsScreen;
-
-    if (isMenuActive) {
-      if (isTextEntryElement(activeElement)) {
-        return;
-      }
-
-      if (/^[1-9]$/.test(key)) {
-        const numericIndex = Number.parseInt(key, 10) - 1;
-        if (numericIndex >= 0 && numericIndex < durationButtons.length) {
-          event.preventDefault();
-          startDurationByIndex(numericIndex);
-          return;
-        }
-      }
-
-      if (durationButtons.length > 0) {
-        if (key === 'ArrowLeft' || key === 'ArrowUp') {
-          event.preventDefault();
-          const currentIndex = getCurrentDurationIndex();
-          const targetIndex = currentIndex > 0 ? currentIndex - 1 : 0;
-          startDurationByIndex(targetIndex);
-          return;
-        }
-        if (key === 'ArrowRight' || key === 'ArrowDown') {
-          event.preventDefault();
-          const currentIndex = getCurrentDurationIndex();
-          const fallbackIndex = durationButtons.length - 1;
-          const targetIndex = currentIndex >= 0 && currentIndex < fallbackIndex
-            ? currentIndex + 1
-            : fallbackIndex;
-          startDurationByIndex(targetIndex);
-          return;
-        }
-      }
-    }
-
-    if (key === 'Escape' && isTestOrResults) {
-      event.preventDefault();
-      resetTestState();
-      setScreen(startScreen);
-      requestAnimationFrame(() => {
-        focusActiveDurationButton();
-      });
-      return;
-    }
-
-    if (restartKey && isTestOrResults) {
-      if (isTextEntryElement(activeElement) && activeElement === typingInput && !typingInput.disabled) {
-        return;
-      }
-      event.preventDefault();
-      const preferredDuration = getPreferredDuration();
-      if (!Number.isFinite(preferredDuration) || preferredDuration <= 0) {
-        resetTestState();
-        setScreen(startScreen);
-        requestAnimationFrame(() => {
-          focusActiveDurationButton();
-        });
-        return;
-      }
-      startDuration(preferredDuration);
-    }
-
-  });
+  if (resultsRetry) {
+    resultsRetry.addEventListener('click', () => {
+      beginTest(testDuration || DEFAULT_DURATION);
+    });
+  }
 
   observeTextPanel();
-
-  const storedSettings = loadStoredSettings();
-
-  if (aliasInput && storedSettings.alias) {
-    aliasInput.value = storedSettings.alias;
-  }
-
-  const sharedSettings = readSharedGistSettings();
-  const sessionToken = getSessionToken();
-
-  gistId = sharedSettings.gistId;
-  gistToken = sharedSettings.gistToken;
-
-  if (!gistToken && sessionToken) {
-    setSessionToken('');
-  }
-
-  updateAliasBadge();
-  setLoginState(false);
-  renderScoreHistory();
-  setLoginStatus('Enter your alias and use the global settings to connect GitHub before syncing scores.');
-
-  const aliasForAutoLogin = aliasInput ? aliasInput.value.trim() : '';
-  if (aliasForAutoLogin && gistId && gistToken) {
-    handleLogin(true);
-  }
-
-  setScreen(startScreen);
-  requestAnimationFrame(() => {
-    focusActiveDurationButton();
-  });
-  focusStartScreenControl();
-  scheduleNextFrame(() => {
-    focusTypingInput();
-  });
-
+  beginTest(DEFAULT_DURATION);
 
   window.addEventListener('beforeunload', () => {
     stopTimer();

--- a/src/apps/cat-typing-speed-test/styles.css
+++ b/src/apps/cat-typing-speed-test/styles.css
@@ -46,129 +46,6 @@ body {
   font-size: 1.05rem;
 }
 
-.alias-display {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.alias-display span {
-  font-weight: 600;
-  color: var(--accent-dark);
-}
-
-.login-card {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.login-intro {
-  margin: 0;
-  color: var(--muted);
-}
-
-#login-form {
-  display: grid;
-  gap: 1rem;
-}
-
-.field {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.field span {
-  font-weight: 600;
-}
-
-#login-form input {
-  border-radius: 0.85rem;
-  border: 2px solid rgba(236, 72, 153, 0.18);
-  background: rgba(255, 255, 255, 0.85);
-  padding: 0.8rem 1rem;
-  font-size: 1rem;
-  transition: border 0.2s ease, box-shadow 0.2s ease;
-}
-
-#login-form input:focus-visible {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.25);
-  outline: none;
-}
-
-.login-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-}
-
-.login-actions button {
-  font-size: 1rem;
-  font-weight: 600;
-  border-radius: 0.9rem;
-  padding: 0.75rem 1.5rem;
-  border: none;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.login-actions button:focus-visible {
-  outline: 3px solid rgba(236, 72, 153, 0.45);
-  outline-offset: 3px;
-}
-
-.login-submit {
-  background: var(--accent);
-  color: #fff;
-}
-
-.login-submit:hover,
-.login-submit:focus-visible {
-  background: var(--accent-dark);
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(236, 72, 153, 0.25);
-}
-
-.login-logout {
-  background: transparent;
-  border: 2px solid rgba(107, 114, 128, 0.35);
-  color: var(--muted);
-}
-
-.login-logout:hover,
-.login-logout:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
-}
-
-.login-actions button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-  transform: none;
-}
-
-.login-note {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.status-message {
-  margin: 0;
-  font-weight: 600;
-  color: var(--muted);
-}
-
-.status-message[data-tone='success'] {
-  color: var(--success);
-}
-
-.status-message[data-tone='error'] {
-  color: var(--error);
-}
-
 .card {
   background: rgba(255, 255, 255, 0.92);
   border-radius: 1.5rem;
@@ -181,61 +58,6 @@ body {
 
 .hidden {
   display: none;
-}
-
-.duration-options {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.duration-btn {
-  border: none;
-  border-radius: 999px;
-  background: var(--accent);
-  color: #fff;
-  font-size: 1.05rem;
-  font-weight: 600;
-  padding: 0.85rem 1.75rem;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.duration-btn:hover,
-.duration-btn:focus-visible {
-  background: var(--accent-dark);
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(236, 72, 153, 0.35);
-}
-
-.duration-btn[data-active] {
-  background: var(--accent-dark);
-  transform: translateY(-2px);
-  box-shadow: 0 12px 28px rgba(236, 72, 153, 0.4);
-}
-
-.duration-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-.duration-btn:focus-visible {
-  outline: 3px solid rgba(236, 72, 153, 0.4);
-  outline-offset: 3px;
-}
-
-.duration-btn[data-active]:focus-visible {
-  outline: 3px solid rgba(236, 72, 153, 0.55);
-  box-shadow: 0 0 0 4px rgba(236, 72, 153, 0.35), 0 12px 28px rgba(236, 72, 153, 0.4);
-}
-
-.start-hint {
-  margin: 0;
-  text-align: center;
-  color: var(--muted);
 }
 
 .test-meta {
@@ -353,12 +175,11 @@ textarea:disabled {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .actions .primary,
-.actions .secondary,
-.actions .ghost {
+.actions .secondary {
   font-size: 1rem;
   font-weight: 600;
   border-radius: 0.9rem;
@@ -390,11 +211,6 @@ textarea:disabled {
 .actions .secondary:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 12px 22px rgba(219, 39, 119, 0.25);
-}
-
-.actions .ghost {
-  background: transparent;
-  color: var(--muted);
 }
 
 .actions button:focus-visible {
@@ -484,11 +300,4 @@ textarea:disabled {
     flex: 1;
   }
 
-  .login-actions {
-    justify-content: stretch;
-  }
-
-  .login-actions button {
-    flex: 1;
-  }
 }


### PR DESCRIPTION
## Summary
- remove the login and duration picker views so the typing test loads as the default screen
- simplify the JavaScript to start the test automatically with the default duration and trim legacy navigation logic
- clean up unused styles and tweak layout so the test view stands on its own

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2be2efd64832b84e4674a23d277e1