### PR TITLE
Fix lint errors in relational algebra and zen-go modules

### DIFF
--- a/src/apps/RelationalAlgebraPlaygroundApp/RelationalAlgebraPlaygroundApp.js
+++ b/src/apps/RelationalAlgebraPlaygroundApp/RelationalAlgebraPlaygroundApp.js
@@ -421,11 +421,11 @@ function PipelineNodeCard({
       {node.type === 'σ' && (
         <div className="ra-node-body">
           <label>
-            Predicate (e.g. Salary > 3000 AND DeptID = 1)
+            Predicate (e.g. Salary &gt; 3000 AND DeptID = 1)
             <input
               value={node.condition || ''}
               onChange={(event) => onUpdate(node.id, { condition: event.target.value })}
-              placeholder="Salary > 3000"
+              placeholder="Salary &gt; 3000"
             />
           </label>
         </div>
@@ -433,11 +433,11 @@ function PipelineNodeCard({
       {node.type === 'π' && (
         <div className="ra-node-body">
           <label>
-            Columns (comma separated, optional alias via ->)
+            Columns (comma separated, optional alias via -&gt;)
             <input
               value={columnsInput}
               onChange={(event) => onUpdate(node.id, { columns: parseColumnsInput(event.target.value) })}
-              placeholder="EmpID, Name->EmployeeName"
+              placeholder="EmpID, Name-&gt;EmployeeName"
             />
           </label>
         </div>
@@ -445,11 +445,11 @@ function PipelineNodeCard({
       {node.type === 'ρ' && (
         <div className="ra-node-body">
           <label>
-            Rename map (comma separated old->new)
+            Rename map (comma separated old-&gt;new)
             <input
               value={renameInput}
               onChange={(event) => onUpdate(node.id, { renameMap: parseRenameInput(event.target.value) })}
-              placeholder="DeptID->DepartmentId"
+              placeholder="DeptID-&gt;DepartmentId"
             />
           </label>
         </div>
@@ -856,6 +856,11 @@ function RelationalAlgebraPlaygroundApp() {
       } else if (event.ctrlKey && (event.key === 'y' || (event.shiftKey && event.key === 'Z'))) {
         event.preventDefault();
         dispatch({ type: 'REDO' });
+      } else if (event.ctrlKey && event.shiftKey && event.key === 'Enter') {
+        event.preventDefault();
+        if (state.nodes.length) {
+          dispatch({ type: 'SET_CURSOR', cursor: state.nodes.length - 1 });
+        }
       } else if (event.ctrlKey && event.key === 'Enter') {
         event.preventDefault();
         const target = state.selectedNodeId
@@ -863,11 +868,6 @@ function RelationalAlgebraPlaygroundApp() {
           : state.nodes.length - 1;
         if (target >= 0) {
           dispatch({ type: 'SET_CURSOR', cursor: target });
-        }
-      } else if (event.ctrlKey && event.shiftKey && event.key === 'Enter') {
-        event.preventDefault();
-        if (state.nodes.length) {
-          dispatch({ type: 'SET_CURSOR', cursor: state.nodes.length - 1 });
         }
       } else if (event.key === 'Delete' && state.selectedNodeId) {
         dispatch({ type: 'DELETE_NODE', id: state.selectedNodeId });

--- a/src/apps/RelationalAlgebraPlaygroundApp/logic/parser.js
+++ b/src/apps/RelationalAlgebraPlaygroundApp/logic/parser.js
@@ -84,7 +84,7 @@ function parseIdentifier(context) {
     }
     throw new ParserError('Unterminated quoted identifier', context.index);
   }
-  const matchResult = /[a-zA-Z_][a-zA-Z0-9_\.]*/.exec(context.source.slice(context.index));
+  const matchResult = /[a-zA-Z_][a-zA-Z0-9_.]*/.exec(context.source.slice(context.index));
   if (!matchResult) {
     throw new ParserError('Expected identifier', context.index);
   }
@@ -93,7 +93,10 @@ function parseIdentifier(context) {
 }
 
 function parseColumnsList(raw) {
-  const trimmed = raw.trim().replace(/[{}\[\]]/g, '');
+  const trimmed = raw.trim()
+    .replace(/[{}]/g, '')
+    .replace(/\[/g, '')
+    .replace(/\]/g, '');
   if (!trimmed) {
     return [];
   }
@@ -110,7 +113,10 @@ function parseColumnsList(raw) {
 }
 
 function parseRenameMap(raw) {
-  const trimmed = raw.trim().replace(/[{}\[\]]/g, '');
+  const trimmed = raw.trim()
+    .replace(/[{}]/g, '')
+    .replace(/\[/g, '')
+    .replace(/\]/g, '');
   if (!trimmed) {
     return {};
   }

--- a/src/apps/RelationalAlgebraPlaygroundApp/logic/predicates.js
+++ b/src/apps/RelationalAlgebraPlaygroundApp/logic/predicates.js
@@ -51,7 +51,7 @@ function tokenise(condition) {
     if (/[0-9]/.test(char)) {
       let buffer = char;
       index += 1;
-      while (index < length && /[0-9\.]/.test(source[index])) {
+      while (index < length && /[0-9.]/.test(source[index])) {
         buffer += source[index];
         index += 1;
       }
@@ -85,10 +85,27 @@ function tokenise(condition) {
       index += keywordMatch[0].length;
       continue;
     }
-    const identifierMatch = /^[A-Za-z_][A-Za-z0-9_\.\[\]]*/.exec(source.slice(index));
-    if (identifierMatch) {
-      pushToken('identifier', identifierMatch[0]);
-      index += identifierMatch[0].length;
+    if (/[A-Za-z_]/.test(char)) {
+      let buffer = char;
+      index += 1;
+      while (index < length) {
+        const next = source[index];
+        if (
+          (next >= 'A' && next <= 'Z') ||
+          (next >= 'a' && next <= 'z') ||
+          (next >= '0' && next <= '9') ||
+          next === '_' ||
+          next === '.' ||
+          next === '[' ||
+          next === ']'
+        ) {
+          buffer += next;
+          index += 1;
+          continue;
+        }
+        break;
+      }
+      pushToken('identifier', buffer);
       continue;
     }
     throw new Error(`Unexpected token near "${source.slice(index, index + 10)}"`);

--- a/src/apps/zen-go/js/tensorflow.js
+++ b/src/apps/zen-go/js/tensorflow.js
@@ -1,17 +1,19 @@
 (function (globalScope, factory) {
-  const existing = factory();
+  const existing = factory(globalScope);
 
   if (typeof module === 'object' && typeof module.exports === 'object') {
     module.exports = existing;
     module.exports.default = existing;
-  } else if (typeof define === 'function' && define.amd) {
-    define([], function () {
+  } else if (typeof globalScope.define === 'function' && globalScope.define.amd) {
+    globalScope.define([], function () {
       return existing;
     });
   } else {
     globalScope.ZenGoTensorflow = existing;
   }
-})(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function () {
+})(
+  typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this,
+  function (globalScope) {
   'use strict';
 
   const DEFAULT_MODEL_SOURCES = Object.freeze({


### PR DESCRIPTION
## Summary
- ensure the Zen Go Tensorflow UMD wrapper receives the global scope and only references AMD globals through that scope
- escape JSX instructional text and reorder keyboard handler branches in the relational algebra playground to satisfy lint rules
- simplify identifier parsing helpers to remove redundant escapes and unused globals flagged by ESLint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d468484268832b95f7e39d77269ec7