### PR TITLE
Refactor Zen garden layout into layered scene

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -914,84 +914,214 @@
   color: #4a5f55;
 }
 
-.zen-garden-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+.zen-garden-scene {
+  position: relative;
   flex: 1;
+  min-height: 420px;
+  border-radius: 22px;
+  overflow: hidden;
+  background: linear-gradient(
+    180deg,
+    rgba(214, 235, 225, 0.7) 0%,
+    rgba(243, 249, 245, 0.92) 48%,
+    rgba(255, 247, 232, 0.96) 100%
+  );
+  box-shadow: inset 0 0 0 1px rgba(160, 204, 185, 0.28);
 }
 
-.zen-garden-section {
-  background: rgba(255, 255, 255, 0.7);
-  border-radius: 18px;
-  padding: 1.25rem;
-  box-shadow: inset 0 0 0 1px rgba(160, 204, 185, 0.32);
+.zen-garden-scene__layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.zen-garden-scene__layer--sky {
+  background: linear-gradient(180deg, #e7f6ff 0%, rgba(231, 246, 255, 0.4) 60%, rgba(255, 255, 255, 0) 100%);
+}
+
+.zen-garden-scene__layer--hills {
+  bottom: 22%;
+  top: auto;
+  left: -18%;
+  right: -18%;
+  height: 48%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 3rem;
+}
+
+.zen-garden-hill {
+  flex: 1;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 60%, rgba(125, 188, 151, 0.75) 0%, rgba(88, 142, 115, 0.9) 70%);
+  filter: blur(0.5px);
+  opacity: 0.85;
+}
+
+.zen-garden-hill--left {
+  transform: scaleX(1.1) scaleY(1.05) translateX(-6%);
+}
+
+.zen-garden-hill--right {
+  transform: scaleX(1.2) scaleY(0.95) translateX(8%);
+  background: radial-gradient(circle at 50% 60%, rgba(190, 156, 193, 0.7) 0%, rgba(142, 109, 162, 0.88) 70%);
+}
+
+.zen-garden-scene__layer--path {
+  top: auto;
+  bottom: 0;
+  height: 32%;
+  background: linear-gradient(
+    180deg,
+    rgba(232, 214, 189, 0.32) 0%,
+    rgba(219, 198, 171, 0.65) 45%,
+    rgba(198, 173, 142, 0.8) 100%
+  );
+  box-shadow: inset 0 10px 24px rgba(148, 119, 88, 0.16);
+}
+
+.zen-garden-scene__content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  padding: 2.5rem 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.zen-garden-cluster {
+  position: absolute;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  max-width: min(320px, 90vw);
 }
 
-.zen-garden-section--priority {
-  background: linear-gradient(160deg, rgba(214, 235, 225, 0.9) 0%, rgba(190, 224, 209, 0.9) 100%);
+.zen-garden-cluster--priority {
+  left: 6%;
+  bottom: 7.5rem;
 }
 
-.zen-garden-section--bonus {
-  background: linear-gradient(160deg, rgba(236, 221, 233, 0.95) 0%, rgba(222, 210, 230, 0.9) 100%);
+.zen-garden-cluster--bonus {
+  right: 8%;
+  bottom: 3.75rem;
 }
 
-.zen-garden-section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  color: #3b6658;
-}
-
-.zen-garden-section-header h2 {
+.zen-garden-cluster-header {
   margin: 0;
-  font-size: 1.15rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #3b6658;
+  box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.28);
 }
 
-.zen-garden-section-count {
+.zen-garden-cluster-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.zen-garden-cluster-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 2rem;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.9);
   font-size: 0.85rem;
   font-weight: 600;
   color: #3b6658;
   box-shadow: inset 0 0 0 1px rgba(108, 161, 143, 0.2);
 }
 
-.zen-garden-empty {
-  margin: 0;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.6);
-  color: #527165;
-  font-size: 0.95rem;
-  text-align: center;
-}
-
-.zen-garden-empty--global {
-  align-self: center;
-  max-width: 560px;
-}
-
-.zen-garden-plant-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.zen-garden-cluster-plants {
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
 }
 
