### PR TITLE
Add export script for curated MusicBrainz staging views

### DIFF
--- a/scripts/export_musicbrainz_catalog.py
+++ b/scripts/export_musicbrainz_catalog.py
@@ -1,0 +1,209 @@
+"""Export curated MusicBrainz staging views to CSV artifacts.
+
+This helper connects to a PostgreSQL instance that hosts the MusicBrainz dump
+and the staging helpers created by ``sql/staging_musicbrainz/001_create_views.sql``.
+It materialises the CSVs referenced by the playlist curator migration plan so
+downstream ETL jobs can ingest deterministic datasets without rebuilding the
+queries.
+
+Usage::
+
+    python scripts/export_musicbrainz_catalog.py --dsn postgresql://... \
+        --output-dir exports/musicbrainz
+
+When ``--dsn`` is omitted the script falls back to the ``DATABASE_URL``
+environment variable. The output directory is created if it does not exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, List, Sequence
+
+import psycopg2
+
+
+CURATED_TRACKS_QUERY = """
+SELECT
+    recording_mbid,
+    track_title,
+    primary_artist_name,
+    primary_artist_mbid,
+    release_title,
+    release_group_title,
+    release_mbid,
+    release_group_mbid,
+    release_date_year,
+    release_country,
+    track_length_ms,
+    release_group_type,
+    release_status,
+    barcode,
+    packaging,
+    first_release_date,
+    row_number
+FROM staging_musicbrainz.curated_tracks
+ORDER BY row_number;
+"""
+
+CURATED_ARTISTS_QUERY = """
+SELECT DISTINCT
+    primary_artist_mbid AS artist_mbid,
+    primary_artist_name AS artist_name
+FROM staging_musicbrainz.curated_tracks
+ORDER BY artist_name, artist_mbid;
+"""
+
+CURATED_RELEASES_QUERY = """
+SELECT DISTINCT
+    release_mbid,
+    release_title,
+    release_group_mbid,
+    release_group_title,
+    release_date_year,
+    release_country,
+    barcode,
+    packaging
+FROM staging_musicbrainz.curated_tracks
+ORDER BY release_title, release_mbid;
+"""
+
+CURATED_TRACK_GENRES_QUERY = """
+SELECT
+    ct.recording_mbid,
+    ctg.normalized_genre,
+    ctg.source_type
+FROM staging_musicbrainz.curated_track_genres ctg
+JOIN staging_musicbrainz.curated_tracks ct
+  ON ct.recording_id = ctg.recording_id
+WHERE ctg.normalized_genre IS NOT NULL
+ORDER BY ct.row_number, ctg.normalized_genre;
+"""
+
+
+@dataclass(frozen=True)
+class ExportDefinition:
+    name: str
+    query: str
+    headers: Sequence[str]
+
+
+EXPORTS: List[ExportDefinition] = [
+    ExportDefinition(
+        name="tracks",
+        query=CURATED_TRACKS_QUERY,
+        headers=(
+            "recording_mbid",
+            "track_title",
+            "primary_artist_name",
+            "primary_artist_mbid",
+            "release_title",
+            "release_group_title",
+            "release_mbid",
+            "release_group_mbid",
+            "release_date_year",
+            "release_country",
+            "track_length_ms",
+            "release_group_type",
+            "release_status",
+            "barcode",
+            "packaging",
+            "first_release_date",
+            "row_number",
+        ),
+    ),
+    ExportDefinition(
+        name="artists",
+        query=CURATED_ARTISTS_QUERY,
+        headers=("artist_mbid", "artist_name"),
+    ),
+    ExportDefinition(
+        name="releases",
+        query=CURATED_RELEASES_QUERY,
+        headers=(
+            "release_mbid",
+            "release_title",
+            "release_group_mbid",
+            "release_group_title",
+            "release_date_year",
+            "release_country",
+            "barcode",
+            "packaging",
+        ),
+    ),
+    ExportDefinition(
+        name="track_genres",
+        query=CURATED_TRACK_GENRES_QUERY,
+        headers=("recording_mbid", "normalized_genre", "source_type"),
+    ),
+]
+
+
+def batched(cursor, size: int = 1000) -> Iterator[Sequence[object]]:
+    while True:
+        rows = cursor.fetchmany(size)
+        if not rows:
+            return
+        for row in rows:
+            yield row
+
+
+def export_table(connection, definition: ExportDefinition, output_dir: Path) -> Path:
+    path = output_dir / f"{definition.name}.csv"
+    with connection.cursor(name=f"export_{definition.name}") as cursor:
+        cursor.itersize = 2000
+        cursor.execute(definition.query)
+        with path.open("w", newline="", encoding="utf-8") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerow(definition.headers)
+            for row in batched(cursor):
+                writer.writerow(row)
+    return path
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export curated MusicBrainz CSVs")
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("DATABASE_URL"),
+        help="PostgreSQL DSN (defaults to DATABASE_URL environment variable)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("exports/musicbrainz"),
+        help="Directory where CSV files will be written",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log planned exports without executing any queries",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    if not args.dsn:
+        raise SystemExit("A PostgreSQL DSN must be provided via --dsn or DATABASE_URL")
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dry_run:
+        for definition in EXPORTS:
+            print(f"[DRY RUN] Would export {definition.name} -> {output_dir / (definition.name + '.csv')}")
+        return
+
+    with psycopg2.connect(args.dsn) as connection:
+        for definition in EXPORTS:
+            path = export_table(connection, definition, output_dir)
+            print(f"Exported {definition.name} ({path})")
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/staging_musicbrainz/001_create_views.sql
+++ b/sql/staging_musicbrainz/001_create_views.sql
@@ -1,0 +1,120 @@
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS staging_musicbrainz;
+
+DROP MATERIALIZED VIEW IF EXISTS staging_musicbrainz.staging_tracks;
+CREATE MATERIALIZED VIEW staging_musicbrainz.staging_tracks AS
+SELECT
+    r.id                AS recording_id,
+    r.gid               AS recording_mbid,
+    r.name              AS track_title,
+    r.length            AS track_length_ms,
+    rg.id               AS release_group_id,
+    rg.gid              AS release_group_mbid,
+    rg.name             AS release_group_title,
+    rel.name            AS release_title,
+    rel.id              AS release_id,
+    rel.gid             AS release_mbid,
+    rel.release_date_year,
+    rel.release_date_month,
+    rel.release_date_day,
+    rel.country         AS release_country,
+    rel.status          AS release_status,
+    rg.type             AS release_group_type,
+    ac.id               AS artist_credit_id,
+    a.id                AS primary_artist_id,
+    a.gid               AS primary_artist_mbid,
+    a.name              AS primary_artist_name,
+    r.first_release_date,
+    rel.barcode,
+    rel.packaging
+FROM recording r
+JOIN recording_release rr        ON rr.recording = r.id
+JOIN release rel                 ON rel.id = rr.release
+JOIN release_group rg            ON rg.id = rel.release_group
+JOIN artist_credit ac            ON ac.id = r.artist_credit
+JOIN artist_credit_name acn      ON acn.artist_credit = ac.id AND acn.position = 0
+JOIN artist a                    ON a.id = acn.artist
+WHERE rel.status = 1 -- Official
+  AND rg.type IN (1, 2, 3) -- Album, Single, EP
+  AND r.length BETWEEN 60000 AND 600000; -- 60s - 10m
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_staging_tracks_recording
+  ON staging_musicbrainz.staging_tracks (recording_id);
+
+DROP MATERIALIZED VIEW IF EXISTS staging_musicbrainz.staging_track_genres;
+CREATE MATERIALIZED VIEW staging_musicbrainz.staging_track_genres AS
+SELECT DISTINCT
+    r.id                AS recording_id,
+    COALESCE(g.name, t.name) AS genre_name,
+    CASE WHEN g.name IS NOT NULL THEN 'genre' ELSE 'tag' END AS source_type
+FROM recording r
+LEFT JOIN l_recording_genre lrg ON lrg.entity0 = r.id
+LEFT JOIN genre g               ON g.id = lrg.entity1
+LEFT JOIN l_recording_tag lrt   ON lrt.entity0 = r.id
+LEFT JOIN tag t                 ON t.id = lrt.entity1;
+
+CREATE INDEX IF NOT EXISTS idx_staging_track_genres_recording
+  ON staging_musicbrainz.staging_track_genres (recording_id);
+
+DROP MATERIALIZED VIEW IF EXISTS staging_musicbrainz.curated_tracks;
+CREATE MATERIALIZED VIEW staging_musicbrainz.curated_tracks AS
+WITH ranked AS (
+  SELECT
+      st.recording_id,
+      st.recording_mbid,
+      st.track_title,
+      st.track_length_ms,
+      st.release_group_id,
+      st.release_group_mbid,
+      st.release_group_title,
+      st.release_title,
+      st.release_id,
+      st.release_mbid,
+      st.release_date_year,
+      st.release_date_month,
+      st.release_date_day,
+      st.release_country,
+      st.release_status,
+      st.release_group_type,
+      st.artist_credit_id,
+      st.primary_artist_id,
+      st.primary_artist_mbid,
+      st.primary_artist_name,
+      st.first_release_date,
+      st.barcode,
+      st.packaging,
+      COALESCE(rgr.rating, 0)          AS release_group_rating,
+      COALESCE(rgr.rating_count, 0)    AS release_group_rating_count,
+      ROW_NUMBER() OVER (
+        ORDER BY COALESCE(rgr.rating, 0) DESC,
+                 COALESCE(st.release_date_year, 0) DESC,
+                 st.recording_id
+      ) AS row_number
+  FROM staging_musicbrainz.staging_tracks st
+  LEFT JOIN release_group_rating_raw rgr ON rgr.release_group = st.release_group_id
+)
+SELECT *
+FROM ranked
+WHERE row_number <= 10000;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_curated_tracks_recording
+  ON staging_musicbrainz.curated_tracks (recording_id);
+
+DROP MATERIALIZED VIEW IF EXISTS staging_musicbrainz.curated_track_genres;
+CREATE MATERIALIZED VIEW staging_musicbrainz.curated_track_genres AS
+SELECT
+    ct.recording_id,
+    CASE
+      WHEN stg.genre_name IS NULL THEN NULL
+      ELSE LOWER(REGEXP_REPLACE(BTRIM(stg.genre_name), '\\s+', ' ', 'g'))
+    END AS normalized_genre,
+    stg.source_type
+FROM staging_musicbrainz.curated_tracks ct
+LEFT JOIN staging_musicbrainz.staging_track_genres stg
+  ON stg.recording_id = ct.recording_id;
+
+CREATE INDEX IF NOT EXISTS idx_curated_track_genres_recording
+  ON staging_musicbrainz.curated_track_genres (recording_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a Python helper that streams the curated MusicBrainz staging views into CSV exports
- document the usage and generated artifacts in the export specification

## Testing
- not run (Python script and documentation changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc413fe710832ba79656e177fd08f1