### PR TITLE
Refactor Snake app around deterministic engine

### DIFF
--- a/docs/GITSTORY.md
+++ b/docs/GITSTORY.md
@@ -14,3 +14,4 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 - 2025-10-12 — feature+docs — Added Cosmos solar system simulator with Three.js physics subapp, launcher integration, and refreshed docs.
 - 2025-10-18 — removal — Retired the Chessboard Summit experience and deleted associated assets, tests, and documentation.
 - 2025-10-20 — feature+docs — Added LangMath natural-language calculator with Pyodide evaluation, launcher wiring, and refreshed documentation.
+- 2025-10-26 — feature+tests — Modularized the Snake app with a deterministic engine, requestAnimationFrame game loop, and new Jest coverage.

--- a/src/apps/SnakeApp/SnakeApp.css
+++ b/src/apps/SnakeApp/SnakeApp.css
@@ -86,6 +86,44 @@
   color: #4caf50;
 }
 
+.meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.meta-item {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.meta-item.status {
+  font-weight: 700;
+}
+
+.meta-item.status.idle {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.meta-item.status.running {
+  color: #4caf50;
+}
+
+.meta-item.status.paused {
+  color: #ff9800;
+}
+
+.meta-item.status.game_over {
+  color: #f44336;
+}
+
+.meta-item.status.completed {
+  color: #00bcd4;
+}
+
 .game-container {
   flex: 1;
   display: flex;

--- a/src/apps/SnakeApp/__tests__/SnakeGameEngine.test.js
+++ b/src/apps/SnakeApp/__tests__/SnakeGameEngine.test.js
@@ -1,0 +1,92 @@
+import { SnakeGameEngine, GAME_OVER_REASONS } from '../game/engine';
+import { DIRECTIONS, GameStatus } from '../game/constants';
+
+describe('SnakeGameEngine', () => {
+  it('spawns food deterministically for the same seed', () => {
+    const config = {
+      gridSize: 6,
+      stepMs: 100,
+      initialSnake: [{ x: 0, y: 0 }],
+      initialFood: { x: 1, y: 0 },
+      seed: 'deterministic-seed'
+    };
+
+    const engineA = new SnakeGameEngine(config);
+    const engineB = new SnakeGameEngine(config);
+
+    engineA.setDirection(DIRECTIONS.Right);
+    engineB.setDirection(DIRECTIONS.Right);
+
+    engineA.tick(100);
+    engineB.tick(100);
+
+    expect(engineA.getState().score).toBe(1);
+    expect(engineB.getState().score).toBe(1);
+    expect(engineA.getState().food).toEqual(engineB.getState().food);
+  });
+
+  it('detects wall collisions and ends the game', () => {
+    const engine = new SnakeGameEngine({
+      gridSize: 3,
+      stepMs: 100,
+      initialSnake: [{ x: 2, y: 1 }],
+      seed: 'wall-test'
+    });
+
+    engine.setDirection(DIRECTIONS.Right);
+    engine.tick(100);
+    const state = engine.getState();
+
+    expect(state.status).toBe(GameStatus.GameOver);
+    expect(state.gameOverReason).toBe(GAME_OVER_REASONS.Wall);
+  });
+
+  it('prevents reversing direction into the snake body', () => {
+    const engine = new SnakeGameEngine({
+      gridSize: 5,
+      stepMs: 100,
+      initialSnake: [
+        { x: 2, y: 2 },
+        { x: 1, y: 2 },
+        { x: 0, y: 2 }
+      ],
+      initialDirection: DIRECTIONS.Right,
+      seed: 'reverse-test'
+    });
+
+    engine.setDirection(DIRECTIONS.Right);
+    engine.tick(100);
+    const afterMove = engine.getState();
+
+    engine.setDirection(DIRECTIONS.Left);
+    const afterReverseAttempt = engine.getState();
+
+    expect(afterReverseAttempt.pendingDirection).toEqual(afterMove.direction);
+  });
+
+  it('serializes and restores state including RNG progression', () => {
+    const engine = new SnakeGameEngine({
+      gridSize: 6,
+      stepMs: 100,
+      initialSnake: [{ x: 0, y: 0 }],
+      initialFood: { x: 1, y: 0 },
+      seed: 'serialize-test'
+    });
+
+    engine.setDirection(DIRECTIONS.Right);
+    engine.tick(100);
+    engine.setDirection(DIRECTIONS.Down);
+    engine.tick(100);
+
+    const serialized = engine.serialize();
+    const clone = new SnakeGameEngine();
+    clone.load(serialized);
+
+    expect(clone.getState()).toEqual(engine.getState());
+
+    engine.tick(100);
+    clone.tick(100);
+
+    expect(clone.getState()).toEqual(engine.getState());
+  });
+});

--- a/src/apps/SnakeApp/game/constants.js
+++ b/src/apps/SnakeApp/game/constants.js
@@ -1,0 +1,18 @@
+export const DIRECTIONS = Object.freeze({
+  None: Object.freeze({ x: 0, y: 0 }),
+  Up: Object.freeze({ x: 0, y: -1 }),
+  Down: Object.freeze({ x: 0, y: 1 }),
+  Left: Object.freeze({ x: -1, y: 0 }),
+  Right: Object.freeze({ x: 1, y: 0 })
+});
+
+export const GameStatus = Object.freeze({
+  Idle: 'idle',
+  Running: 'running',
+  Paused: 'paused',
+  GameOver: 'game_over',
+  Completed: 'completed'
+});
+
+export const DEFAULT_GRID_SIZE = 20;
+export const DEFAULT_STEP_MS = 120;

--- a/src/apps/SnakeApp/game/engine.js
+++ b/src/apps/SnakeApp/game/engine.js
@@ -1,0 +1,355 @@
+import { createDeterministicRng, DeterministicRng } from './rng';
+import { DIRECTIONS, GameStatus, DEFAULT_GRID_SIZE, DEFAULT_STEP_MS } from './constants';
+
+const clonePosition = (position) => ({ x: position.x, y: position.y });
+const directionsEqual = (a, b) => a.x === b.x && a.y === b.y;
+const isOppositeDirection = (a, b) => a.x === -b.x && a.y === -b.y;
+const isZeroDirection = (dir) => dir.x === 0 && dir.y === 0;
+
+const normalizeDirection = (direction) => {
+  if (!direction) {
+    return DIRECTIONS.None;
+  }
+  const x = Math.sign(direction.x ?? 0);
+  const y = Math.sign(direction.y ?? 0);
+  if (x !== 0 && y !== 0) {
+    // prefer horizontal movement when both axes provided
+    return { x, y: 0 };
+  }
+  return { x, y };
+};
+
+const positionKey = (pos) => `${pos.x},${pos.y}`;
+
+const DEFAULT_OPTIONS = {
+  gridSize: DEFAULT_GRID_SIZE,
+  stepMs: DEFAULT_STEP_MS,
+  initialSnake: [{ x: 10, y: 10 }],
+  initialFood: null,
+  initialDirection: DIRECTIONS.None,
+  seed: undefined
+};
+
+const GAME_OVER_REASONS = Object.freeze({
+  Wall: 'wall',
+  Self: 'self',
+  Victory: 'victory'
+});
+
+export class SnakeGameEngine {
+  constructor(options = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+    this.gridSize = this.options.gridSize;
+    this.stepMs = this.options.stepMs;
+    this.seed = this.options.seed ?? `${Date.now()}`;
+    this.rng = options.rng instanceof DeterministicRng
+      ? options.rng.clone()
+      : createDeterministicRng(this.seed, options.rngOffset ?? 0);
+    this.accumulator = 0;
+    this.replayEvents = [];
+    this._initState();
+  }
+
+  _initState() {
+    const initialSnake = this.options.initialSnake.map(clonePosition);
+    const initialDirection = normalizeDirection(this.options.initialDirection);
+    const foodSource = this.options.initialFood
+      ? clonePosition(this.options.initialFood)
+      : this._generateFood(initialSnake);
+
+    this.state = {
+      status: GameStatus.Idle,
+      snake: initialSnake,
+      direction: initialDirection,
+      pendingDirection: initialDirection,
+      food: foodSource,
+      score: 0,
+      step: 0,
+      gameOverReason: null,
+      seed: this.seed
+    };
+    this.accumulator = 0;
+    this.replayEvents = [];
+    this._logEvent({ type: 'init', payload: this._snapshotStateForReplay() });
+  }
+
+  getState() {
+    return {
+      status: this.state.status,
+      snake: this.state.snake.map(clonePosition),
+      direction: { ...this.state.direction },
+      pendingDirection: { ...this.state.pendingDirection },
+      food: this.state.food ? clonePosition(this.state.food) : null,
+      score: this.state.score,
+      step: this.state.step,
+      gameOverReason: this.state.gameOverReason,
+      seed: this.state.seed,
+      stepMs: this.stepMs,
+      gridSize: this.gridSize
+    };
+  }
+
+  setDirection(direction) {
+    const normalized = normalizeDirection(direction);
+    const currentDirection = this.state.direction;
+    if (isZeroDirection(normalized)) {
+      return this.getState();
+    }
+
+    if (
+      !isZeroDirection(currentDirection) &&
+      isOppositeDirection(currentDirection, normalized) &&
+      this.state.snake.length > 1
+    ) {
+      return this.getState();
+    }
+
+    if (directionsEqual(this.state.pendingDirection, normalized)) {
+      return this.getState();
+    }
+
+    this.state.pendingDirection = normalized;
+    if (this.state.status === GameStatus.Idle) {
+      this.state.status = GameStatus.Running;
+    }
+
+    this._logEvent({
+      type: 'direction',
+      payload: {
+        step: this.state.step,
+        direction: { ...normalized }
+      }
+    });
+
+    return this.getState();
+  }
+
+  start() {
+    if (this.state.status === GameStatus.Idle) {
+      this.state.status = GameStatus.Running;
+    }
+    return this.getState();
+  }
+
+  pause() {
+    if (this.state.status === GameStatus.Running) {
+      this.state.status = GameStatus.Paused;
+    }
+    return this.getState();
+  }
+
+  resume() {
+    if (this.state.status === GameStatus.Paused) {
+      this.state.status = GameStatus.Running;
+    }
+    return this.getState();
+  }
+
+  reset({ seed } = {}) {
+    if (seed) {
+      this.seed = String(seed);
+    }
+    this.rng = createDeterministicRng(this.seed);
+    this._initState();
+    return this.getState();
+  }
+
+  updateOptions(options = {}) {
+    if (typeof options.stepMs === 'number') {
+      this.stepMs = options.stepMs;
+    }
+    if (typeof options.gridSize === 'number' && options.gridSize !== this.gridSize) {
+      this.gridSize = options.gridSize;
+      this.options.gridSize = options.gridSize;
+      this.reset({ seed: this.seed });
+    }
+    return this.getState();
+  }
+
+  tick(elapsedMs) {
+    if (this.state.status !== GameStatus.Running) {
+      return this.getState();
+    }
+
+    this.accumulator += typeof elapsedMs === 'number' ? elapsedMs : this.stepMs;
+    while (this.accumulator >= this.stepMs && this.state.status === GameStatus.Running) {
+      this.accumulator -= this.stepMs;
+      this._advance();
+    }
+    return this.getState();
+  }
+
+  serialize() {
+    return JSON.stringify({
+      options: {
+        gridSize: this.gridSize,
+        stepMs: this.stepMs
+      },
+      rng: this.rng.getState(),
+      state: this.getState(),
+      replay: this.getReplay()
+    });
+  }
+
+  load(serialized) {
+    const payload = typeof serialized === 'string' ? JSON.parse(serialized) : serialized;
+    if (!payload || !payload.state) {
+      throw new Error('Invalid serialized state');
+    }
+    this.gridSize = payload.options?.gridSize ?? this.gridSize;
+    this.stepMs = payload.options?.stepMs ?? this.stepMs;
+    this.seed = payload.state.seed ?? this.seed;
+    this.rng = payload.rng
+      ? DeterministicRng.fromState(payload.rng)
+      : createDeterministicRng(this.seed);
+
+    const state = payload.state;
+    this.state = {
+      status: state.status,
+      snake: state.snake.map(clonePosition),
+      direction: { ...state.direction },
+      pendingDirection: { ...state.pendingDirection },
+      food: state.food ? clonePosition(state.food) : null,
+      score: state.score,
+      step: state.step,
+      gameOverReason: state.gameOverReason ?? null,
+      seed: state.seed ?? this.seed
+    };
+    this.accumulator = 0;
+    this.replayEvents = payload.replay?.events?.map((event) => ({
+      ...event,
+      payload: event.payload ? { ...event.payload } : undefined
+    })) ?? [];
+    return this.getState();
+  }
+
+  getReplay() {
+    return {
+      seed: this.seed,
+      options: {
+        gridSize: this.gridSize,
+        stepMs: this.stepMs
+      },
+      events: this.replayEvents.map((event) => ({
+        type: event.type,
+        payload: event.payload ? { ...event.payload } : undefined
+      }))
+    };
+  }
+
+  _advance() {
+    const direction = this.state.pendingDirection;
+    if (isZeroDirection(direction)) {
+      return;
+    }
+
+    this.state.direction = direction;
+    const currentSnake = this.state.snake.map(clonePosition);
+    const head = clonePosition(currentSnake[0]);
+    head.x += direction.x;
+    head.y += direction.y;
+
+    if (!this._isWithinBounds(head)) {
+      this._finishGame(GAME_OVER_REASONS.Wall);
+      return;
+    }
+
+    const isEating = this.state.food && head.x === this.state.food.x && head.y === this.state.food.y;
+    const bodyToCheck = isEating ? currentSnake : currentSnake.slice(0, -1);
+    if (this._isOccupied(head, bodyToCheck)) {
+      this._finishGame(GAME_OVER_REASONS.Self);
+      return;
+    }
+
+    currentSnake.unshift(head);
+    if (isEating) {
+      this.state.score += 1;
+      const nextFood = this._generateFood(currentSnake);
+      this.state.food = nextFood;
+      if (!nextFood) {
+        this._finishGame(GAME_OVER_REASONS.Victory, { keepRunning: false });
+        return;
+      }
+    } else {
+      currentSnake.pop();
+    }
+
+    this.state.snake = currentSnake;
+    this.state.step += 1;
+    this._logEvent({
+      type: 'step',
+      payload: {
+        step: this.state.step,
+        head: clonePosition(head),
+        ateFood: isEating
+      }
+    });
+  }
+
+  _generateFood(snakeBody) {
+    const occupied = new Set(snakeBody.map(positionKey));
+    if (occupied.size >= this.gridSize * this.gridSize) {
+      return null;
+    }
+
+    let candidate;
+    let attempts = 0;
+    do {
+      candidate = {
+        x: this.rng.nextInt(this.gridSize),
+        y: this.rng.nextInt(this.gridSize)
+      };
+      attempts += 1;
+      if (attempts > this.gridSize * this.gridSize) {
+        break;
+      }
+    } while (occupied.has(positionKey(candidate)));
+    return candidate;
+  }
+
+  _isWithinBounds(position) {
+    return (
+      position.x >= 0 &&
+      position.x < this.gridSize &&
+      position.y >= 0 &&
+      position.y < this.gridSize
+    );
+  }
+
+  _isOccupied(position, snakeBody) {
+    return snakeBody.some((segment) => segment.x === position.x && segment.y === position.y);
+  }
+
+  _finishGame(reason, { keepRunning = false } = {}) {
+    this.state.status = reason === GAME_OVER_REASONS.Victory ? GameStatus.Completed : GameStatus.GameOver;
+    this.state.gameOverReason = reason;
+    if (!keepRunning) {
+      this.accumulator = 0;
+    }
+    this._logEvent({
+      type: 'game_end',
+      payload: {
+        reason,
+        step: this.state.step,
+        score: this.state.score
+      }
+    });
+  }
+
+  _logEvent(event) {
+    this.replayEvents.push({ ...event });
+  }
+
+  _snapshotStateForReplay() {
+    return {
+      snake: this.state.snake.map(clonePosition),
+      food: this.state.food ? clonePosition(this.state.food) : null,
+      direction: { ...this.state.direction },
+      score: this.state.score,
+      step: this.state.step,
+      status: this.state.status
+    };
+  }
+}
+
+export { GAME_OVER_REASONS };

--- a/src/apps/SnakeApp/game/rng.js
+++ b/src/apps/SnakeApp/game/rng.js
@@ -1,0 +1,94 @@
+const DEFAULT_SEED = () => `${Date.now()}-${Math.random()}`;
+
+const cyrb128 = (str) => {
+  let h1 = 1779033703,
+    h2 = 3144134277,
+    h3 = 1013904242,
+    h4 = 2773480762;
+  for (let i = 0, k; i < str.length; i++) {
+    k = str.charCodeAt(i);
+    h1 = (h2 ^ Math.imul(h1 ^ k, 597399067)) >>> 0;
+    h2 = (h3 ^ Math.imul(h2 ^ k, 2869860233)) >>> 0;
+    h3 = (h4 ^ Math.imul(h3 ^ k, 951274213)) >>> 0;
+    h4 = (h1 ^ Math.imul(h4 ^ k, 2716044179)) >>> 0;
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067) >>> 0;
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233) >>> 0;
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213) >>> 0;
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179) >>> 0;
+  return [(h1 ^ h2 ^ h3 ^ h4) >>> 0, h2, h3, h4];
+};
+
+const sfc32 = (a, b, c, d) => {
+  return () => {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+};
+
+export class DeterministicRng {
+  constructor(seed = DEFAULT_SEED(), offset = 0) {
+    this.seed = String(seed);
+    const [a, b, c, d] = cyrb128(this.seed);
+    this._generator = sfc32(a, b, c, d);
+    this.offset = 0;
+    if (offset > 0) {
+      this.advance(offset);
+    }
+  }
+
+  next() {
+    const value = this._generator();
+    this.offset += 1;
+    return value;
+  }
+
+  nextInt(maxExclusive) {
+    if (maxExclusive <= 0) {
+      throw new Error('maxExclusive must be greater than 0');
+    }
+    return Math.floor(this.next() * maxExclusive);
+  }
+
+  nextRange(min, max) {
+    if (max <= min) {
+      throw new Error('max must be greater than min');
+    }
+    return min + this.next() * (max - min);
+  }
+
+  advance(steps) {
+    for (let i = 0; i < steps; i++) {
+      this._generator();
+    }
+    this.offset += steps;
+  }
+
+  getState() {
+    return { seed: this.seed, offset: this.offset };
+  }
+
+  clone() {
+    return new DeterministicRng(this.seed, this.offset);
+  }
+
+  static fromState(state) {
+    if (!state || typeof state.seed === 'undefined') {
+      throw new Error('Invalid RNG state');
+    }
+    return new DeterministicRng(state.seed, state.offset ?? 0);
+  }
+}
+
+export const createDeterministicRng = (seed, offset = 0) =>
+  new DeterministicRng(seed, offset);

--- a/src/apps/SnakeApp/game/useSnakeGame.js
+++ b/src/apps/SnakeApp/game/useSnakeGame.js
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SnakeGameEngine } from './engine';
+import { DIRECTIONS, GameStatus, DEFAULT_GRID_SIZE, DEFAULT_STEP_MS } from './constants';
+
+const createEngine = (config) => new SnakeGameEngine(config);
+
+export const useSnakeGame = (config = {}) => {
+  const { gridSize = DEFAULT_GRID_SIZE, stepMs = DEFAULT_STEP_MS, seed } = config;
+  const engineRef = useRef(null);
+  const frameRef = useRef(null);
+  const lastTimestampRef = useRef(null);
+
+  if (!engineRef.current) {
+    engineRef.current = createEngine({ gridSize, stepMs, seed });
+  }
+
+  const [state, setState] = useState(engineRef.current.getState());
+
+  const syncState = useCallback(() => {
+    setState(engineRef.current.getState());
+  }, []);
+
+  const cancelLoop = useCallback(() => {
+    if (frameRef.current != null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, []);
+
+  const stepFrame = useCallback(
+    (timestamp) => {
+      if (lastTimestampRef.current == null) {
+        lastTimestampRef.current = timestamp;
+      }
+      const delta = timestamp - lastTimestampRef.current;
+      lastTimestampRef.current = timestamp;
+      const nextState = engineRef.current.tick(delta);
+      setState(nextState);
+      if (nextState.status === GameStatus.Running) {
+        frameRef.current = requestAnimationFrame(stepFrame);
+      } else {
+        frameRef.current = null;
+      }
+    },
+    []
+  );
+
+  const ensureLoop = useCallback(() => {
+    if (frameRef.current == null) {
+      lastTimestampRef.current = null;
+      frameRef.current = requestAnimationFrame(stepFrame);
+    }
+  }, [stepFrame]);
+
+  useEffect(() => {
+    return () => {
+      cancelLoop();
+    };
+  }, [cancelLoop]);
+
+  useEffect(() => {
+    engineRef.current.updateOptions({ gridSize, stepMs });
+    syncState();
+  }, [gridSize, stepMs, syncState]);
+
+  const setDirection = useCallback(
+    (direction) => {
+      const next = engineRef.current.setDirection(direction);
+      setState(next);
+      if (next.status === GameStatus.Running) {
+        ensureLoop();
+      }
+    },
+    [ensureLoop]
+  );
+
+  const start = useCallback(() => {
+    const next = engineRef.current.start();
+    setState(next);
+    if (next.status === GameStatus.Running) {
+      ensureLoop();
+    }
+  }, [ensureLoop]);
+
+  const pause = useCallback(() => {
+    const next = engineRef.current.pause();
+    cancelLoop();
+    setState(next);
+  }, [cancelLoop]);
+
+  const resume = useCallback(() => {
+    const next = engineRef.current.resume();
+    setState(next);
+    if (next.status === GameStatus.Running) {
+      ensureLoop();
+    }
+  }, [ensureLoop]);
+
+  const reset = useCallback(
+    ({ seed: nextSeed } = {}) => {
+      const next = engineRef.current.reset({ seed: nextSeed });
+      cancelLoop();
+      setState(next);
+    },
+    [cancelLoop]
+  );
+
+  const load = useCallback(
+    (payload) => {
+      const next = engineRef.current.load(payload);
+      cancelLoop();
+      setState(next);
+    },
+    [cancelLoop]
+  );
+
+  const replay = useMemo(() => engineRef.current.getReplay(), [state.step, state.score]);
+
+  return {
+    state,
+    actions: {
+      setDirection,
+      start,
+      pause,
+      resume,
+      reset,
+      load
+    },
+    replay,
+    engine: engineRef.current
+  };
+};
+
+export { DIRECTIONS, GameStatus };


### PR DESCRIPTION
## Summary
- extract a headless SnakeGameEngine with deterministic RNG, serialization, and replay metadata
- add a reusable useSnakeGame hook plus keyboard pause/resume handling in the React UI
- refresh the Snake UI with status badges, seed display, and pause messaging while logging the change in docs/GITSTORY
- introduce dedicated Jest coverage for the engine behaviour

## Testing
- npm test -- --runTestsByPath src/apps/SnakeApp/__tests__/SnakeGameEngine.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d349a5d828832baf6d5cc240bd45b0