### PR TITLE
feat: add favorites storage adapter

### DIFF
--- a/src/state/__tests__/favoritesStorage.test.js
+++ b/src/state/__tests__/favoritesStorage.test.js
@@ -1,0 +1,66 @@
+import { readFavorites, writeFavorites } from '../favoritesStorage';
+
+describe('favoritesStorage', () => {
+  it('returns an empty array when storage is unavailable', () => {
+    expect(readFavorites(undefined)).toEqual([]);
+  });
+
+  it('returns parsed favorites from storage', () => {
+    const mockStorage = {
+      localStorage: {
+        getItem: jest.fn(() => JSON.stringify(['alpha', 'beta'])),
+      },
+    };
+
+    expect(readFavorites(mockStorage)).toEqual(['alpha', 'beta']);
+    expect(mockStorage.localStorage.getItem).toHaveBeenCalledWith('favoriteAppIds');
+  });
+
+  it('returns an empty array when stored value is invalid JSON', () => {
+    const mockStorage = {
+      localStorage: {
+        getItem: jest.fn(() => '{not valid json'),
+      },
+    };
+
+    expect(readFavorites(mockStorage)).toEqual([]);
+  });
+
+  it('returns an empty array when stored value is not an array', () => {
+    const mockStorage = {
+      localStorage: {
+        getItem: jest.fn(() => JSON.stringify({ nope: true })),
+      },
+    };
+
+    expect(readFavorites(mockStorage)).toEqual([]);
+  });
+
+  it('writes favorites as JSON when storage is available', () => {
+    const setItem = jest.fn();
+    const mockStorage = {
+      localStorage: {
+        setItem,
+      },
+    };
+
+    expect(writeFavorites(['foo', 'bar'], mockStorage)).toBe(true);
+    expect(setItem).toHaveBeenCalledWith('favoriteAppIds', JSON.stringify(['foo', 'bar']));
+  });
+
+  it('returns false when storage write fails', () => {
+    const mockStorage = {
+      localStorage: {
+        setItem: jest.fn(() => {
+          throw new Error('nope');
+        }),
+      },
+    };
+
+    expect(writeFavorites(['foo'], mockStorage)).toBe(false);
+  });
+
+  it('returns false when storage is unavailable', () => {
+    expect(writeFavorites(['foo'], { })).toBe(false);
+  });
+});

--- a/src/state/favoritesStorage.js
+++ b/src/state/favoritesStorage.js
@@ -1,0 +1,59 @@
+import { createContext, useContext } from 'react';
+
+const STORAGE_KEY = 'favoriteAppIds';
+
+const getLocalStorage = (storageHost) => {
+  if (!storageHost || !storageHost.localStorage) {
+    return null;
+  }
+
+  return storageHost.localStorage;
+};
+
+export const readFavorites = (storageHost = typeof window !== 'undefined' ? window : undefined) => {
+  const storage = getLocalStorage(storageHost);
+
+  if (!storage) {
+    return [];
+  }
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+export const writeFavorites = (favorites, storageHost = typeof window !== 'undefined' ? window : undefined) => {
+  const storage = getLocalStorage(storageHost);
+
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const defaultFavoritesStorage = {
+  readFavorites: () => readFavorites(),
+  writeFavorites: (favorites) => writeFavorites(favorites),
+};
+
+export const FavoritesStorageContext = createContext(defaultFavoritesStorage);
+
+export const useFavoritesStorage = () => useContext(FavoritesStorageContext);
+
+export default defaultFavoritesStorage;


### PR DESCRIPTION
## Summary
- add a favorites storage adapter that hides direct localStorage access and expose read/write helpers with a context hook
- refactor the App Launcher favorites hook to use the injected adapter
- cover the adapter with serialization and fallback unit tests

## Testing
- npm test -- --runTestsByPath src/state/__tests__/favoritesStorage.test.js
- npm test -- --runTestsByPath src/components/__tests__/AppLauncher.test.js
- npm test *(fails: existing ZenDoApp GardenView tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f1cdc45c832bb073a0837f4e2ce2