### PR TITLE
Refactor app filtering into shared helper

### DIFF
--- a/src/apps/__tests__/filtering.test.js
+++ b/src/apps/__tests__/filtering.test.js
@@ -1,0 +1,62 @@
+import matchesAppQuery from '../filtering';
+
+describe('matchesAppQuery', () => {
+  const baseApp = {
+    id: 'test-app',
+    title: 'Quantum Painter',
+    description: 'Create masterpieces with physics',
+    category: 'Creativity',
+    tags: ['Quantum', 'Art'],
+    disabled: false,
+  };
+
+  it('returns false for disabled apps even when the search matches', () => {
+    const result = matchesAppQuery(
+      { ...baseApp, disabled: true },
+      { category: 'Creativity', searchTerm: 'quantum' },
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('matches tags in a case-insensitive manner', () => {
+    const tagOnlyApp = {
+      ...baseApp,
+      title: 'Gallery',
+      description: 'Colorful creations',
+      tags: ['Strategy', 'Brain Teaser'],
+    };
+
+    const result = matchesAppQuery(tagOnlyApp, {
+      category: 'Creativity',
+      searchTerm: 'brain',
+    });
+
+    expect(result).toBe(true);
+
+    const mixedCaseResult = matchesAppQuery(tagOnlyApp, {
+      category: 'Creativity',
+      searchTerm: 'BRAin',
+    });
+
+    expect(mixedCaseResult).toBe(true);
+  });
+
+  it('treats the "All" category as a wildcard', () => {
+    const result = matchesAppQuery(baseApp, {
+      category: 'All',
+      searchTerm: '',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('requires the category to match when not filtering by "All"', () => {
+    const result = matchesAppQuery(baseApp, {
+      category: 'Productivity',
+      searchTerm: '',
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/apps/filtering.js
+++ b/src/apps/filtering.js
@@ -1,0 +1,35 @@
+export const matchesAppQuery = (app, options = {}) => {
+  if (!app || app.disabled) {
+    return false;
+  }
+
+  const { category = 'All', searchTerm = '' } = options;
+  const normalizedCategory = typeof category === 'string' ? category : 'All';
+  const normalizedSearchTerm = typeof searchTerm === 'string' ? searchTerm : '';
+
+  if (normalizedCategory !== 'All' && app.category !== normalizedCategory) {
+    return false;
+  }
+
+  const loweredSearchTerm = normalizedSearchTerm.toLowerCase();
+
+  if (loweredSearchTerm === '') {
+    return true;
+  }
+
+  const title = typeof app.title === 'string' ? app.title.toLowerCase() : '';
+  const description = typeof app.description === 'string' ? app.description.toLowerCase() : '';
+  const tags = Array.isArray(app.tags) ? app.tags : [];
+
+  if (title.includes(loweredSearchTerm)) {
+    return true;
+  }
+
+  if (description.includes(loweredSearchTerm)) {
+    return true;
+  }
+
+  return tags.some((tag) => typeof tag === 'string' && tag.toLowerCase().includes(loweredSearchTerm));
+};
+
+export default matchesAppQuery;

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { APP_CATEGORIES, getAllApps } from '../apps/registry';
+import matchesAppQuery from '../apps/filtering';
 import AppLauncherHeader from './AppLauncher/AppLauncherHeader';
 import CategoryNav from './AppLauncher/CategoryNav';
 import FavoritesSection from './AppLauncher/FavoritesSection';
@@ -62,18 +63,16 @@ const AppLauncher = () => {
     toggleFavorite,
   } = useFavorites(allApps, selectedCategory, searchQuery);
 
+  const filterOptions = useMemo(() => ({
+    category: selectedCategory,
+    searchTerm: searchQuery.toLowerCase(),
+  }), [searchQuery, selectedCategory]);
+
   const filteredApps = useMemo(() => {
     const favoriteSet = new Set(favoriteIds);
-    const searchLower = searchQuery.toLowerCase();
 
     return allApps
-      .filter((app) => {
-        const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
-        const matchesSearch = app.title.toLowerCase().includes(searchLower) ||
-          app.description.toLowerCase().includes(searchLower) ||
-          app.tags.some((tag) => tag.toLowerCase().includes(searchLower));
-        return matchesCategory && matchesSearch && !app.disabled;
-      })
+      .filter((app) => matchesAppQuery(app, filterOptions))
       .sort((a, b) => {
         const aFavorited = favoriteSet.has(a.id);
         const bFavorited = favoriteSet.has(b.id);
@@ -85,7 +84,7 @@ const AppLauncher = () => {
         }
         return a.title.localeCompare(b.title);
       });
-  }, [allApps, favoriteIds, searchQuery, selectedCategory]);
+  }, [allApps, favoriteIds, filterOptions]);
 
   const featuredApps = useMemo(() => allApps
     .filter((app) => app.featured && !app.disabled)

--- a/src/components/AppLauncher/hooks/useFavorites.js
+++ b/src/components/AppLauncher/hooks/useFavorites.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFavoritesStorage } from '../../../state/favoritesStorage';
+import matchesAppQuery from '../../../apps/filtering';
 
 const useFavorites = (allApps, selectedCategory, searchQuery) => {
   const { readFavorites, writeFavorites } = useFavoritesStorage();
@@ -32,30 +33,24 @@ const useFavorites = (allApps, selectedCategory, searchQuery) => {
 
   const isFavorited = useCallback((appId) => favoriteIds.includes(appId), [favoriteIds]);
 
-  const favoriteApps = useMemo(() => allApps
-    .filter((app) => favoriteIds.includes(app.id) && !app.disabled)
-    .filter((app) => {
-      const searchLower = searchQuery.toLowerCase();
-      const matchesCategory = selectedCategory === 'All' || app.category === selectedCategory;
-      const matchesSearch = app.title.toLowerCase().includes(searchLower) ||
-        app.description.toLowerCase().includes(searchLower) ||
-        app.tags.some((tag) => tag.toLowerCase().includes(searchLower));
+  const filterOptions = useMemo(() => ({
+    category: selectedCategory,
+    searchTerm: searchQuery.toLowerCase(),
+  }), [searchQuery, selectedCategory]);
 
-      return matchesCategory && matchesSearch;
-    })
+  const favoriteApps = useMemo(() => allApps
+    .filter((app) => favoriteIds.includes(app.id))
+    .filter((app) => matchesAppQuery(app, filterOptions))
     .sort((a, b) => a.title.localeCompare(b.title)), [
     allApps,
     favoriteIds,
-    searchQuery,
-    selectedCategory,
+    filterOptions,
   ]);
 
   const hasHiddenFavoritesInCategory = useMemo(() => {
     if (selectedCategory === 'All' || favoriteIds.length === 0) {
       return false;
     }
-
-    const searchLower = searchQuery.toLowerCase();
 
     return favoriteIds.some((favoriteId) => {
       const app = allApps.find((candidate) => candidate.id === favoriteId);
@@ -64,17 +59,13 @@ const useFavorites = (allApps, selectedCategory, searchQuery) => {
         return false;
       }
 
-      const matchesSearch = app.title.toLowerCase().includes(searchLower) ||
-        app.description.toLowerCase().includes(searchLower) ||
-        app.tags.some((tag) => tag.toLowerCase().includes(searchLower));
-
-      if (!matchesSearch) {
+      if (!matchesAppQuery(app, { category: 'All', searchTerm: filterOptions.searchTerm })) {
         return false;
       }
 
       return app.category !== selectedCategory;
     });
-  }, [allApps, favoriteIds, searchQuery, selectedCategory]);
+  }, [allApps, favoriteIds, filterOptions.searchTerm, selectedCategory]);
 
   return {
     favoriteIds,


### PR DESCRIPTION
## Summary
- add a shared matchesAppQuery helper to centralize app filtering rules
- switch AppLauncher and useFavorites to reuse the helper with normalized query options
- add unit tests covering disabled apps, tag searches, and category handling for the helper

## Testing
- npm test -- filtering

------
https://chatgpt.com/codex/tasks/task_e_68d324224384832b91cf37b42818fecd