### PR TITLE
Add provider-aware playlist curator relations

### DIFF
--- a/docs/playlist-curator-migration-plan.md
+++ b/docs/playlist-curator-migration-plan.md
@@ -68,6 +68,9 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 2. Provide configuration (env var, feature flag) to select provider at runtime.
 3. Ensure tests run against mock provider while allowing integration tests with MusicBrainz subset.
 
+> **Status:** `src/apps/playlist-curator/data/seed.js` exports `setActiveSource`, `getActiveSource`, and `listSources` so the
+> executor now reads provider-scoped relations. The canonical sources catalog remains available for toggles via `listSources()`.
+
 ## Schema Diff
 | Field | Mock Schema | MusicBrainz-Aligned Schema | Status |
 |-------|-------------|----------------------------|--------|
@@ -104,7 +107,7 @@ This plan outlines how to replace the mock playlist curator database with a Musi
 - [x] MusicBrainz export spec drafted and approved.
 - [x] ETL prototype ingests initial dataset into staging.
 - [x] Database schema migrated and documented.
-- [ ] RA executor updated with provider abstraction and schema changes.
+- [x] RA executor updated with provider abstraction and schema changes.
 - [ ] Frontend supports pagination, caching, and source toggling UI/flags.
 - [ ] Documentation updated (README, runbooks) with ingestion steps and configuration.
 - [ ] Monitoring plan ready for medium-term automation.

--- a/src/apps/playlist-curator/__tests__/parser.test.js
+++ b/src/apps/playlist-curator/__tests__/parser.test.js
@@ -1,11 +1,30 @@
 import { parseQuery } from '../nlp/parser';
 import { EXAMPLE_QUERIES } from '../nlp/lexicon';
+import { getRelation, setActiveSource } from '../data/seed';
 
 const expectOk = (result, query) => {
   expect(result.status).toBe('ok');
   expect(result.expression).toBeTruthy();
   expect(Array.isArray(result.steps)).toBe(true);
 };
+
+const sourceRows = getRelation('Sources').rows;
+const DEFAULT_SOURCE_ID = sourceRows.find((source) => source.isPrimary)?.sourceId ?? sourceRows[0]?.sourceId;
+const MOCK_SOURCE_ID = sourceRows.find((source) => source.sourceId === 'mock' && source.sourceId !== DEFAULT_SOURCE_ID)?.sourceId
+  ?? sourceRows.find((source) => source.sourceId !== DEFAULT_SOURCE_ID)?.sourceId
+  ?? null;
+
+beforeEach(() => {
+  if (DEFAULT_SOURCE_ID) {
+    setActiveSource(DEFAULT_SOURCE_ID);
+  }
+});
+
+afterAll(() => {
+  if (DEFAULT_SOURCE_ID) {
+    setActiveSource(DEFAULT_SOURCE_ID);
+  }
+});
 
 describe('playlist curator parser', () => {
   test('parses curated examples without falling back', () => {
@@ -27,5 +46,35 @@ describe('playlist curator parser', () => {
     expectOk(result, query);
     const titles = result.result.rows.map((row) => row.values.title);
     expect(titles).not.toContain('Ogbaje Acoustic');
+  });
+
+  const providerTest = MOCK_SOURCE_ID ? test : test.skip;
+
+  providerTest('marks toggled source as primary and filters relations', () => {
+    const baselineWide = getRelation('SongWideView').rows.length;
+    setActiveSource(MOCK_SOURCE_ID);
+    const sources = getRelation('Sources').rows;
+    const mockEntry = sources.find((entry) => entry.sourceId === MOCK_SOURCE_ID);
+    expect(mockEntry?.isPrimary).toBe(true);
+    if (DEFAULT_SOURCE_ID && DEFAULT_SOURCE_ID !== MOCK_SOURCE_ID) {
+      const primaryEntry = sources.find((entry) => entry.sourceId === DEFAULT_SOURCE_ID);
+      expect(primaryEntry?.isPrimary).toBe(false);
+    }
+    const filteredWide = getRelation('SongWideView').rows.length;
+    expect(filteredWide).toBeLessThanOrEqual(baselineWide);
+  });
+
+  providerTest('limits parser execution to the selected provider catalog', () => {
+    setActiveSource(MOCK_SOURCE_ID);
+    const result = parseQuery('Find upbeat rock songs from the 2000s for working out.');
+    expect(result.status).toBe('ok');
+    const providerWide = getRelation('SongWideView').rows;
+    if (providerWide.length === 0) {
+      expect(result.result.rows.length).toBe(0);
+    } else if (result.result.rows.length > 0) {
+      const allSources = new Set(result.result.rows.map((row) => row.values.source));
+      expect(allSources.size).toBe(1);
+      expect(allSources.has(MOCK_SOURCE_ID)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- scope playlist curator relations by active source so the executor runs against a single provider at a time
- expose helper utilities to inspect or switch providers and update the migration plan checklist accordingly
- extend parser tests to cover provider toggling semantics for SongWideView queries

## Testing
- npm test -- --runTestsByPath src/apps/playlist-curator/__tests__/parser.test.js
- npm run lint *(fails: repository has pre-existing accessibility and lint warnings unrelated to the playlist curator changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d46a92205c832bb5ee59c020d73281