-.zen-garden-plant-item {
+.zen-garden-scene-empty {
+  max-width: 420px;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 18px 26px rgba(72, 116, 96, 0.18);
+  color: #527165;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.zen-garden-scene-empty p {
   margin: 0;
+}
+
+@media (max-width: 1024px) {
+  .zen-garden-scene {
+    min-height: 520px;
+  }
+
+  .zen-garden-cluster--priority {
+    left: 4%;
+    bottom: 8.5rem;
+  }
+
+  .zen-garden-cluster--bonus {
+    right: 4%;
+    bottom: 4.5rem;
+  }
+}
+
+@media (max-width: 860px) {
+  .zen-garden-scene {
+    min-height: 560px;
+  }
+
+  .zen-garden-scene__content {
+    padding: 2rem 1.75rem 3rem;
+    align-items: flex-end;
+  }
+
+  .zen-garden-cluster {
+    position: static;
+    width: 100%;
+  }
+
+  .zen-garden-cluster-plants {
+    width: 100%;
+  }
+
+  .zen-garden-scene__content {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .zen-garden-scene {
+    min-height: auto;
+  }
+
+  .zen-garden-scene__layer--hills {
+    display: none;
+  }
+
+  .zen-garden-scene__layer--path {
+    height: 38%;
+  }
+
+  .zen-garden-cluster-header {
+    align-self: flex-start;
+  }
 }
 
 .zen-garden-plant {

--- a/src/apps/ZenDoApp/__tests__/GardenView.test.js
+++ b/src/apps/ZenDoApp/__tests__/GardenView.test.js
@@ -41,9 +41,11 @@ describe('GardenView', () => {
 
     render(<GardenView priority={[entry]} bonus={[]} />);
 
-    expect(screen.getByRole('heading', { name: 'Priority Trees' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Priority Grove' })).toBeInTheDocument();
     expect(screen.getByText('Morning priority')).toBeInTheDocument();
-    expect(screen.getByText('Stage 2 / 4')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Morning priority is at growth stage 3 of 4'),
+    ).toBeInTheDocument();
   });
 
   it('labels completed focus snapshots as persisted for the current day', () => {
@@ -66,16 +68,18 @@ describe('GardenView', () => {
 
     render(<GardenView priority={[]} bonus={[snapshotEntry]} />);
 
-    expect(screen.getByRole('heading', { name: 'Bonus Bushes' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bonus Blooms' })).toBeInTheDocument();
     expect(screen.getByText('Finished bonus bloom')).toBeInTheDocument();
-    expect(screen.getByText('Persisted')).toBeInTheDocument();
-    expect(screen.getByText('Stage 3 / 3')).toBeInTheDocument();
+    expect(screen.getByText('Persisted bloom')).toBeInTheDocument();
+    expect(screen.getByLabelText('Finished bonus bloom is fully grown')).toBeInTheDocument();
   });
 
   it('announces empty buckets with readable fallback copy', () => {
     render(<GardenView priority={[]} bonus={[]} />);
 
-    const hints = screen.getAllByText('Nothing planted yet.');
-    expect(hints).toHaveLength(2);
+    const callout = screen.getByRole('status');
+    expect(callout).toHaveTextContent(
+      'Assign tasks to the Priority or Bonus focus lists to watch seedlings sprout here.',
+    );
   });
 });

--- a/src/apps/ZenDoApp/__tests__/ZenDoApp.garden.test.js
+++ b/src/apps/ZenDoApp/__tests__/ZenDoApp.garden.test.js
@@ -77,9 +77,11 @@ describe('ZenDoApp garden navigation', () => {
 
     fireEvent.click(gardenButton);
 
-    expect(screen.getByRole('heading', { name: 'Priority Trees' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Bonus Bushes' })).toBeInTheDocument();
-    expect(screen.getAllByText('Nothing planted yet.')).toHaveLength(2);
+    expect(
+      screen.getByText('Assign tasks to the Priority or Bonus focus lists to watch seedlings sprout here.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Priority Grove' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Bonus Blooms' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Landing' }));
     expect(screen.getByRole('heading', { name: 'All Tasks' })).toBeInTheDocument();

--- a/src/apps/ZenDoApp/components/garden/GardenScene.js
+++ b/src/apps/ZenDoApp/components/garden/GardenScene.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import GardenPlant from './GardenPlant';
+
+const GardenScene = ({ priority = [], bonus = [] }) => {
+  const hasPriority = priority.length > 0;
+  const hasBonus = bonus.length > 0;
+  const hasAny = hasPriority || hasBonus;
+
+  const renderPlant = (entry, variant) => (
+    <GardenPlant
+      key={entry.id}
+      title={entry.title}
+      description={entry.description}
+      variant={variant}
+      isComplete={entry.isSnapshot || entry.stage?.isComplete}
+      stageIndex={entry.stage?.completedStages || 0}
+      totalStages={entry.stage?.totalStages || 1}
+      persisted={Boolean(entry.isSnapshot)}
+    />
+  );
+
+  return (
+    <div className="zen-garden-scene">
+      <div className="zen-garden-scene__layer zen-garden-scene__layer--sky" aria-hidden="true" />
+      <div className="zen-garden-scene__layer zen-garden-scene__layer--hills" aria-hidden="true">
+        <span className="zen-garden-hill zen-garden-hill--left" />
+        <span className="zen-garden-hill zen-garden-hill--right" />
+      </div>
+      <div className="zen-garden-scene__layer zen-garden-scene__layer--path" aria-hidden="true" />
+
+      <div className="zen-garden-scene__content">
+        {hasPriority && (
+          <section className="zen-garden-cluster zen-garden-cluster--priority" aria-label="Priority grove">
+            <header className="zen-garden-cluster-header">
+              <h2>Priority Grove</h2>
+              <span className="zen-garden-cluster-count" aria-label={`${priority.length} priority tasks`}>
+                {priority.length}
+              </span>
+            </header>
+
+            <div className="zen-garden-cluster-plants">{priority.map((entry) => renderPlant(entry, 'priority'))}</div>
+          </section>
+        )}
+
+        {hasBonus && (
+          <section className="zen-garden-cluster zen-garden-cluster--bonus" aria-label="Bonus blooms">
+            <header className="zen-garden-cluster-header">
+              <h2>Bonus Blooms</h2>
+              <span className="zen-garden-cluster-count" aria-label={`${bonus.length} bonus tasks`}>
+                {bonus.length}
+              </span>
+            </header>
+
+            <div className="zen-garden-cluster-plants">{bonus.map((entry) => renderPlant(entry, 'bonus'))}</div>
+          </section>
+        )}
+
+        {!hasAny && (
+          <div className="zen-garden-scene-empty" role="status">
+            <p>Assign tasks to the Priority or Bonus focus lists to watch seedlings sprout here.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GardenScene;

--- a/src/apps/ZenDoApp/views/GardenView.js
+++ b/src/apps/ZenDoApp/views/GardenView.js
@@ -1,43 +1,8 @@
 import React from 'react';
-import GardenPlant from '../components/garden/GardenPlant';
 import GardenLegend from '../components/garden/GardenLegend';
-
-const GardenSection = ({ title, entries, variant }) => (
-  <section className={`zen-garden-section zen-garden-section--${variant}`}>
-    <header className="zen-garden-section-header">
-      <h2>{title}</h2>
-      {entries.length > 0 && (
-        <span className="zen-garden-section-count" aria-label={`${entries.length} plants`}>
-          {entries.length}
-        </span>
-      )}
-    </header>
-
-    {entries.length === 0 ? (
-      <p className="zen-garden-empty">Nothing planted here yet. Add a task to start growing.</p>
-    ) : (
-      <ul className="zen-garden-plant-list">
-        {entries.map((entry) => (
-          <li key={entry.id} className="zen-garden-plant-item">
-            <GardenPlant
-              title={entry.title}
-              description={entry.description}
-              variant={variant}
-              isComplete={entry.isSnapshot || entry.stage?.isComplete}
-              stageIndex={entry.stage?.completedStages || 0}
-              totalStages={entry.stage?.totalStages || 1}
-              persisted={Boolean(entry.isSnapshot)}
-            />
-          </li>
-        ))}
-      </ul>
-    )}
-  </section>
-);
+import GardenScene from '../components/garden/GardenScene';
 
 const GardenView = ({ priority = [], bonus = [] }) => {
-  const hasPlants = priority.length > 0 || bonus.length > 0;
-
   return (
     <div className="zen-garden">
       <div className="zen-garden-header">
@@ -48,16 +13,7 @@ const GardenView = ({ priority = [], bonus = [] }) => {
         <GardenLegend />
       </div>
 
-      <div className="zen-garden-grid">
-        <GardenSection title="Priority Grove" entries={priority} variant="priority" />
-        <GardenSection title="Bonus Blooms" entries={bonus} variant="bonus" />
-      </div>
-
-      {!hasPlants && (
-        <p className="zen-garden-empty zen-garden-empty--global">
-          Assign tasks to the Priority or Bonus focus lists to watch seedlings sprout here.
-        </p>
-      )}
+      <GardenScene priority={priority} bonus={bonus} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the Zen Garden list layout with a new GardenScene wrapper
- add layered scene styling and updated empty-state callout for the garden view
- refresh garden-related tests to reflect the new scene-driven presentation

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d30093ece0832b9c7d7b3707645e1c