### PR TITLE
Fix mini timer popup opener handling

### DIFF
--- a/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
+++ b/src/apps/NPomodoroApp/__tests__/NPomodoroApp.test.js
@@ -10,6 +10,7 @@ class PopupWindowStub {
     this.focus = jest.fn();
     this.listeners = new Map();
     this.document = document.implementation.createHTMLDocument('mini');
+    this.opener = window;
     Object.defineProperty(this.document, 'readyState', {
       configurable: true,
       get: () => 'complete'
@@ -171,7 +172,8 @@ describe('NPomodoroApp interactions', () => {
     expect(name).toBe('n-pomodoro-mini-timer');
     expect(features).toContain('width=360');
     expect(features).toContain('height=520');
-    expect(features).toContain('noopener=yes');
+    expect(features).not.toContain('noopener=yes');
+    expect(popup.opener).toBeNull();
     expect(popoutButton).toHaveAttribute('aria-pressed', 'true');
     expect(popup.focus).toHaveBeenCalled();
 

--- a/src/components/MiniTimerWindow.tsx
+++ b/src/components/MiniTimerWindow.tsx
@@ -14,7 +14,7 @@ type MiniTimerWindowProps = React.PropsWithChildren<{
 const DEFAULT_WIDTH = 360;
 const DEFAULT_HEIGHT = 520;
 const DEFAULT_FEATURES =
-  'toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=yes,noopener=yes';
+  'toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=yes';
 
 const MiniTimerWindow: React.FC<MiniTimerWindowProps> = ({
   children,
@@ -74,6 +74,8 @@ const MiniTimerWindow: React.FC<MiniTimerWindowProps> = ({
       setContainerEl(null);
       return () => undefined;
     }
+
+    popup.opener = null;
 
     let cancelled = false;
     const extDoc = popup.document;


### PR DESCRIPTION
## Summary
- remove the noopener flag from the mini timer popup feature string and null out the opener after the window opens
- update the NPomodoro popup test stub to start with an opener and assert the feature string change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d40846ec60832b902c61615973e576