### PR TITLE
feat(zendo): add garden tree for priority grove

### DIFF
--- a/src/apps/ZenDoApp/ZenDoApp.css
+++ b/src/apps/ZenDoApp/ZenDoApp.css
@@ -7,6 +7,18 @@
   font-family: 'Segoe UI', 'Helvetica Neue', sans-serif;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .zen-app-header {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -1050,6 +1062,13 @@
   gap: 0.85rem;
 }
 
+.zen-garden-cluster--priority .zen-garden-cluster-plants {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.2rem;
+  justify-items: center;
+}
+
 .zen-garden-scene-empty {
   max-width: 420px;
   padding: 1.25rem 1.5rem;
@@ -1106,6 +1125,12 @@
   }
 }
 
+@media (max-width: 720px) {
+  .zen-garden-cluster--priority .zen-garden-cluster-plants {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 640px) {
   .zen-garden-scene {
     min-height: auto;
@@ -1121,6 +1146,189 @@
 
   .zen-garden-cluster-header {
     align-self: flex-start;
+  }
+}
+
+.zen-garden-tree {
+  --tree-accent: #5a8d7a;
+  --tree-accent-bright: #7fc4a1;
+  --tree-canopy: radial-gradient(circle at 40% 35%, #d7f3e3 0%, #7fc4a1 75%);
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 1.6rem 1.4rem 2.1rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(94, 138, 119, 0.24), 0 18px 28px rgba(63, 91, 78, 0.18);
+  text-align: center;
+  color: #2f3b35;
+  overflow: hidden;
+}
+
+.zen-garden-tree--mature {
+  --tree-accent-bright: #9fe7c1;
+  --tree-canopy: radial-gradient(circle at 45% 35%, #e5f9ef 0%, #8bd3af 75%);
+  box-shadow: inset 0 0 0 1px rgba(82, 130, 111, 0.32), 0 22px 34px rgba(63, 91, 78, 0.22);
+}
+
+.zen-garden-tree.is-persisted {
+  box-shadow: inset 0 0 0 2px rgba(63, 110, 91, 0.32), 0 22px 34px rgba(63, 91, 78, 0.22);
+}
+
+.zen-garden-tree-figure {
+  position: relative;
+  width: min(220px, 68vw);
+  aspect-ratio: 1 / 1.05;
+  display: grid;
+  place-items: center;
+}
+
+.zen-garden-tree-shadow {
+  position: absolute;
+  bottom: 6%;
+  left: 50%;
+  width: 62%;
+  height: 14%;
+  background: radial-gradient(circle at center, rgba(48, 73, 61, 0.32) 0%, rgba(48, 73, 61, 0) 70%);
+  transform: translateX(-50%);
+  filter: blur(7px);
+}
+
+.zen-garden-tree-trunk {
+  position: absolute;
+  bottom: 18%;
+  left: 50%;
+  width: 18px;
+  height: 40%;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(96, 74, 52, 0.92) 0%, rgba(70, 49, 32, 0.96) 100%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+}
+
+.zen-garden-tree-branch {
+  position: absolute;
+  bottom: 34%;
+  width: 38%;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(74, 106, 90, 0.85) 0%, rgba(64, 96, 81, 0) 100%);
+  filter: blur(0.4px);
+}
+
+.zen-garden-tree-branch--left {
+  left: 18%;
+  transform: rotate(-12deg);
+}
+
+.zen-garden-tree-branch--right {
+  right: 18%;
+  transform: rotate(12deg) scaleX(-1);
+}
+
+.zen-garden-tree-canopy {
+  position: relative;
+  width: 78%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--tree-canopy);
+  display: grid;
+  place-items: center;
+  box-shadow: 0 20px 36px rgba(63, 91, 78, 0.2);
+}
+
+.zen-garden-tree-progress {
+  position: absolute;
+  inset: -14%;
+}
+
+.zen-garden-tree-progress svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.zen-garden-tree-progress-track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.4);
+  stroke-width: 8;
+}
+
+.zen-garden-tree-progress-fill {
+  fill: none;
+  stroke: var(--tree-accent-bright);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.45s ease;
+}
+
+.zen-garden-tree-badge {
+  position: relative;
+  width: 84%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  padding: 1.5rem 1.35rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(148, 199, 175, 0.38), 0 8px 16px rgba(80, 118, 99, 0.18);
+}
+
+.zen-garden-tree-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+  color: #2f3b35;
+}
+
+.zen-garden-tree-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #3f6957;
+}
+
+.zen-garden-tree-persisted {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.9);
+  color: #3f6e5b;
+  box-shadow: inset 0 0 0 1px rgba(63, 110, 91, 0.3);
+}
+
+.zen-garden-tree.is-persisted .zen-garden-tree-persisted {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.zen-garden-tree--growing .zen-garden-tree-subtitle {
+  color: #3e6654;
+}
+
+.zen-garden-tree--mature .zen-garden-tree-subtitle {
+  color: #2f513f;
+  font-weight: 600;
+}
+
+@media (max-width: 520px) {
+  .zen-garden-tree {
+    padding: 1.35rem 1.1rem 1.8rem;
+  }
+
+  .zen-garden-tree-title {
+    font-size: 0.95rem;
+  }
+
+  .zen-garden-tree-subtitle {
+    font-size: 0.8rem;
   }
 }
 

--- a/src/apps/ZenDoApp/components/garden/GardenScene.js
+++ b/src/apps/ZenDoApp/components/garden/GardenScene.js
@@ -1,17 +1,29 @@
 import React from 'react';
 import GardenPlant from './GardenPlant';
+import GardenTree from './GardenTree';
 
 const GardenScene = ({ priority = [], bonus = [] }) => {
   const hasPriority = priority.length > 0;
   const hasBonus = bonus.length > 0;
   const hasAny = hasPriority || hasBonus;
 
-  const renderPlant = (entry, variant) => (
+  const renderPriorityTree = (entry) => (
+    <GardenTree
+      key={entry.id}
+      title={entry.title}
+      isComplete={entry.isSnapshot || entry.stage?.isComplete}
+      stageIndex={entry.stage?.completedStages || 0}
+      totalStages={entry.stage?.totalStages || 1}
+      persisted={Boolean(entry.isSnapshot)}
+    />
+  );
+
+  const renderBonusPlant = (entry) => (
     <GardenPlant
       key={entry.id}
       title={entry.title}
       description={entry.description}
-      variant={variant}
+      variant="bonus"
       isComplete={entry.isSnapshot || entry.stage?.isComplete}
       stageIndex={entry.stage?.completedStages || 0}
       totalStages={entry.stage?.totalStages || 1}
@@ -38,7 +50,7 @@ const GardenScene = ({ priority = [], bonus = [] }) => {
               </span>
             </header>
 
-            <div className="zen-garden-cluster-plants">{priority.map((entry) => renderPlant(entry, 'priority'))}</div>
+            <div className="zen-garden-cluster-plants">{priority.map((entry) => renderPriorityTree(entry))}</div>
           </section>
         )}
 
@@ -51,7 +63,7 @@ const GardenScene = ({ priority = [], bonus = [] }) => {
               </span>
             </header>
 
-            <div className="zen-garden-cluster-plants">{bonus.map((entry) => renderPlant(entry, 'bonus'))}</div>
+            <div className="zen-garden-cluster-plants">{bonus.map((entry) => renderBonusPlant(entry))}</div>
           </section>
         )}
 

--- a/src/apps/ZenDoApp/components/garden/GardenTree.js
+++ b/src/apps/ZenDoApp/components/garden/GardenTree.js
@@ -1,0 +1,70 @@
+import React, { useId } from 'react';
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const GardenTree = ({ title, isComplete, stageIndex, totalStages, persisted }) => {
+  const safeTotal = Math.max(1, totalStages || 0);
+  const cappedStage = clamp(stageIndex || 0, 0, safeTotal);
+  const growthProgress = clamp(cappedStage / safeTotal, 0, 1);
+  const displayStage = isComplete ? safeTotal : Math.min(cappedStage + 1, safeTotal);
+
+  const progressLabel = isComplete
+    ? `${title} is fully grown`
+    : `${title} is at growth stage ${displayStage} of ${safeTotal}`;
+
+  const titleId = useId();
+  const statusId = useId();
+  const progressId = useId();
+
+  const radius = 52;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - growthProgress);
+
+  const treeClassNames = [
+    'zen-garden-tree',
+    isComplete ? 'zen-garden-tree--mature' : 'zen-garden-tree--growing',
+    persisted ? 'is-persisted' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <article className={treeClassNames} aria-labelledby={`${titleId} ${statusId}`} aria-describedby={progressId}>
+      <div className="zen-garden-tree-figure" aria-hidden="true">
+        <span className="zen-garden-tree-shadow" />
+        <span className="zen-garden-tree-trunk" />
+        <span className="zen-garden-tree-branch zen-garden-tree-branch--left" />
+        <span className="zen-garden-tree-branch zen-garden-tree-branch--right" />
+        <div className="zen-garden-tree-canopy">
+          <div className="zen-garden-tree-progress" role="presentation">
+            <svg viewBox="0 0 120 120" focusable="false" aria-hidden="true">
+              <circle className="zen-garden-tree-progress-track" cx="60" cy="60" r={radius} />
+              <circle
+                className="zen-garden-tree-progress-fill"
+                cx="60"
+                cy="60"
+                r={radius}
+                strokeDasharray={circumference}
+                strokeDashoffset={dashOffset}
+              />
+            </svg>
+          </div>
+          <div className="zen-garden-tree-badge">
+            <h3 id={titleId} className="zen-garden-tree-title">
+              {title}
+            </h3>
+            <p id={statusId} className="zen-garden-tree-subtitle">
+              {isComplete ? 'Fully grown canopy' : `Stage ${displayStage} of ${safeTotal}`}
+            </p>
+            {persisted && <span className="zen-garden-tree-persisted">Persisted</span>}
+          </div>
+        </div>
+      </div>
+      <span id={progressId} className="sr-only">
+        {progressLabel}
+      </span>
+    </article>
+  );
+};
+
+export default GardenTree;


### PR DESCRIPTION
## Summary
- add a dedicated `GardenTree` component that presents priority tasks with a canopy badge and radial progress indicator while keeping screen reader context
- swap the priority grove rendering to use `GardenTree` and retain `GardenPlant` for bonus blooms
- style the new tree presentation, priority cluster layout, and add a shared `.sr-only` helper class for accessibility text

## Testing
- npm run lint *(fails: pre-existing lint errors in src/apps/zen-go/js/tensorflow.js and other untouched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d307566f7c832b874efefc9d5faf41