### PR TITLE
feat: add leaderboard syncing to cat typing test

### DIFF
--- a/src/apps/cat-typing-speed-test/index.html
+++ b/src/apps/cat-typing-speed-test/index.html
@@ -113,20 +113,28 @@
             duration.
           </p>
         </div>
-        <div class="score-history" id="score-history" aria-live="polite">
-          <h3>Score history</h3>
-          <p class="history-empty" id="history-empty">Connect GitHub access from the global settings to sync your scores.</p>
-          <table class="history-table hidden" id="history-table">
-            <thead>
-              <tr>
-                <th scope="col">Date</th>
-                <th scope="col">Duration</th>
-                <th scope="col">WPM</th>
-                <th scope="col">Accuracy</th>
-              </tr>
-            </thead>
-            <tbody id="history-rows"></tbody>
-          </table>
+        <div class="leaderboard-card" id="leaderboard" aria-live="polite">
+          <div class="leaderboard-card__header">
+            <label class="alias-field" for="leaderboard-alias">
+              <span class="alias-field__label">Leaderboard alias</span>
+              <input
+                id="leaderboard-alias"
+                type="text"
+                name="leaderboard-alias"
+                maxlength="32"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="none"
+                spellcheck="false"
+                placeholder="Enter a short nickname"
+              />
+            </label>
+            <p class="sync-status" id="sync-status" role="status" aria-live="polite"></p>
+          </div>
+          <p class="leaderboard-empty" id="leaderboard-empty">
+            Connect GitHub access from the global settings to sync your scores.
+          </p>
+          <ol class="leaderboard-list hidden" id="leaderboard-list" aria-label="Top runs"></ol>
         </div>
         <div class="actions">
           <button type="button" class="primary" id="results-retry">Try again</button>

--- a/src/apps/cat-typing-speed-test/styles.css
+++ b/src/apps/cat-typing-speed-test/styles.css
@@ -373,45 +373,127 @@ textarea:disabled {
   color: var(--muted);
 }
 
-.score-history {
+.leaderboard-card {
   border-top: 1px solid rgba(209, 213, 219, 0.6);
   padding-top: 1.25rem;
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.score-history h3 {
+.leaderboard-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.alias-field {
+  display: grid;
+  gap: 0.4rem;
+  min-width: min(220px, 100%);
+}
+
+.alias-field__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.alias-field input {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(209, 213, 219, 0.8);
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.alias-field input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(236, 72, 153, 0.25);
+}
+
+.sync-status {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+  min-height: 1.35em;
 }
 
-.history-empty {
+.sync-status[data-status='disabled'] {
+  color: var(--muted);
+}
+
+.sync-status[data-status='syncing'] {
+  color: var(--accent-dark);
+}
+
+.sync-status[data-status='success'] {
+  color: var(--success);
+}
+
+.sync-status[data-status='error'] {
+  color: var(--error);
+}
+
+.leaderboard-empty {
   margin: 0;
   color: var(--muted);
 }
 
-.history-table {
-  width: 100%;
-  border-collapse: collapse;
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.25);
+.leaderboard-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
 }
 
-.history-table th,
-.history-table td {
-  text-align: left;
-  padding: 0.65rem 0.9rem;
-  font-size: 0.95rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.history-table thead {
+.leaderboard-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 0.9rem;
   background: rgba(236, 72, 153, 0.08);
+  border: 1px solid rgba(236, 72, 153, 0.18);
 }
 
-.history-table tbody tr:nth-child(even) {
-  background: rgba(15, 23, 42, 0.04);
+.leaderboard-row:nth-child(odd) {
+  background: rgba(236, 72, 153, 0.12);
+}
+
+.leaderboard-row .leaderboard-rank {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent-dark);
+}
+
+.leaderboard-row .leaderboard-alias {
+  font-weight: 600;
+}
+
+.leaderboard-row .leaderboard-wpm,
+.leaderboard-row .leaderboard-duration {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.leaderboard-row.is-self {
+  background: rgba(16, 185, 129, 0.15);
+  border-color: rgba(16, 185, 129, 0.5);
+}
+
+.leaderboard-row.is-self .leaderboard-alias {
+  color: var(--success);
+}
+
+.leaderboard-row.is-self .leaderboard-wpm,
+.leaderboard-row.is-self .leaderboard-duration {
+  color: var(--success);
 }
 
 @media (max-width: 640px) {
@@ -446,6 +528,15 @@ textarea:disabled {
   }
 
   .duration-toggle__option span {
+    width: 100%;
+  }
+
+  .leaderboard-card__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sync-status {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the results history table with an alias field, sync status, and inline leaderboard list
- restyle the results card to support the alias input, status text, and leaderboard rows
- integrate shared gist settings to load, render, and persist leaderboard runs for completed tests

## Testing
- npm run lint *(fails: existing eslint errors in unrelated modules such as src/apps/zen-go/js/tensorflow.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d3252550832b808e709dcb013508