### PR TITLE
Refactor AppLauncher into hooks and child components

### DIFF
--- a/src/components/AppLauncher/AppLauncherHeader.js
+++ b/src/components/AppLauncher/AppLauncherHeader.js
@@ -1,0 +1,78 @@
+import React from 'react';
+
+const AppLauncherHeader = ({
+  appCount,
+  onOpenSettings,
+  onRandomLaunch,
+  onSearchChange,
+  onViewModeChange,
+  searchQuery,
+  settingsButtonRef,
+  torontoTime,
+  viewMode,
+}) => (
+  <header className="launcher-header">
+    <div className="launcher-header-top">
+      <h1 className="launcher-title">
+        <span className="title-icon">📱</span>
+        64 Apps
+        <span className="app-count">({appCount} apps)</span>
+      </h1>
+
+      <div className="toronto-clock" aria-label="Current time">
+        <span className="clock-time">{torontoTime}</span>
+      </div>
+    </div>
+
+    <div className="launcher-controls">
+      <div className="search-container">
+        <input
+          type="text"
+          placeholder="Search apps..."
+          value={searchQuery}
+          onChange={onSearchChange}
+          className="search-input"
+        />
+        <span className="search-icon">🔍</span>
+      </div>
+
+      <div className="view-controls">
+        <button
+          type="button"
+          className="random-launch-btn"
+          onClick={onRandomLaunch}
+          aria-label="Launch a random app"
+        >
+          🎲
+        </button>
+        <div className="view-toggle-group">
+          <button
+            type="button"
+            className={`view-btn ${viewMode === 'grid' ? 'active' : ''}`}
+            onClick={() => onViewModeChange('grid')}
+          >
+            ⊞
+          </button>
+          <button
+            type="button"
+            className={`view-btn ${viewMode === 'list' ? 'active' : ''}`}
+            onClick={() => onViewModeChange('list')}
+          >
+            ☰
+          </button>
+        </div>
+        <button
+          type="button"
+          className="settings-btn"
+          onClick={onOpenSettings}
+          ref={settingsButtonRef}
+        >
+          <span aria-hidden="true">⚙️</span>
+          <span className="settings-btn-label">Settings</span>
+        </button>
+      </div>
+    </div>
+  </header>
+);
+
+export default AppLauncherHeader;

--- a/src/components/AppLauncher/CategoryNav.js
+++ b/src/components/AppLauncher/CategoryNav.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { APP_CATEGORIES } from '../../apps/registry';
+
+const CategoryNav = ({ categories, onSelectCategory, selectedCategory }) => (
+  <nav className="category-nav">
+    {categories.map((category) => (
+      <button
+        key={category}
+        className={`category-btn ${selectedCategory === category ? 'active' : ''}`}
+        onClick={() => onSelectCategory(category)}
+      >
+        {category !== 'All' && (
+          <span className="category-icon">
+            {APP_CATEGORIES[category]?.icon}
+          </span>
+        )}
+        {category}
+      </button>
+    ))}
+  </nav>
+);
+
+export default CategoryNav;

--- a/src/components/AppLauncher/FavoritesSection.js
+++ b/src/components/AppLauncher/FavoritesSection.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const FavoritesSection = ({
+  favoriteApps,
+  hasFavoriteIds,
+  hasHiddenFavoritesInCategory,
+  renderAppCard,
+  viewMode,
+}) => {
+  if (favoriteApps.length === 0) {
+    if (hasFavoriteIds && hasHiddenFavoritesInCategory) {
+      return <div className="favorites-empty-message">Mark apps as ★ to see them here</div>;
+    }
+
+    return null;
+  }
+
+  return (
+    <section className="favorites-section">
+      <h2 className="section-title">★ Favorite Apps</h2>
+      <div className={`apps-container ${viewMode}`}>
+        {favoriteApps.map(renderAppCard)}
+      </div>
+    </section>
+  );
+};
+
+export default FavoritesSection;

