### PR TITLE
Scope playlist curator relations to active provider

### DIFF
--- a/docs/playlist-curator-migration-plan.md
+++ b/docs/playlist-curator-migration-plan.md
@@ -104,7 +104,7 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 - [x] MusicBrainz export spec drafted and approved.
 - [x] ETL prototype ingests initial dataset into staging.
 - [x] Database schema migrated and documented.
-- [ ] RA executor updated with provider abstraction and schema changes.
+- [x] RA executor updated with provider abstraction and schema changes.
 - [ ] Frontend supports pagination, caching, and source toggling UI/flags.
 - [ ] Documentation updated (README, runbooks) with ingestion steps and configuration.
 - [ ] Monitoring plan ready for medium-term automation.
@@ -114,6 +114,9 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 - Add runbook for ETL execution and troubleshooting.
 - Maintain schema diagram reflecting MusicBrainz alignment.
 - Capture canonical table definitions and migration steps in [`docs/playlist-curator-schema.md`](playlist-curator-schema.md) and keep [`sql/playlist-curator/001_musicbrainz_schema.sql`](../sql/playlist-curator/001_musicbrainz_schema.sql) in sync with future changes.
+
+## Status Updates
+- Provider interface now exports helpers to query available sources and toggle the active catalog. The RA executor consumes these scoped relations so downstream planners only operate on rows from the selected provider.
 
 ## Next Steps
 1. Assign owners for Phase 1 deliverables and align on acceptance criteria.

--- a/src/apps/playlist-curator/__tests__/parser.test.js
+++ b/src/apps/playlist-curator/__tests__/parser.test.js
@@ -1,5 +1,6 @@
 import { parseQuery } from '../nlp/parser';
 import { EXAMPLE_QUERIES } from '../nlp/lexicon';
+import { getActiveSourceId, getRelation, setActiveSourceId } from '../data/seed';
 
 const expectOk = (result, query) => {
   expect(result.status).toBe('ok');
@@ -8,6 +9,12 @@ const expectOk = (result, query) => {
 };
 
 describe('playlist curator parser', () => {
+  const defaultSource = getActiveSourceId();
+
+  afterEach(() => {
+    setActiveSourceId(defaultSource);
+  });
+
   test('parses curated examples without falling back', () => {
     EXAMPLE_QUERIES.forEach((query) => {
       const result = parseQuery(query);
@@ -27,5 +34,43 @@ describe('playlist curator parser', () => {
     expectOk(result, query);
     const titles = result.result.rows.map((row) => row.values.title);
     expect(titles).not.toContain('Ogbaje Acoustic');
+  });
+
+  test('updates sources relation when toggling providers', () => {
+    setActiveSourceId(defaultSource);
+    const initialSources = getRelation('Sources').rows;
+    const primaryRow = initialSources.find((row) => row.sourceId === defaultSource);
+    expect(primaryRow?.isPrimary).toBe(true);
+
+    const alternate = initialSources.find((row) => row.sourceId !== defaultSource);
+    expect(alternate).toBeDefined();
+
+    setActiveSourceId(alternate.sourceId);
+    const toggledSources = getRelation('Sources').rows;
+    const toggledPrimary = toggledSources.find((row) => row.sourceId === alternate.sourceId);
+    expect(toggledPrimary?.isPrimary).toBe(true);
+    const defaultEntry = toggledSources.find((row) => row.sourceId === defaultSource);
+    expect(defaultEntry?.isPrimary).toBe(false);
+  });
+
+  test('limits parsed query results to the active source catalog', () => {
+    const query = 'List chill acoustic songs not liked by Alex.';
+
+    setActiveSourceId(defaultSource);
+    const defaultResult = parseQuery(query);
+    expectOk(defaultResult, query);
+    defaultResult.result.rows.forEach((row) => {
+      expect(row.values.source).toBe(defaultSource);
+    });
+
+    const alternateSource = getRelation('Sources').rows.find((row) => row.sourceId !== defaultSource);
+    expect(alternateSource).toBeDefined();
+
+    setActiveSourceId(alternateSource.sourceId);
+    const alternateResult = parseQuery(query);
+    expectOk(alternateResult, query);
+    alternateResult.result.rows.forEach((row) => {
+      expect(row.values.source).toBe(alternateSource.sourceId);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- cache playlist curator relations per source and expose helpers to query or switch the active provider
- extend playlist curator parser tests to verify provider toggling updates the sources relation and result catalog
- record the provider interface status and RA executor milestone in the migration plan

## Testing
- npm test -- --runTestsByPath src/apps/playlist-curator/__tests__/parser.test.js
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc31a6aa70832b832f19cbf6eadfc9