### PR TITLE
Add garden view coverage and docs

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -13,7 +13,7 @@ CatPad is a feline-inspired notepad that autosaves to IndexedDB and offers optio
 - Provide rich-text flourishes like headings or checklists while keeping the editor lightweight.
 
 ## Zen Do
-Zen Do cultivates a minimalist to-do garden with pastel calm. Unfinished tasks live beside a seven-day planner where cards drag into day buckets while staying in the main list. Today view promotes the current day’s tasks into Priority and Bonus focus lanes, and Focus Mode reveals a Pomodoro timer with fully expanded subtasks. Every change syncs through an optional public GitHub gist so collections follow you across sessions.
+Zen Do cultivates a minimalist to-do garden with pastel calm. Unfinished tasks live beside a seven-day planner where cards drag into day buckets while staying in the main list. Today view promotes the current day’s tasks into Priority and Bonus focus lanes, and Focus Mode reveals a Pomodoro timer with fully expanded subtasks. The new Garden tab celebrates focus work as seedlings that grow with subtask completion while persisting completed blooms for the rest of the day so wins stay visible. Press “Z” outside of text inputs to toggle a distraction-free full-screen shell. Every change syncs through an optional public GitHub gist so collections follow you across sessions.
 - Allow per-task color tags or emojis to cluster projects within the zen garden.
 - Surface sync diagnostics so contributors can inspect gist history, last push status, and conflict resolution options.
 - Offer keyboard-first flows for adding tasks, toggling completion, and hopping between landing, today, and focus screens.

--- a/docs/ZenDoApp.md
+++ b/docs/ZenDoApp.md
@@ -13,9 +13,18 @@
 - `ZenDoApp` wires those callbacks to state helpers from `useZenDoState`, which in turn delegate to the scheduling utilities. `placeTaskInDay`, `reorderDay`, `placeInFocusBucket`, `reorderFocus`, and `clearFocus` wrap the drag payload in reducer-friendly mutations before persisting.
 - The utilities coerce schedules to a normalized shape so moving a task between days clears old focus assignments, and moving between focus buckets preserves order indexes per container. This logic lives in `assignTaskToDay`, `reorderDayAssignments`, `assignFocusBucket`, `reorderFocusBucket`, `removeFocusBucket`, and `removeDayAssignment` in `taskUtils.js`.
 
+## Garden view snapshots & accessibility
+- The Garden view mirrors the focus buckets into “Priority Trees” and “Bonus Bushes” columns. Each card includes a `Stage X / Y` text summary sourced from subtask progress so screen readers describe growth without relying on colour alone.
+- Completed focus work stores a same-day snapshot with a “Persisted” pill. Cards leave the active focus lanes once completed but remain in the garden through midnight, keeping celebratory context available to assistive tech users via plain text labels.
+
+## Keyboard shortcuts
+- Press `Z` outside of editable fields to toggle the Zen Do shell between standard and full-screen layouts. Inputs continue to receive native keypresses so typing in gist credential boxes does not unexpectedly change the viewport.
+
 ## Manual QA checklist
 1. **Weekly planning drag loop** – With a mouse or touchpad, drag a root task from *All Tasks* into a weekly bucket and back again. Confirm the source list still contains the item and the bucket cards reorder to match the drop position supplied by the hover index.
 2. **Today view promotions** – Drag a card from a weekly bucket into the Today column, then into Priority/Bonus. Verify the placeholder tracks the pointer, the target column reorders correctly, and leaving the Today list clears any prior focus bucket metadata.
 3. **Keyboard fallback** – Use Tab/Shift+Tab to reach the “+ New Task” button, press Enter to launch the editor, and save a task. Expand/collapse it with the toggle buttons and mark it complete via the checkbox to confirm core flows remain accessible without drag gestures.
 4. **Touch responsiveness** – On a touch device or emulator, flick a task between buckets and ensure the preview disappears after release without leaving orphaned DOM nodes or duplicate cards. The shared controllers reset hover state and drag snapshots on pointer cancel events.
-5. **State regression guardrails** – After moving tasks across days and focus buckets, reload the app to confirm schedules persist via the normalized task utilities. The Jest suite covers null schedule migrations for both day assignments and focus buckets; run `npm test -- src/apps/ZenDoApp/__tests__/taskUtils.test.js` to verify.
+5. **Garden persistence** – Schedule a task into today, complete one of its subtasks, and finish the parent task. Open the Garden tab to confirm the card displays the updated `Stage` fraction and a “Persisted” label that remains visible until the next day.
+6. **Full-screen shortcut** – While focus is on the shell, press “Z” to toggle full-screen mode, then press it again to exit. Start with a gist credential field focused to verify the shortcut is ignored for active text inputs.
+7. **State regression guardrails** – After moving tasks across days and focus buckets, reload the app to confirm schedules persist via the normalized task utilities. The Jest suite covers null schedule migrations for both day assignments and focus buckets; run `npm test -- src/apps/ZenDoApp/__tests__/taskUtils.test.js` to verify.

