### PR TITLE
Ensure NPomodoro pop-out window lifecycle is synchronized

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -31,7 +31,7 @@ Quantum Playground invites curious learners to assemble drag-and-drop circuits o
 - Support exporting circuits to OpenQASM or JSON for sharing and importing beyond the playground.
 
 ## N-Pomodoro Timer
-N-Pomodoro Timer choreographs customizable work cycles within a cosmic interface. Users pick multi-activity presets, monitor progress through animated rings, and toggle configuration panels without losing context. Timers persist across states, enabling focused sprints, reflective breaks, and celebratory completions through ambient stars, all tailored to evolving productivity rituals and team rhythms.
+N-Pomodoro Timer choreographs customizable work cycles within a cosmic interface. Users pick multi-activity presets, monitor progress through animated rings, and toggle configuration panels without losing context. A pop-out mini timer mirrors the active session in its own window, staying in sync with the main dashboard and closing automatically when the ritual resets, so focused sprints, reflective breaks, and celebratory completions remain cohesive across surfaces.
 - Enable user-defined activity presets with saved profiles synchronized across devices.
 - Add analytics for completed cycles, streaks, and activity performance over time.
 - Integrate ambient audio cues and focus playlists aligned with each activity.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Gif coming soon
 * **Day Switcher**: cycle through the week with animated transitions.
 * **CatPad**: cat-themed note editor with GitHub gist syncing.
 * **Zen Do**: manage tasks in a zen-styled weekly garden with focus mode, gist sync, and a custom pointer-driven drag system for moving cards between the task tree, weekly buckets, and focus lists. 【F:src/apps/ZenDoApp/views/LandingView.js†L1-L168】【F:src/apps/ZenDoApp/views/TodayView.js†L1-L126】
-* **N-Pomodoro**: orchestrate multi-activity pomodoro sessions.
+* **N-Pomodoro**: orchestrate multi-activity pomodoro sessions with a synchronized pop-out mini timer.
 
 ### Games
 

--- a/src/apps/NPomodoroApp/NPomodoroApp.js
+++ b/src/apps/NPomodoroApp/NPomodoroApp.js
@@ -396,10 +396,40 @@ const NPomodoroAppContent = () => {
     overallProgress,
     ritualMinutes,
     isPlannerExpanded,
-    setIsPlannerExpanded
+    setIsPlannerExpanded,
+    providerVersion
   } = timerState;
   const [isMiniTimerOpen, setIsMiniTimerOpen] = React.useState(false);
   const miniTimerWindowRef = React.useRef(null);
