### PR TITLE
Refine ZenDo garden view

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -880,3 +880,349 @@
     grid-template-rows: 1fr 1fr;
   }
 }
+
+/* Garden view */
+.zen-garden {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 20px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 40px rgba(67, 117, 99, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  height: 100%;
+}
+
+.zen-garden-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.zen-garden-title {
+  margin: 0;
+  font-size: 1.65rem;
+  color: #3b6658;
+  letter-spacing: 0.03em;
+}
+
+.zen-garden-subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: #4a5f55;
+}
+
+.zen-garden-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  flex: 1;
+}
+
+.zen-garden-section {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 18px;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(160, 204, 185, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.zen-garden-section--priority {
+  background: linear-gradient(160deg, rgba(214, 235, 225, 0.9) 0%, rgba(190, 224, 209, 0.9) 100%);
+}
+
+.zen-garden-section--bonus {
+  background: linear-gradient(160deg, rgba(236, 221, 233, 0.95) 0%, rgba(222, 210, 230, 0.9) 100%);
+}
+
+.zen-garden-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  color: #3b6658;
+}
+
+.zen-garden-section-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.zen-garden-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #3b6658;
+  box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.2);
+}
+
+.zen-garden-empty {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  color: #527165;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.zen-garden-empty--global {
+  align-self: center;
+  max-width: 560px;
+}
+
+.zen-garden-plant-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.zen-garden-plant-item {
+  margin: 0;
+}
+
+.zen-garden-plant {
+  --growth-progress: 0;
+  --accent-color: #5a8d7a;
+  --accent-muted: rgba(90, 141, 122, 0.28);
+  --accent-canopy: radial-gradient(circle at 40% 30%, #bde6cc 0%, #7cb896 80%);
+  position: relative;
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.18);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.zen-garden-plant:hover {
+  transform: translateY(-2px);
+  box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.26), 0 10px 18px rgba(70, 110, 90, 0.18);
+}
+
+.zen-garden-plant--bonus {
+  --accent-color: #b17596;
+  --accent-muted: rgba(177, 117, 150, 0.28);
+  --accent-canopy: radial-gradient(circle at 45% 35%, #f8d3e4 0%, #d99ab8 75%);
+  box-shadow: inset 0 0 0 1px rgba(177, 117, 150, 0.18);
+}
+
+.zen-garden-plant-graphic {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  display: grid;
+  place-items: end center;
+  filter: drop-shadow(0 8px 14px rgba(63, 91, 78, 0.2));
+}
+
+.zen-garden-plant::after {
+  content: '';
+  position: absolute;
+  inset: auto 1.1rem -0.25rem 1.1rem;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(61, 87, 74, 0.18);
+  filter: blur(6px);
+  pointer-events: none;
+}
+
+.zen-garden-plant-stem {
+  width: 6px;
+  height: calc(26px + 32px * var(--growth-progress));
+  background: linear-gradient(180deg, rgba(87, 125, 105, 0.9) 0%, rgba(60, 88, 74, 0.95) 100%);
+  border-radius: 999px;
+  transform-origin: bottom;
+  transition: height 0.35s ease;
+}
+
+.zen-garden-plant--bonus .zen-garden-plant-stem {
+  background: linear-gradient(180deg, rgba(164, 117, 140, 0.9) 0%, rgba(118, 78, 101, 0.95) 100%);
+}
+
+.zen-garden-plant-canopy {
+  width: calc(34px + 30px * var(--growth-progress));
+  height: calc(26px + 30px * var(--growth-progress));
+  border-radius: 48% 52% 40% 40%;
+  background: var(--accent-canopy);
+  transform: translateY(calc(-10px - 12px * var(--growth-progress)));
+  transition: width 0.35s ease, height 0.35s ease, transform 0.35s ease, filter 0.35s ease;
+}
+
+.zen-garden-plant--bonus .zen-garden-plant-canopy {
+  border-radius: 55% 55% 45% 45%;
+}
+
+.zen-garden-plant--mature .zen-garden-plant-canopy {
+  filter: saturate(1.1) drop-shadow(0 0 12px rgba(255, 255, 255, 0.4));
+}
+
+.zen-garden-plant-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #2f3b35;
+}
+
+.zen-garden-plant-title {
+  margin: 0;
+  font-size: 1rem;
+  color: #365448;
+}
+
+.zen-garden-plant-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #54685f;
+}
+
+.zen-garden-plant-badge {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.75);
+  color: #3f6e5b;
+  box-shadow: inset 0 0 0 1px rgba(63, 110, 91, 0.32);
+}
+
+.zen-garden-plant.is-persisted {
+  box-shadow: inset 0 0 0 2px rgba(63, 110, 91, 0.25);
+}
+
+.zen-garden-stage {
+  display: flex;
+  align-items: center;
+}
+
+.zen-garden-stage-track {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.zen-garden-stage-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 999px;
+  background: rgba(83, 116, 101, 0.18);
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.zen-garden-stage-dot.is-filled {
+  background: var(--accent-color);
+}
+
+.zen-garden-stage-dot.is-current {
+  transform: scale(1.1);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+.zen-garden-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.18);
+}
+
+.zen-garden-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: #4a5f55;
+}
+
+.zen-garden-legend-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: rgba(108, 161, 143, 0.4);
+  position: relative;
+}
+
+.zen-garden-legend-icon--seedling {
+  background: linear-gradient(135deg, #9ed9b6 0%, #6fb089 100%);
+}
+
+.zen-garden-legend-icon--bud {
+  background: linear-gradient(135deg, #f2c3d9 0%, #cf8ba8 100%);
+}
+
+.zen-garden-legend-icon--tree {
+  background: linear-gradient(135deg, #6fb089 0%, #3f7f66 100%);
+}
+
+.zen-garden-legend-icon--bloom {
+  background: linear-gradient(135deg, #e4a8c6 0%, #b9718c 100%);
+}
+
+.zen-garden-legend-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: inset 0 0 0 1px rgba(63, 110, 91, 0.32);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #3f6e5b;
+}
+
+@media (max-width: 768px) {
+  .zen-garden {
+    padding: 1.35rem;
+    border-radius: 16px;
+  }
+
+  .zen-garden-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .zen-garden-plant {
+    grid-template-columns: 72px 1fr;
+    gap: 0.75rem;
+  }
+
+  .zen-garden-legend {
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .zen-garden-header {
+    flex-direction: column;
+  }
+
+  .zen-garden-title {
+    font-size: 1.4rem;
+  }
+
+  .zen-garden-subtitle {
+    font-size: 0.9rem;
+  }
+}

--- a/src/apps/ZenDoApp/components/garden/GardenLegend.js
+++ b/src/apps/ZenDoApp/components/garden/GardenLegend.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const GardenLegend = () => (
+  <div className="zen-garden-legend" aria-label="Garden legend">
+    <div className="zen-garden-legend-item">
+      <span className="zen-garden-legend-icon zen-garden-legend-icon--seedling" aria-hidden="true" />
+      <span>Active priority seedlings</span>
+    </div>
+    <div className="zen-garden-legend-item">
+      <span className="zen-garden-legend-icon zen-garden-legend-icon--bud" aria-hidden="true" />
+      <span>Active bonus buds</span>
+    </div>
+    <div className="zen-garden-legend-item">
+      <span className="zen-garden-legend-icon zen-garden-legend-icon--tree" aria-hidden="true" />
+      <span>Completed priority trees</span>
+    </div>
+    <div className="zen-garden-legend-item">
+      <span className="zen-garden-legend-icon zen-garden-legend-icon--bloom" aria-hidden="true" />
+      <span>Completed bonus blooms</span>
+    </div>
+    <div className="zen-garden-legend-item">
+      <span className="zen-garden-legend-badge">Persisted</span>
+      <span>Carried over from today</span>
+    </div>
+  </div>
+);
+
+export default GardenLegend;

--- a/src/apps/ZenDoApp/components/garden/GardenPlant.js
+++ b/src/apps/ZenDoApp/components/garden/GardenPlant.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PlantStageIndicator from './PlantStageIndicator';
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const GardenPlant = ({
+  title,
+  description,
+  variant,
+  isComplete,
+  stageIndex,
+  totalStages,
+  persisted,
+}) => {
+  const safeTotal = Math.max(1, totalStages || 0);
+  const cappedStage = clamp(stageIndex || 0, 0, safeTotal);
+  const growthProgress = safeTotal === 0 ? 0 : cappedStage / safeTotal;
+
+  const label = isComplete
+    ? `${title} is fully grown`
+    : `${title} is at growth stage ${Math.min(cappedStage + 1, safeTotal)} of ${safeTotal}`;
+
+  const plantClassNames = [
+    'zen-garden-plant',
+    `zen-garden-plant--${variant}`,
+    isComplete ? 'zen-garden-plant--mature' : 'zen-garden-plant--growing',
+    persisted ? 'is-persisted' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <article className={plantClassNames} style={{ '--growth-progress': growthProgress }}>
+      <div className="zen-garden-plant-graphic" aria-hidden="true">
+        <span className="zen-garden-plant-stem" />
+        <span className="zen-garden-plant-canopy" />
+      </div>
+
+      <div className="zen-garden-plant-details">
+        <h3 className="zen-garden-plant-title">{title}</h3>
+        {description && <p className="zen-garden-plant-description">{description}</p>}
+        <PlantStageIndicator
+          stageIndex={cappedStage}
+          totalStages={safeTotal}
+          isComplete={isComplete}
+          label={label}
+        />
+        {persisted && <span className="zen-garden-plant-badge">Persisted bloom</span>}
+      </div>
+    </article>
+  );
+};
+
+export default GardenPlant;

--- a/src/apps/ZenDoApp/components/garden/PlantStageIndicator.js
+++ b/src/apps/ZenDoApp/components/garden/PlantStageIndicator.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const PlantStageIndicator = ({ stageIndex, totalStages, isComplete, label }) => {
+  const safeTotal = Math.max(1, totalStages || 0);
+  const completedCount = Math.max(0, Math.min(stageIndex || 0, safeTotal));
+  const currentIndex = isComplete ? safeTotal - 1 : Math.min(completedCount, safeTotal - 1);
+
+  return (
+    <div className="zen-garden-stage" role="img" aria-label={label}>
+      <div className="zen-garden-stage-track">
+        {Array.from({ length: safeTotal }).map((_, index) => {
+          const dotClassNames = [
+            'zen-garden-stage-dot',
+            index < completedCount || isComplete ? 'is-filled' : '',
+            index === currentIndex && !isComplete ? 'is-current' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
+          return <span key={index} className={dotClassNames} />;
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PlantStageIndicator;

--- a/src/apps/ZenDoApp/views/GardenView.js
+++ b/src/apps/ZenDoApp/views/GardenView.js
@@ -1,23 +1,33 @@
 import React from 'react';
+import GardenPlant from '../components/garden/GardenPlant';
+import GardenLegend from '../components/garden/GardenLegend';
 
-const GardenColumn = ({ title, entries }) => (
-  <section className="zen-garden-column">
-    <h2>{title}</h2>
+const GardenSection = ({ title, entries, variant }) => (
+  <section className={`zen-garden-section zen-garden-section--${variant}`}>
+    <header className="zen-garden-section-header">
+      <h2>{title}</h2>
+      {entries.length > 0 && (
+        <span className="zen-garden-section-count" aria-label={`${entries.length} plants`}>
+          {entries.length}
+        </span>
+      )}
+    </header>
+
     {entries.length === 0 ? (
-      <p className="zen-empty-hint">Nothing planted yet.</p>
+      <p className="zen-garden-empty">Nothing planted here yet. Add a task to start growing.</p>
     ) : (
-      <ul className="zen-garden-list">
+      <ul className="zen-garden-plant-list">
         {entries.map((entry) => (
-          <li key={entry.id} className={`zen-garden-item${entry.isSnapshot ? ' is-snapshot' : ''}`}>
-            <div className="zen-garden-card">
-              <div className="zen-garden-card-header">
-                <span className="zen-garden-card-title">{entry.title}</span>
-                {entry.isSnapshot && <span className="zen-garden-card-tag">Persisted</span>}
-              </div>
-              <div className="zen-garden-card-progress">
-                Stage {entry.stage.completedStages} / {entry.stage.totalStages}
-              </div>
-            </div>
+          <li key={entry.id} className="zen-garden-plant-item">
+            <GardenPlant
+              title={entry.title}
+              description={entry.description}
+              variant={variant}
+              isComplete={entry.isSnapshot || entry.stage?.isComplete}
+              stageIndex={entry.stage?.completedStages || 0}
+              totalStages={entry.stage?.totalStages || 1}
+              persisted={Boolean(entry.isSnapshot)}
+            />
           </li>
         ))}
       </ul>
@@ -25,11 +35,31 @@ const GardenColumn = ({ title, entries }) => (
   </section>
 );
 
-const GardenView = ({ priority, bonus }) => (
-  <div className="zen-garden-view">
-    <GardenColumn title="Priority Trees" entries={priority} />
-    <GardenColumn title="Bonus Bushes" entries={bonus} />
-  </div>
-);
+const GardenView = ({ priority = [], bonus = [] }) => {
+  const hasPlants = priority.length > 0 || bonus.length > 0;
+
+  return (
+    <div className="zen-garden">
+      <div className="zen-garden-header">
+        <div>
+          <h1 className="zen-garden-title">Zen Garden</h1>
+          <p className="zen-garden-subtitle">Grow today&apos;s focus work into tomorrow&apos;s blooms.</p>
+        </div>
+        <GardenLegend />
+      </div>
+
+      <div className="zen-garden-grid">
+        <GardenSection title="Priority Grove" entries={priority} variant="priority" />
+        <GardenSection title="Bonus Blooms" entries={bonus} variant="bonus" />
+      </div>
+
+      {!hasPlants && (
+        <p className="zen-garden-empty zen-garden-empty--global">
+          Assign tasks to the Priority or Bonus focus lists to watch seedlings sprout here.
+        </p>
+      )}
+    </div>
+  );
+};
 
 export default GardenView;


### PR DESCRIPTION
## Summary
- split the garden view into priority and bonus sections rendered through new garden components and legend
- add GardenPlant, PlantStageIndicator, and GardenLegend components to depict growth stages and persisted blooms
- style the Zen garden layout, animations, and responsive behaviour to match the rest of the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2d572311c832ba8e1aef344ccc9ed