### PR TITLE
docs: expand agent handbook with workspace workflows

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,11 +4,13 @@ Welcome! This guide captures expectations for future coding agents collaborating
 
 ## Quick start
 - Use Node.js 18 or 20 when possible. Install dependencies with `npm install` before running any scripts.
-- Local development happens through `npm start`, which runs webpack-dev-server on port 3000.
+- Install `pnpm` globally (`npm install -g pnpm`) so you can use the workspace-aware scripts.
+- Local development happens through `npm start`, which runs webpack-dev-server on port 3000. If you are iterating on the cache lab workspace run `npm run dev` to launch both webpack and the pnpm workspace watcher together.
 - The production bundle is created with `npm run build`; assets are emitted to `dist/`.
 
 ## Required checks
 - When you change any JavaScript, JSX, or CSS that impacts runtime behaviour or visuals, run `npm test`. The suite is powered by Jest and `@testing-library`.
+- Run `npm run lint` after touching JavaScript or JSX to catch issues before CI.
 - If you touch build tooling (webpack, Babel config, deployment setup) also run `npm run build` to ensure the bundle still compiles.
 - Documentation-only updates (Markdown, plain text) do not require automated checks, but state this explicitly in your summary.
 
@@ -21,6 +23,10 @@ Welcome! This guide captures expectations for future coding agents collaborating
 ## When adding or changing apps
 - Register the app in `src/apps/registry.js` and verify the launcher entry in `src/components/AppLauncher` renders correctly.
 - Update `APPS.md` with a short blurb and usage tips for the new experience.
+
+### Workspace-specific workflows
+- **cache lab** (`src/apps/cache-lab`): use the pnpm scripts exposed through the root package. `npm run dev` launches the workspace `dev` task alongside the main webpack server, while `npm run test:cache-lab` and `npm run e2e:cache-lab` proxy the respective pnpm commands.
+- **etymosphere** (`apps/etymosphere`): use the npm prefix helpers like `npm run etymosphere:dev` for local work and `npm run etymosphere:test` before submitting changes.
 
 ## Documentation expectations
 - Keep this `AGENTS.md` file updated when conventions evolve.


### PR DESCRIPTION
## Summary
- document the need for pnpm when working with the cache lab workspace and show how to start both servers together
- require running the lint script alongside tests for JavaScript and JSX edits
- capture per-app workflows for cache lab and etymosphere within the handbook

## Testing
- n/a (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d34f8a5cb8832b9cecd8958222bbae