### PR TITLE
Redirect unknown routes to GitHub Pages root

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=https://hardik-s.github.io/g1" />
+    <title>Redirecting...</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+        background: #f5f5f5;
+        color: #333;
+      }
+    </style>
+  </head>
+  <body>
+    <noscript>
+      <p>
+        This page redirects to
+        <a href="https://hardik-s.github.io/g1">https://hardik-s.github.io/g1</a>
+        .
+      </p>
+    </noscript>
+    <script>
+      (function () {
+        var target = 'https://hardik-s.github.io/g1';
+        if (window.location.hash) {
+          target += window.location.hash;
+        }
+        window.location.replace(target);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -52,9 +52,11 @@ const AppContainer = () => {
 
   useEffect(() => {
     if (!activeApp && normalizedPath !== '/') {
-      navigate('/', { replace: true });
+      if (typeof window !== 'undefined') {
+        window.location.replace('https://hardik-s.github.io/g1');
+      }
     }
-  }, [activeApp, navigate, normalizedPath]);
+  }, [activeApp, normalizedPath]);
 
   const handleBackToLauncher = useCallback(() => {
     navigate('/');


### PR DESCRIPTION
## Summary
- replace the in-app fallback navigation with a hard redirect to https://hardik-s.github.io/g1 when an unknown route is visited
- add a GitHub Pages-friendly 404.html that immediately redirects visitors back to the published root while preserving any hash fragment

## Testing
- npx jest src/components/__tests__/AppContainer.test.js
- Manual: launched the production build with `serve` and confirmed an unknown client-side route jumps to https://hardik-s.github.io/g1
- Manual: served public/404.html and confirmed it redirects to https://hardik-s.github.io/g1

------
https://chatgpt.com/codex/tasks/task_e_68d3076c8d94832b8dc8c7d3387b71fd