### PR TITLE
feat: migrate playlist curator schema to MusicBrainz

### DIFF
--- a/docs/GITSTORY.md
+++ b/docs/GITSTORY.md
@@ -18,3 +18,4 @@ Use this file to track commits, pushes, merges, and noteworthy design choices. E
 - 2025-10-26 — feature+docs — Introduced Playlist Curator with rule-based NL→RA planner, mock dataset, launcher integration, and documentation/tests.
 - 2025-10-24 — feature+docs — Added Relational Algebra Playground with RA operators, parser, SQL translator, CSV import, challenges, and documentation updates.
 - 2025-10-26 — feature+tests — Modularized the Snake app with a deterministic engine, requestAnimationFrame game loop, and new Jest coverage.
+- 2025-10-27 — feature+docs — Migrated Playlist Curator schema to MusicBrainz IDs, added sources/genre relations, seeded wide view refresh, and documented the SQL migration.

--- a/docs/playlist-curator-migration-plan.md
+++ b/docs/playlist-curator-migration-plan.md
@@ -103,7 +103,7 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 ## Deliverables Checklist
 - [x] MusicBrainz export spec drafted and approved.
 - [x] ETL prototype ingests initial dataset into staging.
-- [ ] Database schema migrated and documented.
+- [x] Database schema migrated and documented.
 - [ ] RA executor updated with provider abstraction and schema changes.
 - [ ] Frontend supports pagination, caching, and source toggling UI/flags.
 - [ ] Documentation updated (README, runbooks) with ingestion steps and configuration.
@@ -113,9 +113,10 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 - Update README with overview of real-data mode vs mock mode.
 - Add runbook for ETL execution and troubleshooting.
 - Maintain schema diagram reflecting MusicBrainz alignment.
+- Capture canonical table definitions and migration steps in [`docs/playlist-curator-schema.md`](playlist-curator-schema.md) and keep [`sql/playlist-curator/001_musicbrainz_schema.sql`](../sql/playlist-curator/001_musicbrainz_schema.sql) in sync with future changes.
 
 ## Next Steps
 1. Assign owners for Phase 1 deliverables and align on acceptance criteria.
 2. Schedule MusicBrainz export dry run to validate tooling.
-3. Kick off schema migration and executor updates in parallel (with feature flags) to minimize downtime.
+3. Continue RA executor updates and frontend pagination work using the migrated schema as the new contract.
 4. Begin planning for Phase 2 automation to ensure smooth transition post-MVP.