+  const providerVersionRef = React.useRef(providerVersion);
+
+  const closeMiniTimerWindow = React.useCallback(() => {
+    const popup = miniTimerWindowRef.current;
+    miniTimerWindowRef.current = null;
+    setIsMiniTimerOpen(false);
+    if (popup && !popup.closed) {
+      popup.close();
+    }
+  }, [setIsMiniTimerOpen]);
+
+  React.useEffect(
+    () => () => {
+      const popup = miniTimerWindowRef.current;
+      miniTimerWindowRef.current = null;
+      if (popup && !popup.closed) {
+        popup.close();
+      }
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    if (providerVersionRef.current === providerVersion) {
+      return;
+    }
+    providerVersionRef.current = providerVersion;
+    closeMiniTimerWindow();
+  }, [providerVersion, closeMiniTimerWindow]);
 
   const handleMiniTimerButtonClick = React.useCallback(() => {
     const popup = miniTimerWindowRef.current;

--- a/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
+++ b/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
@@ -2,67 +2,91 @@ import React from 'react';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-jest.mock('../../../components/MiniTimerWindow', () => {
-  const React = require('react');
-  const mockWindow = {
-    focus: jest.fn(),
-    closed: false
-  };
-
-  const MiniTimerWindowMock = (props) => {
-    const propsRef = React.useRef(props);
-    propsRef.current = props;
-
-    React.useEffect(() => {
-      MiniTimerWindowMock.propsRef = propsRef;
-      mockWindow.closed = false;
-      if (MiniTimerWindowMock.shouldBlock) {
-        propsRef.current.onBlocked?.();
-        return undefined;
-      }
-      propsRef.current.onOpen?.(mockWindow);
-      return () => {
-        MiniTimerWindowMock.propsRef = null;
-        propsRef.current.onClose?.();
-      };
-    }, []);
-
-    return <div data-testid="mock-mini-window">{props.children}</div>;
-  };
-
-  MiniTimerWindowMock.mockWindow = mockWindow;
-  MiniTimerWindowMock.propsRef = null;
-  MiniTimerWindowMock.shouldBlock = false;
-  MiniTimerWindowMock.close = () => {
-    mockWindow.closed = true;
-    MiniTimerWindowMock.propsRef?.current?.onClose?.();
-  };
-  MiniTimerWindowMock.block = () => {
-    MiniTimerWindowMock.propsRef?.current?.onBlocked?.();
-  };
-  MiniTimerWindowMock.reset = () => {
-    mockWindow.focus = jest.fn();
-    mockWindow.closed = false;
-    MiniTimerWindowMock.shouldBlock = false;
-    MiniTimerWindowMock.propsRef = null;
-  };
-
-  return { __esModule: true, default: MiniTimerWindowMock };
-});
-
 import NPomodoroApp from '../NPomodoroApp';
-import MiniTimerWindow from '../../../components/MiniTimerWindow';
+
+class PopupWindowStub {
+  constructor() {
+    this.closed = false;
+    this.focus = jest.fn();
+    this.listeners = new Map();
+    this.document = document.implementation.createHTMLDocument('mini');
+    Object.defineProperty(this.document, 'readyState', {
+      configurable: true,
+      get: () => 'complete'
+    });
+  }
+
+  addEventListener(eventName, handler) {
+    if (!this.listeners.has(eventName)) {
+      this.listeners.set(eventName, new Set());
+    }
+    this.listeners.get(eventName).add(handler);
+  }
+
+  removeEventListener(eventName, handler) {
+    const handlers = this.listeners.get(eventName);
+    if (!handlers) return;
+    handlers.delete(handler);
+    if (!handlers.size) {
+      this.listeners.delete(eventName);
+    }
+  }
+
+  dispatch(eventName) {
+    const handlers = this.listeners.get(eventName);
+    if (!handlers) return;
+    handlers.forEach((handler) => handler());
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.dispatch('beforeunload');
+  }
+}
 
 describe('NPomodoroApp interactions', () => {
+  const originalTitle = document.title;
+  let openSpy;
+  let lastPopup;
+
   beforeEach(() => {
     window.localStorage.clear();
+    document.title = originalTitle;
     Object.defineProperty(window, 'innerWidth', {
       writable: true,
       configurable: true,
       value: 1200
     });
-    MiniTimerWindow.reset();
+    lastPopup = null;
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => {
+      lastPopup = new PopupWindowStub();
+      return lastPopup;
+    });
   });
+
+  afterEach(async () => {
+    if (openSpy) {
+      openSpy.mockRestore();
+    }
+    if (lastPopup && !lastPopup.closed) {
+      await act(async () => {
+        lastPopup.close();
+      });
+    }
+  });
+
+  const openMiniWindow = async (user) => {
+    const popoutButton = screen.getByRole('button', { name: /mini timer window/i });
+    await user.click(popoutButton);
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(lastPopup?.document.body.querySelector('.mini-timer-window-root')).toBeTruthy();
+    });
+    return { popoutButton, popup: lastPopup };
+  };
 
   it('toggles focus mode when the focus session button is used', async () => {
     render(<NPomodoroApp />);
@@ -135,39 +159,120 @@ describe('NPomodoroApp interactions', () => {
     });
   });
 
-  it('opens the mini timer window and focuses it on repeat clicks', async () => {
+  it('opens the mini timer window via window.open and focuses existing popups', async () => {
     render(<NPomodoroApp />);
     const user = userEvent.setup();
 
-    const popoutButton = screen.getByRole('button', { name: /mini timer window/i });
-    MiniTimerWindow.mockWindow.focus = jest.fn();
+    const { popoutButton, popup } = await openMiniWindow(user);
 
-    await user.click(popoutButton);
-    expect(screen.getByTestId('mock-mini-window')).toBeInTheDocument();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [url, name, features] = openSpy.mock.calls[0];
+    expect(url).toBe('');
+    expect(name).toBe('n-pomodoro-mini-timer');
+    expect(features).toContain('width=360');
+    expect(features).toContain('height=520');
+    expect(features).toContain('noopener=yes');
     expect(popoutButton).toHaveAttribute('aria-pressed', 'true');
+    expect(popup.focus).toHaveBeenCalled();
 
     await user.click(popoutButton);
-    expect(MiniTimerWindow.mockWindow.focus).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(popup.focus).toHaveBeenCalledTimes(2);
   });
 
-  it('resets the popout state when the mini window closes', async () => {
+  it('renders the mini timer content inside the popup portal', async () => {
     render(<NPomodoroApp />);
     const user = userEvent.setup();
 
-    const popoutButton = screen.getByRole('button', { name: /mini timer window/i });
+    await openMiniWindow(user);
 
-    await user.click(popoutButton);
+    await waitFor(() => {
+      const miniCard = lastPopup.document.body.querySelector('.timer-card[data-variant="mini"]');
+      expect(miniCard).toBeTruthy();
+      expect(miniCard.textContent).toContain('Session 1 of');
+    });
+  });
+
+  it('keeps timer values in sync between the main view and the popup', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const mainTimeDisplay = document.querySelector('.play-panel .time-display');
+    expect(mainTimeDisplay).not.toBeNull();
+
+    await openMiniWindow(user);
+
+    await waitFor(() => {
+      const popupTimeDisplay = lastPopup.document.querySelector('.time-display');
+      expect(popupTimeDisplay).toBeTruthy();
+      expect(popupTimeDisplay.textContent).toBe(mainTimeDisplay.textContent);
+    });
+  });
+
+  it('resets the popout state when the mini window closes itself', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const { popoutButton, popup } = await openMiniWindow(user);
     expect(popoutButton).toHaveAttribute('aria-pressed', 'true');
 
     await act(async () => {
-      MiniTimerWindow.close();
+      popup.close();
     });
 
     await waitFor(() => {
       expect(popoutButton).toHaveAttribute('aria-pressed', 'false');
     });
+  });
 
-    await user.click(popoutButton);
-    expect(screen.getByTestId('mock-mini-window')).toBeInTheDocument();
+  it('closes the popup when the provider resets to defaults', async () => {
+    render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const { popoutButton, popup } = await openMiniWindow(user);
+    expect(popup.closed).toBe(false);
+
+    const restoreButton = screen.getByRole('button', { name: /restore defaults/i });
+    await user.click(restoreButton);
+
+    await waitFor(() => {
+      expect(popoutButton).toHaveAttribute('aria-pressed', 'false');
+      expect(popup.closed).toBe(true);
+    });
+  });
+
+  it('persists session edits after using the mini window and remounting', async () => {
+    const { unmount } = render(<NPomodoroApp />);
+    const user = userEvent.setup();
+
+    const sessionPreviews = screen.getAllByTestId('session-preview');
+    await user.click(sessionPreviews[0]);
+
+    const editor = screen.getByTestId('session-editor-modal');
+    const nameInput = within(editor).getByDisplayValue('Morning Momentum');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Persistent Focus');
+
+    await waitFor(() => {
+      const stored = window.localStorage.getItem('n-pomodoro-sessions-v2');
+      expect(stored).toContain('Persistent Focus');
+    });
+
+    const closeButton = within(editor).getByRole('button', {
+      name: /close session editor/i
+    });
+    await user.click(closeButton);
+
+    const { popup } = await openMiniWindow(user);
+    expect(popup.closed).toBe(false);
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(popup.closed).toBe(true);
+
+    render(<NPomodoroApp />);
+    expect(screen.getAllByText('Persistent Focus')[0]).toBeInTheDocument();
   });
 });

--- a/src/apps/n-pomodoro/state/PomodoroTimerProvider.tsx
+++ b/src/apps/n-pomodoro/state/PomodoroTimerProvider.tsx
@@ -48,6 +48,7 @@ type TimelineSegment = {
 };
 
 type PomodoroTimerContextValue = {
+  providerVersion: number;
   sessions: PomodoroSession[];
   currentSessionIndex: number;
   currentBlockIndex: number;
@@ -188,6 +189,7 @@ export const PomodoroTimerProvider: React.FC<React.PropsWithChildren> = ({
   });
   const [isFocusMode, setIsFocusMode] = useState(false);
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [providerVersion, setProviderVersion] = useState(0);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -701,6 +703,7 @@ export const PomodoroTimerProvider: React.FC<React.PropsWithChildren> = ({
     setIsComplete(false);
     setIsFocusMode(false);
     setEditingSessionId(null);
+    setProviderVersion((version) => version + 1);
     if (typeof window !== 'undefined') {
       window.localStorage.removeItem(STORAGE_KEY);
     }
@@ -747,6 +750,7 @@ export const PomodoroTimerProvider: React.FC<React.PropsWithChildren> = ({
   ]);
 
   const contextValue: PomodoroTimerContextValue = {
+    providerVersion,
     sessions,
     currentSessionIndex,
     currentBlockIndex,

--- a/src/components/MiniTimerWindow.tsx
+++ b/src/components/MiniTimerWindow.tsx
@@ -23,7 +23,8 @@ const MiniTimerWindow: React.FC<MiniTimerWindowProps> = ({
   windowName = 'mini-timer',
   features,
   onClose,
-  onBlocked
+  onBlocked,
+  onOpen
 }) => {
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
   const styleObserverRef = useRef<MutationObserver | null>(null);


### PR DESCRIPTION
## Summary
- close the NPomodoro mini timer popup when the provider resets or the app unmounts and expose a lifecycle version in the timer context
- teach the mini timer window component about the onOpen callback and update tests to exercise the real popup behaviour
- document the pop-out timer feature in the NPomodoro docs

## Testing
- npm test -- NPomodoroApp

------
https://chatgpt.com/codex/tasks/task_e_68d34ca33ff8832b889bc1b6309f80ce