### PR TITLE
Refine mini timer card layout

### DIFF
--- a/src/apps/NPomodoroApp/NPomodoroApp.css
+++ b/src/apps/NPomodoroApp/NPomodoroApp.css
@@ -717,48 +717,62 @@ body.n-pomodoro-focus-active {
 }
 
 .timer-card[data-variant='mini'] {
-  max-width: 320px;
+  width: min(100%, 300px);
   margin: 0 auto;
-  gap: 18px;
-  padding: 24px;
-  border-radius: 24px;
+  gap: 16px;
+  padding: 20px 18px;
+  border-radius: 22px;
+  align-items: center;
+  text-align: center;
 }
 
 .timer-card[data-variant='mini'] .timer-meta {
-  gap: 10px;
+  width: 100%;
+  gap: 8px;
+  align-items: center;
 }
 
 .timer-card[data-variant='mini'] .session-label {
-  font-size: 0.7rem;
-  padding: 5px 12px;
+  font-size: 0.68rem;
+  padding: 4px 10px;
 }
 
 .timer-card[data-variant='mini'] .timer-meta h2 {
-  font-size: 1.6rem;
+  font-size: 1.55rem;
+  line-height: 1.2;
 }
 
 .timer-card[data-variant='mini'] .block-label {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+}
+
+.timer-card[data-variant='mini'] .mini-block-duration {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(241, 245, 255, 0.68);
 }
 
 .timer-card[data-variant='mini'] .timer-visual {
-  width: min(220px, 68vw);
+  width: min(200px, 70vw);
+  margin-inline: auto;
 }
 
 .timer-card[data-variant='mini'] .time-display {
-  font-size: 2.4rem;
+  font-size: 2.2rem;
 }
 
 .timer-card[data-variant='mini'] .timer-controls {
   flex-direction: column;
   align-items: stretch;
-  gap: 12px;
+  gap: 10px;
+  width: 100%;
 }
 
 .timer-card[data-variant='mini'] .control-btn {
   width: 100%;
-  padding: 10px 18px;
+  padding: 11px 18px;
   justify-content: center;
+  min-width: auto;
 }
 
 .mini-timer-window {

--- a/src/apps/NPomodoroApp/components/TimerCard.tsx
+++ b/src/apps/NPomodoroApp/components/TimerCard.tsx
@@ -50,8 +50,46 @@ const TimerCard: React.FC<TimerCardProps> = ({
   onSkipBackward,
   onSkipForward
 }) => {
-  const showQuickStats = variant !== 'mini';
-  const showCompletionBanner = variant !== 'mini' && isComplete;
+  const isMiniVariant = variant === 'mini';
+  const showPlannerControls = !isMiniVariant;
+  const showQuickStats = !isMiniVariant;
+  const showCompletionBanner = !isMiniVariant && isComplete;
+
+  const renderPrimaryControl = () => {
+    if (isRunning) {
+      return (
+        <button type="button" className="control-btn warning" onClick={onPause}>
+          ⏸ Pause
+        </button>
+      );
+    }
+
+    if (isPaused) {
+      return (
+        <button
+          type="button"
+          className="control-btn primary"
+          onClick={onStart}
+          disabled={controlsDisabled}
+        >
+          ▶ Resume
+        </button>
+      );
+    }
+
+    return (
+      <button
+        type="button"
+        className="control-btn primary"
+        onClick={onStart}
+        disabled={controlsDisabled}
+      >
+        ▶ Start
+      </button>
+    );
+  };
+
+  const primaryControl = renderPrimaryControl();
 
   return (
     <div
@@ -62,6 +100,9 @@ const TimerCard: React.FC<TimerCardProps> = ({
         <span className="session-label">{sessionLabel}</span>
         <h2>{sessionName}</h2>
         <p className="block-label">{blockLabel}</p>
+        {isMiniVariant && (
+          <p className="mini-block-duration">{currentBlockDurationLabel}</p>
+        )}
       </div>
 
       <div className="timer-visual">
@@ -111,50 +152,37 @@ const TimerCard: React.FC<TimerCardProps> = ({
       )}
 
       <div className="timer-controls">
-        <button
-          type="button"
-          className="control-btn ghost"
-          onClick={onSkipBackward}
-          disabled={controlsDisabled}
-        >
-          ⟲ Previous
-        </button>
-        {!isRunning && !isPaused && (
+        {showPlannerControls && (
           <button
             type="button"
-            className="control-btn primary"
-            onClick={onStart}
+            className="control-btn ghost"
+            onClick={onSkipBackward}
             disabled={controlsDisabled}
           >
-            ▶ Start
+            ⟲ Previous
           </button>
         )}
-        {isRunning && (
-          <button type="button" className="control-btn warning" onClick={onPause}>
-            ⏸ Pause
+        {primaryControl}
+        {showPlannerControls && (
+          <button
+            type="button"
+            className="control-btn ghost"
+            onClick={onReset}
+            disabled={controlsDisabled}
+          >
+            ⟲ Reset
           </button>
         )}
-        {isPaused && !isRunning && (
-          <button type="button" className="control-btn primary" onClick={onStart}>
-            ▶ Resume
+        {showPlannerControls && (
+          <button
+            type="button"
+            className="control-btn ghost"
+            onClick={onSkipForward}
+            disabled={controlsDisabled}
+          >
+            Next ⟳
           </button>
         )}
-        <button
-          type="button"
-          className="control-btn ghost"
-          onClick={onReset}
-          disabled={controlsDisabled}
-        >
-          ⟲ Reset
-        </button>
-        <button
-          type="button"
-          className="control-btn ghost"
-          onClick={onSkipForward}
-          disabled={controlsDisabled}
-        >
-          Next ⟳
-        </button>
       </div>
 
       {showCompletionBanner && (


### PR DESCRIPTION
## Summary
- hide planner-only controls in the mini timer card and surface current block duration inline
- refactor timer control rendering so the mini variant keeps only the primary start/pause button
- tighten mini timer spacing and typography to fit compact popup dimensions

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d34a3d8334832b88cf98c932e946b2