--- a/docs/playlist-curator-schema.md
+++ b/docs/playlist-curator-schema.md
@@ -1,0 +1,101 @@
+# Playlist Curator MusicBrainz-Aligned Schema
+
+The Playlist Curator now stores MusicBrainz-backed identifiers and metadata so
+that the executor, frontend, and future integrations share a single canonical
+contract. This document captures the live relational model, indexes, migration
+script, and rollback guidance.
+
+## Core Tables
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `songs` | Recording-level catalog sourced from MusicBrainz. | `song_id` (MBID string), `primary_artist_id`, `release_id`, `genre`, `release_year`, `source`, `energy`, `bpm`, `cover_art_url`, `is_duet` |
+| `artists` | Unique artist credits referenced by selected recordings. | `artist_id` (MBID string), `name`, `country` |
+| `song_artists` | Link table between songs and artists (supports duets and features). | `song_id`, `artist_id` |
+| `releases` | Album/release metadata used for cover art and year attribution. | `release_id` (MBID string), `title`, `release_year`, `cover_art_url` |
+| `genres` | Canonical genre dictionary mapped from MusicBrainz tags. | `genre_id` (slug), `name` |
+| `song_genres` | Many-to-many join between songs and canonical genres. | `song_id`, `genre_id` |
+| `song_mood` | Stubbed mood annotations (nullable, retained for future enrichment). | `song_id`, `mood` |
+| `song_activity` | Stubbed activity tags (nullable array until enrichment lands). | `song_id`, `activity_tag` |
+| `users` | Demo users for relational exercises. | `user_id`, `name`, `group` |
+| `likes` | Demo user ↔ song like relationships. | `user_id`, `song_id` |
+| `sources` | Catalog providers available to the executor. | `source_id`, `name`, `description`, `is_primary` |
+
+### Derived View
+
+`SongWideView` is a materialised helper produced by
+`src/apps/playlist-curator/data/seed.js`. It contains denormalised columns used
+by the relational algebra executor and UI:
+
+```
+(song_id, title, artists, genre, release_year, energy, bpm, source,
+ release_title, cover_art_url, moods, activities, liked_by)
+```
+
+Each wide row joins `songs`, `song_artists`, `artists`, `song_mood`,
+`song_activity`, `likes`, and `releases`. The `source` column is the provider
+ID (`musicbrainz`, `mock`, ...); friendly names come from the `sources` table.
+
+## Migration Script
+
+The live schema is backed by
+[`sql/playlist-curator/001_musicbrainz_schema.sql`](../sql/playlist-curator/001_musicbrainz_schema.sql).
+Run it against the existing database to migrate from the legacy mock schema:
+
+```sh
+psql "$DATABASE_URL" -f sql/playlist-curator/001_musicbrainz_schema.sql
+```
+
+The script performs the following actions:
+
+1. Renames and widens song identifiers to store MusicBrainz MBIDs (`TEXT`).
+2. Adds `release_year`, `source`, `release_id`, and `cover_art_url` columns to
+   `songs` with sensible defaults.
+3. Creates `releases`, `genres`, `song_genres`, and `sources` tables if they do
+   not exist.
+4. Seeds the `sources` table with `musicbrainz` and `mock` providers.
+5. Adds supporting indexes on foreign-key pairs (`song_artists`, `song_genres`,
+   `likes`) and on `songs.release_year`, `songs.genre`, and `songs.source` for
+   executor filters.
+
+## Rollback Strategy
+
+To revert to the legacy mock schema:
+
+1. Export the new tables (`releases`, `genres`, `song_genres`, `sources`) for
+   safekeeping.
+2. Drop the added foreign-key tables and indexes:
+   ```sql
+   DROP TABLE IF EXISTS song_genres;
+   DROP TABLE IF EXISTS genres;
+   DROP TABLE IF EXISTS releases;
+   DROP TABLE IF EXISTS sources;
+   DROP INDEX IF EXISTS idx_songs_release_year;
+   DROP INDEX IF EXISTS idx_songs_genre;
+   DROP INDEX IF EXISTS idx_songs_source;
+   DROP INDEX IF EXISTS idx_song_artists_song;
+   DROP INDEX IF EXISTS idx_song_genres_song;
+   DROP INDEX IF EXISTS idx_likes_song;
+   ```
+3. Rename `song_id` back to the legacy integer surrogate (if it still exists)
+   and cast the column to `INTEGER` using the archived IDs.
+4. Remove the added `release_year`, `release_id`, `source`, and
+   `cover_art_url` columns from `songs`.
+
+Because the executor and UI now depend on `release_year` and `source`, only run
+this rollback on isolated environments; production should remain on the MBID
+schema.
+
+## Seeding Notes
+
+- `scripts/playlist-curator/generateMusicbrainzDataset.js` (referenced in the
+  dataset file header) produces `musicbrainzDataset.js` with MusicBrainz exports.
+- `src/apps/playlist-curator/data/seed.js` normalises those exports into the
+  relations documented above and materialises `SongWideView`.
+- `DATASET` (exported from `seed.js`) now exposes `songs`, `releases`, `genres`,
+  `songGenres`, and `sources` so the NLP lexicon and executor can inspect the
+  new schema directly.
+
+Keep this document and the SQL migration script updated whenever the schema
+changes so downstream tooling, ETL jobs, and curriculum materials remain in
+sync.

--- a/sql/playlist-curator/001_musicbrainz_schema.sql
+++ b/sql/playlist-curator/001_musicbrainz_schema.sql
@@ -1,0 +1,70 @@
+BEGIN;
+
+-- Normalize primary key and add MusicBrainz-friendly columns on songs.
+ALTER TABLE songs
+  RENAME COLUMN IF EXISTS id TO song_id;
+
+ALTER TABLE songs
+  ALTER COLUMN song_id TYPE TEXT;
+
+ALTER TABLE songs
+  ADD COLUMN IF NOT EXISTS primary_artist_id TEXT,
+  ADD COLUMN IF NOT EXISTS release_id TEXT,
+  ADD COLUMN IF NOT EXISTS release_year INTEGER,
+  ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'mock',
+  ADD COLUMN IF NOT EXISTS cover_art_url TEXT,
+  ADD COLUMN IF NOT EXISTS is_duet BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS energy INTEGER,
+  ADD COLUMN IF NOT EXISTS bpm INTEGER;
+
+UPDATE songs
+SET source = COALESCE(source, 'mock');
+
+ALTER TABLE songs
+  ALTER COLUMN source DROP DEFAULT;
+
+-- Releases catalogue.
+CREATE TABLE IF NOT EXISTS releases (
+  release_id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  release_year INTEGER,
+  cover_art_url TEXT
+);
+
+-- Canonical genres and join table.
+CREATE TABLE IF NOT EXISTS genres (
+  genre_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS song_genres (
+  song_id TEXT NOT NULL REFERENCES songs(song_id) ON DELETE CASCADE,
+  genre_id TEXT NOT NULL REFERENCES genres(genre_id) ON DELETE RESTRICT,
+  PRIMARY KEY (song_id, genre_id)
+);
+
+-- Source providers.
+CREATE TABLE IF NOT EXISTS sources (
+  source_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  is_primary BOOLEAN DEFAULT FALSE
+);
+
+INSERT INTO sources (source_id, name, description, is_primary)
+VALUES
+  ('musicbrainz', 'MusicBrainz', 'MusicBrainz catalog export used for Playlist Curator.', TRUE),
+  ('mock', 'Mock Seed', 'Legacy in-memory dataset used for demos and tests.', FALSE)
+ON CONFLICT (source_id) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description;
+
+-- Supporting indexes for executor filters and joins.
+CREATE INDEX IF NOT EXISTS idx_songs_release_year ON songs (release_year);
+CREATE INDEX IF NOT EXISTS idx_songs_genre ON songs (genre);
+CREATE INDEX IF NOT EXISTS idx_songs_source ON songs (source);
+CREATE INDEX IF NOT EXISTS idx_song_artists_song ON song_artists (song_id);
+CREATE INDEX IF NOT EXISTS idx_song_genres_song ON song_genres (song_id);
+CREATE INDEX IF NOT EXISTS idx_likes_song ON likes (song_id);
+
+COMMIT;

--- a/src/apps/playlist-curator/data/schema.js
+++ b/src/apps/playlist-curator/data/schema.js
@@ -6,13 +6,12 @@ export const RELATIONS = {
       'title',
       'primaryArtistId',
       'genre',
-      'year',
+      'releaseYear',
       'energy',
       'bpm',
       'isDuet',
       'source',
       'releaseId',
-      'releaseTitle',
       'coverArtUrl',
     ],
   },
