### PR TITLE
Add garden tab wiring in ZenDo app

### DIFF
--- a/src/apps/ZenDoApp/views/GardenView.js
+++ b/src/apps/ZenDoApp/views/GardenView.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const GardenColumn = ({ title, entries }) => (
+  <section className="zen-garden-column">
+    <h2>{title}</h2>
+    {entries.length === 0 ? (
+      <p className="zen-empty-hint">Nothing planted yet.</p>
+    ) : (
+      <ul className="zen-garden-list">
+        {entries.map((entry) => (
+          <li key={entry.id} className={`zen-garden-item${entry.isSnapshot ? ' is-snapshot' : ''}`}>
+            <div className="zen-garden-card">
+              <div className="zen-garden-card-header">
+                <span className="zen-garden-card-title">{entry.title}</span>
+                {entry.isSnapshot && <span className="zen-garden-card-tag">Persisted</span>}
+              </div>
+              <div className="zen-garden-card-progress">
+                Stage {entry.stage.completedStages} / {entry.stage.totalStages}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+);
+
+const GardenView = ({ priority, bonus }) => (
+  <div className="zen-garden-view">
+    <GardenColumn title="Priority Trees" entries={priority} />
+    <GardenColumn title="Bonus Bushes" entries={bonus} />
+  </div>
+);
+
+export default GardenView;


### PR DESCRIPTION
## Summary
- add the Garden tab and routing so the new view is selectable within ZenDo
- derive garden assignments with stage metadata for active focus tasks and same-day snapshots
- add a placeholder GardenView that renders priority trees and bonus bushes lists

## Testing
- npm test -- --runTestsByPath src/apps/ZenDoApp/__tests__/taskUtils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2d0146850832b83c883392753253b