--- a/src/apps/ZenDoApp/__tests__/GardenView.test.js
+++ b/src/apps/ZenDoApp/__tests__/GardenView.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GardenView from '../views/GardenView';
+
+describe('GardenView', () => {
+  const createEntry = (overrides = {}) => ({
+    id: 'task-1',
+    title: 'Grow a sapling',
+    description: 'Daily watering routine',
+    bucket: 'priority',
+    isSnapshot: false,
+    snapshot: null,
+    completedAt: null,
+    order: 0,
+    stage: {
+      completedStages: 1,
+      totalStages: 3,
+      remainingStages: 2,
+      subtaskTotal: 2,
+      subtaskCompleted: 1,
+      progress: 0.33,
+      isComplete: false,
+    },
+    ...overrides,
+  });
+
+  it('renders stage progress so seedlings grow with each completed subtask', () => {
+    const entry = createEntry({
+      id: 'priority-seedling',
+      title: 'Morning priority',
+      stage: {
+        completedStages: 2,
+        totalStages: 4,
+        remainingStages: 2,
+        subtaskTotal: 3,
+        subtaskCompleted: 1,
+        progress: 0.5,
+        isComplete: false,
+      },
+    });
+
+    render(<GardenView priority={[entry]} bonus={[]} />);
+
+    expect(screen.getByRole('heading', { name: 'Priority Trees' })).toBeInTheDocument();
+    expect(screen.getByText('Morning priority')).toBeInTheDocument();
+    expect(screen.getByText('Stage 2 / 4')).toBeInTheDocument();
+  });
+
+  it('labels completed focus snapshots as persisted for the current day', () => {
+    const snapshotEntry = createEntry({
+      id: 'bonus-bloom',
+      title: 'Finished bonus bloom',
+      bucket: 'bonus',
+      isSnapshot: true,
+      completedAt: '2024-02-01T12:00:00.000Z',
+      stage: {
+        completedStages: 3,
+        totalStages: 3,
+        remainingStages: 0,
+        subtaskTotal: 2,
+        subtaskCompleted: 2,
+        progress: 1,
+        isComplete: true,
+      },
+    });
+
+    render(<GardenView priority={[]} bonus={[snapshotEntry]} />);
+
+    expect(screen.getByRole('heading', { name: 'Bonus Bushes' })).toBeInTheDocument();
+    expect(screen.getByText('Finished bonus bloom')).toBeInTheDocument();
+    expect(screen.getByText('Persisted')).toBeInTheDocument();
+    expect(screen.getByText('Stage 3 / 3')).toBeInTheDocument();
+  });
+
+  it('announces empty buckets with readable fallback copy', () => {
+    render(<GardenView priority={[]} bonus={[]} />);
+
+    const hints = screen.getAllByText('Nothing planted yet.');
+    expect(hints).toHaveLength(2);
+  });
+});

--- a/src/apps/ZenDoApp/__tests__/ZenDoApp.garden.test.js
+++ b/src/apps/ZenDoApp/__tests__/ZenDoApp.garden.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ZenDoApp from '../ZenDoApp';
+import { loadState, loadSettings } from '../storage';
+
+jest.mock('../storage', () => {
+  const loadState = jest.fn();
+  const saveState = jest.fn();
+  const loadSettings = jest.fn();
+  const saveSettings = jest.fn();
+  const fetchGistSnapshot = jest.fn();
+  const pushGistSnapshot = jest.fn();
+  const createSnapshot = jest.fn(() => ({ tasks: [], lastUpdatedAt: new Date().toISOString() }));
+
+  return {
+    __esModule: true,
+    loadState,
+    saveState,
+    loadSettings,
+    saveSettings,
+    fetchGistSnapshot,
+    pushGistSnapshot,
+    createSnapshot,
+    DEFAULT_GIST_FILENAME: 'zen-do-data.json',
+  };
+});
+
+jest.mock('../../../state/globalGistSettings', () => {
+  const readGlobalGistSettings = jest.fn(() => ({}));
+  const writeGlobalGistSettings = jest.fn();
+  const clearGlobalGistSettings = jest.fn();
+  const subscribeToGlobalGistSettings = jest.fn(() => () => {});
+
+  return {
+    __esModule: true,
+    readGlobalGistSettings,
+    writeGlobalGistSettings,
+    clearGlobalGistSettings,
+    subscribeToGlobalGistSettings,
+    GLOBAL_GIST_SETTINGS_CLIENT_ID: 'test-client',
+    default: {
+      readGlobalGistSettings,
+      writeGlobalGistSettings,
+      clearGlobalGistSettings,
+      subscribeToGlobalGistSettings,
+    },
+  };
+});
+
+describe('ZenDoApp garden navigation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    loadState.mockReturnValue({
+      tasks: [],
+      lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    loadSettings.mockReturnValue({
+      gistId: '',
+      gistToken: '',
+      filename: 'zen-do-data.json',
+      lastSyncedAt: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('exposes the Garden tab and toggles the view when clicked', () => {
+    render(<ZenDoApp />);
+
+    const gardenButton = screen.getByRole('button', { name: 'Garden' });
+    expect(gardenButton).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { name: 'All Tasks' })).toBeInTheDocument();
+
+    fireEvent.click(gardenButton);
+
+    expect(screen.getByRole('heading', { name: 'Priority Trees' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bonus Bushes' })).toBeInTheDocument();
+    expect(screen.getAllByText('Nothing planted yet.')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Landing' }));
+    expect(screen.getByRole('heading', { name: 'All Tasks' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add GardenView unit tests verifying stage progress, persisted snapshots, and accessible fallbacks
- extend ZenDoApp integration coverage for the Garden tab navigation
- document the Garden tab updates, persistence QA, and fullscreen shortcut guidance

## Testing
- npm test -- src/apps/ZenDoApp/__tests__/GardenView.test.js
- npm test -- src/apps/ZenDoApp/__tests__/ZenDoApp.garden.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2d57f740c832ba75b8f726bf816d9