@@ -47,7 +46,7 @@ export const RELATIONS = {
       'title',
       'artists',
       'genre',
-      'year',
+      'releaseYear',
       'energy',
       'bpm',
       'source',
@@ -60,7 +59,19 @@ export const RELATIONS = {
   },
   Releases: {
     name: 'Releases',
-    columns: ['releaseId', 'title', 'year', 'coverArtUrl'],
+    columns: ['releaseId', 'title', 'releaseYear', 'coverArtUrl'],
+  },
+  Genres: {
+    name: 'Genres',
+    columns: ['genreId', 'name'],
+  },
+  SongGenres: {
+    name: 'SongGenres',
+    columns: ['songId', 'genreId'],
+  },
+  Sources: {
+    name: 'Sources',
+    columns: ['sourceId', 'name', 'description', 'isPrimary'],
   },
 };
 

--- a/src/apps/playlist-curator/nlp/parser.js
+++ b/src/apps/playlist-curator/nlp/parser.js
@@ -90,7 +90,7 @@ const buildBaseFilterPlan = (entities, options = {}) => {
     clauses.push({ type: 'includes', field: 'activities', value: entities.activity });
   }
   if (entities.yearRange) {
-    clauses.push({ type: 'between', field: 'year', min: entities.yearRange.start, max: entities.yearRange.end });
+    clauses.push({ type: 'between', field: 'releaseYear', min: entities.yearRange.start, max: entities.yearRange.end });
   }
   if (entities.bpm) {
     clauses.push({ type: 'comparison', field: 'bpm', operator: entities.bpm.operator, value: entities.bpm.value });
@@ -192,11 +192,11 @@ const buildCartesianPlan = (genre, rangeStart, rangeEnd, activity) => {
   const base = baseNode('SongWideView', 'Songs');
   const clauses = [
     { type: 'equals', field: 'genre', value: genre },
-    { type: 'between', field: 'year', min: rangeStart, max: rangeEnd },
+    { type: 'between', field: 'releaseYear', min: rangeStart, max: rangeEnd },
   ];
   const predicate = buildPredicate(clauses);
   const filteredSongs = selectNode(base, predicate);
-  const projectedSongs = projectNode(filteredSongs, ['songId', 'title', 'genre', 'year']);
+  const projectedSongs = projectNode(filteredSongs, ['songId', 'title', 'genre', 'releaseYear']);
   const activityPredicate = buildPredicate([{ type: 'equals', field: 'activityTag', value: activity }]);
   const activitySelection = selectNode(baseNode('SongActivity'), activityPredicate);
   const activityRelation = projectNode(activitySelection, ['activityTag']);


### PR DESCRIPTION
## Summary
- align the playlist curator relations with the MusicBrainz contract, adding releaseYear plus Genres, SongGenres, and Sources tables
- normalize seed data to surface provider metadata, update the SongWideView rollup, and switch NLP filters to releaseYear
- document the schema and ship an idempotent SQL migration while updating the phase plan and project history

## Testing
- `npm test -- --runTestsByPath src/apps/playlist-curator/__tests__/parser.test.js`
- `npm run lint` *(fails: repository already contains eslint violations outside the playlist curator scope)*
- `npx eslint src/apps/playlist-curator/**/*.js`


------
https://chatgpt.com/codex/tasks/task_e_68d45ecb92ac832ba40aa7371d20a155