### PR TITLE
Refactor gist verification fetch handling

### DIFF
--- a/src/global/verifyGistConnection.js
+++ b/src/global/verifyGistConnection.js
@@ -10,16 +10,19 @@ const buildHeaders = (token) => {
   return headers;
 };
 
-export const verifyGistConnection = async ({ gistId, gistToken }) => {
+export const verifyGistConnection = async (
+  { gistId, gistToken },
+  fetchFn = globalThis.fetch,
+) => {
   if (!gistId) {
     throw new Error('A gist ID is required to verify the connection.');
   }
 
-  if (typeof fetch !== 'function') {
+  if (typeof fetchFn !== 'function') {
     throw new Error('Fetch API is not available in this environment.');
   }
 
-  const response = await fetch(`https://api.github.com/gists/${gistId}`, {
+  const response = await fetchFn(`https://api.github.com/gists/${gistId}`, {
     method: 'GET',
     headers: buildHeaders(gistToken),
   });

--- a/src/global/verifyGistConnection.test.js
+++ b/src/global/verifyGistConnection.test.js
@@ -1,0 +1,54 @@
+import { verifyGistConnection } from './verifyGistConnection';
+
+describe('verifyGistConnection', () => {
+  const gistId = '123abc';
+
+  it('returns gist data when the request succeeds', async () => {
+    const gistToken = 'token-123';
+    const gistData = { id: gistId };
+    const json = jest.fn().mockResolvedValue(gistData);
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json,
+    });
+
+    const result = await verifyGistConnection({ gistId, gistToken }, fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(`https://api.github.com/gists/${gistId}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${gistToken}`,
+      },
+    });
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(gistData);
+  });
+
+  it('throws an error when the request fails', async () => {
+    const text = jest.fn().mockResolvedValue('Not Found');
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text,
+    });
+
+    await expect(
+      verifyGistConnection({ gistId, gistToken: undefined }, fetchMock),
+    ).rejects.toThrow('Unable to verify gist (404): Not Found');
+
+    expect(fetchMock).toHaveBeenCalledWith(`https://api.github.com/gists/${gistId}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    expect(text).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when no fetch implementation is available', async () => {
+    await expect(
+      verifyGistConnection({ gistId, gistToken: undefined }, null),
+    ).rejects.toThrow('Fetch API is not available in this environment.');
+  });
+});


### PR DESCRIPTION
## Summary
- allow `verifyGistConnection` to accept an optional injected `fetch` implementation that defaults to `globalThis.fetch`
- reuse the shared header builder and add unit coverage for success, failure, and missing-fetch cases

## Testing
- npm test -- --runTestsByPath src/global/verifyGistConnection.test.js
- npm test -- --runInBand *(fails: existing ZenDo Garden tests expect "Nothing planted yet." copy)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f4191614832ba646222b4633e725