### PR TITLE
Align launcher header buttons

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -268,7 +268,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 16px;
+  width: 52px;
+  height: 52px;
+  padding: 0;
 }
 
 .app-launcher.mechanical-view .view-btn,
@@ -277,6 +279,27 @@
   border-color: #334155;
   color: #e2e8f0;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.app-launcher.mechanical-view .admin-toggle {
+  width: 52px;
+  height: 52px;
+  padding: 0;
+  justify-content: center;
+}
+
+.app-launcher.mechanical-view .admin-toggle-label,
+.app-launcher.mechanical-view .admin-toggle-switch {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app-launcher.mechanical-view .view-btn.active,
@@ -1125,7 +1148,7 @@
     justify-content: space-between;
   }
 
-  .admin-toggle {
+  .app-launcher.admin-view .admin-toggle {
     width: 100%;
     justify-content: center;
   }

--- a/src/components/AppLauncher/AppLauncherHeader.js
+++ b/src/components/AppLauncher/AppLauncherHeader.js
@@ -66,6 +66,7 @@ const AppLauncherHeader = ({
           className={`admin-toggle ${isAdminView ? 'active' : ''}`}
           onClick={onToggleAdminView}
           aria-pressed={isAdminView}
+          aria-label={isAdminView ? 'Disable admin view' : 'Enable admin view'}
         >
           <span className="admin-toggle-icon" aria-hidden="true">🛠️</span>
           <span className="admin-toggle-label">Admin View: {isAdminView ? 'On' : 'Off'}</span>


### PR DESCRIPTION
## Summary
- make the launcher header's view and random launch buttons square for a consistent footprint
- collapse the mechanical view admin toggle to an icon-sized square while keeping accessible labelling
- ensure admin view still shows the full-width toggle at small breakpoints

## Testing
- `npm run lint` *(fails: existing lint warnings and errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d466dcc79c832b9ddfcad1288d1c1b