--- a/src/components/AppLauncher/GistSettingsModal.js
+++ b/src/components/AppLauncher/GistSettingsModal.js
@@ -1,0 +1,88 @@
+import React from 'react';
+
+const GistSettingsModal = ({
+  cancelButtonRef,
+  gistIdInputRef,
+  gistSettingsForm,
+  gistTokenInputRef,
+  isOpen,
+  onCancel,
+  onChange,
+  onSubmit,
+  saveButtonRef,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="settings-modal-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        className="settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gist-settings-title"
+      >
+        <form onSubmit={onSubmit}>
+          <h2 id="gist-settings-title" className="settings-modal-title">
+            GitHub Gist Sync
+          </h2>
+
+          <div className="settings-field">
+            <label htmlFor="gist-id-input">Gist ID</label>
+            <input
+              id="gist-id-input"
+              ref={gistIdInputRef}
+              type="text"
+              value={gistSettingsForm.gistId}
+              onChange={onChange('gistId')}
+              placeholder="e.g. a1b2c3d4e5"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-field">
+            <label htmlFor="gist-token-input">Personal Access Token</label>
+            <input
+              id="gist-token-input"
+              ref={gistTokenInputRef}
+              type="password"
+              value={gistSettingsForm.gistToken}
+              onChange={onChange('gistToken')}
+              placeholder="ghp_..."
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="settings-modal-actions">
+            <button
+              type="button"
+              className="settings-secondary-btn"
+              onClick={onCancel}
+              ref={cancelButtonRef}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="settings-primary-btn"
+              ref={saveButtonRef}
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default GistSettingsModal;

--- a/src/components/AppLauncher/hooks/useClock.js
+++ b/src/components/AppLauncher/hooks/useClock.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+const useClock = (options = {}) => {
+  const {
+    timeZone = 'America/Toronto',
+    locale = 'en-CA',
+  } = options;
+
+  const [time, setTime] = useState('--:--:--');
+
+  useEffect(() => {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      timeZone,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+
+    const updateTime = () => {
+      setTime(formatter.format(new Date()));
+    };
+
+    updateTime();
+    const intervalId = setInterval(updateTime, 1000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [locale, timeZone]);
+
+  return time;
+};
+
+export default useClock;

--- a/src/components/AppLauncher/hooks/useFavorites.js
+++ b/src/components/AppLauncher/hooks/useFavorites.js
@@ -1,0 +1,86 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const readFavoriteIds = () => {
+  try {
+    const stored = localStorage.getItem('favoriteAppIds');
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const useFavorites = (allApps, selectedCategory, searchQuery) => {
+  const [favoriteIds, setFavoriteIds] = useState(readFavoriteIds);
+
+  const toggleFavorite = useCallback((appId) => {
+    setFavoriteIds((previous) => {
+      const next = previous.includes(appId)
+        ? previous.filter((id) => id !== appId)
+        : [...previous, appId];
+
+      try {
+        localStorage.setItem('favoriteAppIds', JSON.stringify(next));
+      } catch (error) {
+        // Ignore write failures (e.g., private mode restrictions)
+      }
+
+      return next;
+    });
+  }, []);
+
+  const isFavorited = useCallback((appId) => favoriteIds.includes(appId), [favoriteIds]);
+
+  const favoriteApps = useMemo(() => allApps
+    .filter((app) => favoriteIds.includes(app.id) && !app.disabled)
+    .filter((app) => {
+      const searchLower = searchQuery.toLowerCase();
+      const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
+      const matchesSearch = app.title.toLowerCase().includes(searchLower) ||
+        app.description.toLowerCase().includes(searchLower) ||
+        app.tags.some((tag) => tag.toLowerCase().includes(searchLower));
+
+      return matchesCategory && matchesSearch;
+    })
+    .sort((a, b) => a.title.localeCompare(b.title)), [
+    allApps,
+    favoriteIds,
+    searchQuery,
+    selectedCategory,
+  ]);
+
+  const hasHiddenFavoritesInCategory = useMemo(() => {
+    if (selectedCategory === 'All' || favoriteIds.length === 0) {
+      return false;
+    }
+
+    const searchLower = searchQuery.toLowerCase();
+
+    return favoriteIds.some((favoriteId) => {
+      const app = allApps.find((candidate) => candidate.id === favoriteId);
+
+      if (!app || app.disabled) {
+        return false;
+      }
+
+      const matchesSearch = app.title.toLowerCase().includes(searchLower) ||
+        app.description.toLowerCase().includes(searchLower) ||
+        app.tags.some((tag) => tag.toLowerCase().includes(searchLower));
+
+      if (!matchesSearch) {
+        return false;
+      }
+
+      return app.category !== selectedCategory;
+    });
+  }, [allApps, favoriteIds, searchQuery, selectedCategory]);
+
+  return {
+    favoriteIds,
+    favoriteApps,
+    hasHiddenFavoritesInCategory,
+    isFavorited,
+    toggleFavorite,
+  };
+};
+
+export default useFavorites;

--- a/src/components/AppLauncher/hooks/useGistSettingsModal.js
+++ b/src/components/AppLauncher/hooks/useGistSettingsModal.js
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  readGlobalGistSettings,
+  subscribeToGlobalGistSettings,
+  writeGlobalGistSettings,
+} from '../../../state/globalGistSettings';
+import { verifyGistConnection } from '../../../global/verifyGistConnection';
+
+const useGistSettingsModal = () => {
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [gistSettingsForm, setGistSettingsForm] = useState({
+    gistId: '',
+    gistToken: '',
+  });
+  const [gistSettingsStatus, setGistSettingsStatus] = useState({
+    type: null,
+    message: '',
+  });
+
+  const settingsButtonRef = useRef(null);
+  const gistIdInputRef = useRef(null);
+  const gistTokenInputRef = useRef(null);
+  const cancelButtonRef = useRef(null);
+  const saveButtonRef = useRef(null);
+  const gistStatusTimerRef = useRef(null);
+
+  const clearGistStatus = useCallback(() => {
+    if (gistStatusTimerRef.current) {
+      clearTimeout(gistStatusTimerRef.current);
+      gistStatusTimerRef.current = null;
+    }
+
+    setGistSettingsStatus({ type: null, message: '' });
+  }, []);
+
+  const scheduleGistStatusDismissal = useCallback(() => {
+    if (gistStatusTimerRef.current) {
+      clearTimeout(gistStatusTimerRef.current);
+    }
+
+    gistStatusTimerRef.current = setTimeout(() => {
+      setGistSettingsStatus({ type: null, message: '' });
+      gistStatusTimerRef.current = null;
+    }, 6000);
+  }, []);
+
+  useEffect(() => () => {
+    if (gistStatusTimerRef.current) {
+      clearTimeout(gistStatusTimerRef.current);
+    }
+  }, []);
+
+  useEffect(() => {
+    const initialSettings = readGlobalGistSettings();
+    setGistSettingsForm(initialSettings);
+
+    const unsubscribe = subscribeToGlobalGistSettings((nextSettings) => {
+      setGistSettingsForm(nextSettings);
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isSettingsOpen) {
+      clearGistStatus();
+    }
+  }, [clearGistStatus, isSettingsOpen]);
+
+  const closeSettingsModal = useCallback(() => {
+    setIsSettingsOpen(false);
+
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => {
+        settingsButtonRef.current?.focus();
+      });
+    } else {
+      settingsButtonRef.current?.focus();
+    }
+  }, []);
+
+  const handleCloseWithoutSaving = useCallback(() => {
+    setGistSettingsForm(readGlobalGistSettings());
+    closeSettingsModal();
+  }, [closeSettingsModal]);
+
+  useEffect(() => {
+    if (!isSettingsOpen || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const focusableElements = () => [
+      gistIdInputRef.current,
+      gistTokenInputRef.current,
+      cancelButtonRef.current,
+      saveButtonRef.current,
+    ].filter(Boolean);
+
+    const firstElement = focusableElements()[0];
+    if (firstElement) {
+      setTimeout(() => {
+        firstElement.focus();
+      }, 0);
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCloseWithoutSaving();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const elements = focusableElements();
+      if (elements.length === 0) {
+        return;
+      }
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !elements.includes(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last || !elements.includes(active)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleCloseWithoutSaving, isSettingsOpen]);
+
+  const openSettingsModal = useCallback(() => {
+    setIsSettingsOpen(true);
+  }, []);
+
+  const handleGistInputChange = useCallback((field) => (event) => {
+    const { value } = event.target;
+    setGistSettingsForm((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  }, []);
+
+  const handleSaveSettings = useCallback(async (event) => {
+    event.preventDefault();
+    clearGistStatus();
+
+    try {
+      const savedSettings = writeGlobalGistSettings({
+        gistId: gistSettingsForm.gistId,
+        gistToken: gistSettingsForm.gistToken,
+      });
+
+      if (savedSettings.gistId) {
+        await verifyGistConnection({
+          gistId: savedSettings.gistId,
+          gistToken: savedSettings.gistToken,
+        });
+      }
+
+      setGistSettingsStatus({
+        type: 'success',
+        message: savedSettings.gistId
+          ? 'Gist connection verified successfully.'
+          : 'Gist settings saved.',
+      });
+      closeSettingsModal();
+      scheduleGistStatusDismissal();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      setGistSettingsStatus({
+        type: 'error',
+        message: `Failed to verify gist settings: ${errorMessage}`,
+      });
+      scheduleGistStatusDismissal();
+    }
+  }, [
+    clearGistStatus,
+    closeSettingsModal,
+    gistSettingsForm,
+    scheduleGistStatusDismissal,
+  ]);
+
+  return {
+    cancelButtonRef,
+    closeSettingsModal,
+    gistIdInputRef,
+    gistSettingsForm,
+    gistSettingsStatus,
+    gistTokenInputRef,
+    handleCloseWithoutSaving,
+    handleGistInputChange,
+    handleSaveSettings,
+    isSettingsOpen,
+    openSettingsModal,
+    saveButtonRef,
+    settingsButtonRef,
+  };
+};
+
+export default useGistSettingsModal;


### PR DESCRIPTION
## Summary
- extract `useClock`, `useFavorites`, and `useGistSettingsModal` hooks to manage the AppLauncher logic outside of the main component
- add presentational components for the launcher header, category nav, favorites section, and gist settings modal to simplify AppLauncher rendering
- update AppLauncher to compose the new hooks/components while preserving existing behaviour

## Testing
- npm test -- --watch=false *(fails: existing ZenDoApp garden tests expect outdated copy)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ee8558ec832ba7a4797c97da61aa