### PR TITLE
feat(playlist-curator): normalize schema with release metadata

### DIFF
--- a/docs/playlist-curator-migration-plan.md
+++ b/docs/playlist-curator-migration-plan.md
@@ -103,7 +103,7 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 ## Deliverables Checklist
 - [x] MusicBrainz export spec drafted and approved.
 - [x] ETL prototype ingests initial dataset into staging.
-- [ ] Database schema migrated and documented.
+- [x] Database schema migrated and documented.
 - [ ] RA executor updated with provider abstraction and schema changes.
 - [ ] Frontend supports pagination, caching, and source toggling UI/flags.
 - [ ] Documentation updated (README, runbooks) with ingestion steps and configuration.

--- a/src/apps/playlist-curator/data/schema.js
+++ b/src/apps/playlist-curator/data/schema.js
@@ -5,12 +5,11 @@ export const RELATIONS = {
       'songId',
       'title',
       'primaryArtistId',
-      'genre',
-      'year',
+      'releaseYear',
       'energy',
       'bpm',
       'isDuet',
-      'source',
+      'sourceId',
       'releaseId',
       'releaseTitle',
       'coverArtUrl',
@@ -46,11 +45,11 @@ export const RELATIONS = {
       'songId',
       'title',
       'artists',
-      'genre',
-      'year',
+      'genres',
+      'releaseYear',
       'energy',
       'bpm',
-      'source',
+      'sourceId',
       'releaseTitle',
       'coverArtUrl',
       'moods',
@@ -61,6 +60,18 @@ export const RELATIONS = {
   Releases: {
     name: 'Releases',
     columns: ['releaseId', 'title', 'year', 'coverArtUrl'],
+  },
+  Genres: {
+    name: 'Genres',
+    columns: ['genreId', 'name'],
+  },
+  SongGenres: {
+    name: 'SongGenres',
+    columns: ['songId', 'genreId'],
+  },
+  Sources: {
+    name: 'Sources',
+    columns: ['sourceId', 'label', 'kind'],
   },
 };
 

--- a/src/apps/playlist-curator/nlp/lexicon.js
+++ b/src/apps/playlist-curator/nlp/lexicon.js
@@ -2,7 +2,7 @@ import { DATASET } from '../data/seed';
 
 const unique = (values) => Array.from(new Set(values)).sort();
 
-export const GENRES = unique(DATASET.songs.map((song) => song.genre));
+export const GENRES = unique(DATASET.genres.map((genre) => genre.genreId));
 export const MOODS = unique(DATASET.songMood.map((entry) => entry.mood));
 export const ACTIVITIES = unique(DATASET.songActivity.map((entry) => entry.activityTag));
 export const USERS = DATASET.users.map((user) => ({

--- a/src/apps/playlist-curator/nlp/parser.js
+++ b/src/apps/playlist-curator/nlp/parser.js
@@ -81,7 +81,7 @@ const extractBpmComparison = (text) => {
 const buildBaseFilterPlan = (entities, options = {}) => {
   const clauses = [];
   if (entities.genre) {
-    clauses.push({ type: 'equals', field: 'genre', value: entities.genre });
+    clauses.push({ type: 'includes', field: 'genres', value: entities.genre });
   }
   if (entities.mood) {
     clauses.push({ type: 'includes', field: 'moods', value: entities.mood });
@@ -90,7 +90,12 @@ const buildBaseFilterPlan = (entities, options = {}) => {
     clauses.push({ type: 'includes', field: 'activities', value: entities.activity });
   }
   if (entities.yearRange) {
-    clauses.push({ type: 'between', field: 'year', min: entities.yearRange.start, max: entities.yearRange.end });
+    clauses.push({
+      type: 'between',
+      field: 'releaseYear',
+      min: entities.yearRange.start,
+      max: entities.yearRange.end,
+    });
   }
   if (entities.bpm) {
     clauses.push({ type: 'comparison', field: 'bpm', operator: entities.bpm.operator, value: entities.bpm.value });
@@ -157,8 +162,8 @@ const buildDivisionPlan = (groupName) => {
 };
 
 const buildSymmetricDifferencePlan = (genreA, genreB) => {
-  const predicateA = buildPredicate([{ type: 'equals', field: 'genre', value: genreA }]);
-  const predicateB = buildPredicate([{ type: 'equals', field: 'genre', value: genreB }]);
+  const predicateA = buildPredicate([{ type: 'includes', field: 'genres', value: genreA }]);
+  const predicateB = buildPredicate([{ type: 'includes', field: 'genres', value: genreB }]);
   const base = baseNode('SongWideView', 'Songs');
   const relA = selectNode(base, predicateA);
   const relB = selectNode(baseNode('SongWideView', 'Songs'), predicateB);
@@ -182,7 +187,7 @@ const buildDuetPlan = () => {
 };
 
 const buildProjectionPlan = (genre) => {
-  const predicate = buildPredicate([{ type: 'equals', field: 'genre', value: genre }]);
+  const predicate = buildPredicate([{ type: 'includes', field: 'genres', value: genre }]);
   const base = baseNode('SongWideView', 'Songs');
   const filtered = selectNode(base, predicate);
   return projectNode(filtered, ['title', 'artists']);
@@ -191,12 +196,12 @@ const buildProjectionPlan = (genre) => {
 const buildCartesianPlan = (genre, rangeStart, rangeEnd, activity) => {
   const base = baseNode('SongWideView', 'Songs');
   const clauses = [
-    { type: 'equals', field: 'genre', value: genre },
-    { type: 'between', field: 'year', min: rangeStart, max: rangeEnd },
+    { type: 'includes', field: 'genres', value: genre },
+    { type: 'between', field: 'releaseYear', min: rangeStart, max: rangeEnd },
   ];
   const predicate = buildPredicate(clauses);
   const filteredSongs = selectNode(base, predicate);
-  const projectedSongs = projectNode(filteredSongs, ['songId', 'title', 'genre', 'year']);
+  const projectedSongs = projectNode(filteredSongs, ['songId', 'title', 'genres', 'releaseYear']);
   const activityPredicate = buildPredicate([{ type: 'equals', field: 'activityTag', value: activity }]);
   const activitySelection = selectNode(baseNode('SongActivity'), activityPredicate);
   const activityRelation = projectNode(activitySelection, ['activityTag']);


### PR DESCRIPTION
## Summary
- add releaseYear and sourceId columns to the Songs/SongWideView relations and register the Genres, SongGenres, and Sources tables
- normalize MusicBrainz seed data into canonical genre/source catalogs and rebuild the wide view with release-aware metadata
- retarget the NLP lexicon and predicates to the new schema fields and record the migration milestone in the roadmap

## Testing
- npm test
- npm run lint *(fails: repository baseline emits pre-existing lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d4672a5924832b8219bfdead3aca7d