### PR TITLE
Revamp cat typing leaderboard UI

### DIFF
--- a/src/apps/cat-typing-speed-test/index.html
+++ b/src/apps/cat-typing-speed-test/index.html
@@ -60,20 +60,30 @@
           </div>
         </div>
         <p class="results-note" id="results-note"></p>
-        <div class="score-history" id="score-history" aria-live="polite">
-          <h3>Score history</h3>
-          <p class="history-empty" id="history-empty">Connect GitHub access from the global settings to sync your scores.</p>
-          <table class="history-table hidden" id="history-table">
-            <thead>
-              <tr>
-                <th scope="col">Date</th>
-                <th scope="col">Duration</th>
-                <th scope="col">WPM</th>
-                <th scope="col">Accuracy</th>
-              </tr>
-            </thead>
-            <tbody id="history-rows"></tbody>
-          </table>
+        <div class="score-sync" id="score-sync" aria-live="polite">
+          <div class="alias-section">
+            <label class="alias-label" for="alias-input">Leaderboard alias</label>
+            <div class="alias-controls">
+              <input
+                type="text"
+                id="alias-input"
+                name="alias"
+                class="alias-input"
+                maxlength="30"
+                autocomplete="nickname"
+                placeholder="Choose an alias to sync your runs"
+              />
+              <p class="sync-status" id="sync-status" role="status">
+                Add an alias to sync scores and appear on the public leaderboard.
+              </p>
+            </div>
+          </div>
+
+          <div class="leaderboard" id="leaderboard">
+            <h3>Top scores</h3>
+            <p class="leaderboard-empty" id="leaderboard-empty">No leaderboard data yet. Finish a test to claim a spot.</p>
+            <ol class="leaderboard-list hidden" id="leaderboard-list"></ol>
+          </div>
         </div>
         <div class="actions">
           <button type="button" class="primary" id="results-retry">Try again</button>

--- a/src/apps/cat-typing-speed-test/main.js
+++ b/src/apps/cat-typing-speed-test/main.js
@@ -15,6 +15,7 @@
   const finalAccuracy = document.getElementById('final-accuracy');
   const resultsNote = document.getElementById('results-note');
   const resultsRetry = document.getElementById('results-retry');
+  const aliasInput = document.getElementById('alias-input');
 
   if (!testScreen || !resultsScreen || !typingInput) {
     return;
@@ -27,7 +28,7 @@
     },
     results: {
       element: resultsScreen,
-      getDefaultFocus: () => resultsRetry,
+      getDefaultFocus: () => aliasInput || resultsRetry,
     },
   };
 

--- a/src/apps/cat-typing-speed-test/styles.css
+++ b/src/apps/cat-typing-speed-test/styles.css
@@ -240,45 +240,98 @@ textarea:disabled {
   color: var(--muted);
 }
 
-.score-history {
+.score-sync {
   border-top: 1px solid rgba(209, 213, 219, 0.6);
-  padding-top: 1.25rem;
+  padding-top: 1.5rem;
   display: grid;
+  gap: 1.25rem;
+}
+
+.alias-section {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.alias-label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.alias-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.75rem;
 }
 
-.score-history h3 {
-  margin: 0;
-  font-size: 1.2rem;
+.alias-input {
+  flex: 1 1 220px;
+  min-width: 200px;
+  border-radius: 0.85rem;
+  border: 2px solid rgba(148, 163, 184, 0.45);
+  padding: 0.55rem 0.9rem;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
 }
 
-.history-empty {
+.alias-input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.25);
+  outline: none;
+}
+
+.alias-input:disabled {
+  opacity: 0.6;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.sync-status {
   margin: 0;
   color: var(--muted);
 }
 
-.history-table {
-  width: 100%;
-  border-collapse: collapse;
+.leaderboard {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.leaderboard h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.leaderboard-empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+.leaderboard-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.leaderboard-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
   border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.25);
+  background: rgba(236, 72, 153, 0.06);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.2);
 }
 
-.history-table th,
-.history-table td {
-  text-align: left;
-  padding: 0.65rem 0.9rem;
-  font-size: 0.95rem;
+.leaderboard-alias {
+  font-weight: 600;
+}
+
+.leaderboard-wpm,
+.leaderboard-duration {
   font-variant-numeric: tabular-nums;
-}
-
-.history-table thead {
-  background: rgba(236, 72, 153, 0.08);
-}
-
-.history-table tbody tr:nth-child(even) {
-  background: rgba(15, 23, 42, 0.04);
+  color: var(--muted);
 }
 
 @media (max-width: 640px) {
@@ -298,6 +351,26 @@ textarea:disabled {
 
   .actions button {
     flex: 1;
+  }
+
+  .alias-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .alias-input {
+    width: 100%;
+  }
+
+  .leaderboard-row {
+    grid-template-columns: 1fr;
+    gap: 0.4rem;
+    text-align: left;
+  }
+
+  .leaderboard-wpm,
+  .leaderboard-duration {
+    color: var(--text-primary);
   }
 
 }


### PR DESCRIPTION
## Summary
- replace the results sync area with an alias entry, sync status messaging, and a leaderboard list scaffold
- introduce modern styles for the alias controls and leaderboard rows while dropping the legacy score table rules
- focus the alias input when the results screen opens so keyboard users can immediately discover sync options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2cce47268832ba659f6d60553b580