### PR TITLE
Simplify landing theme to a single admin toggle

### DIFF
--- a/src/components/AppLauncher.css
+++ b/src/components/AppLauncher.css
@@ -518,64 +518,95 @@
   line-height: 1.5;
 }
 
-.landing-theme-selector {
-  border: none;
-  margin: 0;
-  padding: 0;
-}
-
-.landing-theme-selector-label {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: #374151;
-  margin-bottom: 10px;
-}
-
-.landing-theme-options {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.landing-theme-option {
+.landing-theme-toggle {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border-radius: 14px;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 18px;
   border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(148, 163, 184, 0.1);
-  color: #374151;
+  background: rgba(241, 245, 249, 0.65);
   cursor: pointer;
   transition: all 0.2s ease;
-  font-weight: 600;
+  width: 100%;
 }
 
-.landing-theme-option input {
+.landing-theme-toggle:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.12);
+}
+
+.landing-theme-toggle:focus-within {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
+.landing-theme-toggle input {
   position: absolute;
   opacity: 0;
   pointer-events: none;
 }
 
-.landing-theme-option span {
-  pointer-events: none;
+.landing-theme-toggle-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.landing-theme-option:hover {
-  border-color: rgba(59, 130, 246, 0.5);
-  background: rgba(191, 219, 254, 0.3);
+.landing-theme-toggle-label {
+  font-weight: 600;
+  color: #1f2937;
 }
 
-.landing-theme-option.selected {
-  border-color: #3b82f6;
+.landing-theme-toggle-status {
+  color: #4b5563;
+  font-size: 0.92rem;
+}
+
+.landing-theme-toggle-switch {
+  width: 54px;
+  height: 30px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.4);
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  transition: background 0.2s ease;
+}
+
+.landing-theme-toggle-knob {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.18);
+  transform: translateX(0);
+  transition: transform 0.2s ease;
+}
+
+.landing-theme-toggle.active {
+  border-color: rgba(37, 99, 235, 0.6);
   background: rgba(59, 130, 246, 0.12);
-  color: #1d4ed8;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.18);
 }
 
-.landing-theme-toggle-btn {
-  align-self: flex-start;
+.landing-theme-toggle.active .landing-theme-toggle-switch {
+  background: #2563eb;
+}
+
+.landing-theme-toggle.active .landing-theme-toggle-knob {
+  transform: translateX(24px);
+}
+
+.landing-theme-toggle.active .landing-theme-toggle-label {
+  color: #1d4ed8;
+}
+
+.landing-theme-toggle.active .landing-theme-toggle-status {
+  color: #1f2937;
 }
 
 .admin-app-list {

--- a/src/components/AppLauncher.js
+++ b/src/components/AppLauncher.js
@@ -284,10 +284,6 @@ const AppLauncher = () => {
     return favoriteApps.filter((app) => hiddenAppIdSet.has(app.id)).length;
   }, [favoriteApps, hiddenAppIdSet, isAdminView]);
 
-  const handleSelectLandingTheme = useCallback((nextTheme) => {
-    setLandingTheme(nextTheme === 'light' ? 'light' : 'dark');
-  }, []);
-
   const toggleLandingTheme = useCallback(() => {
     setLandingTheme((current) => (current === 'dark' ? 'light' : 'dark'));
   }, []);
@@ -359,7 +355,6 @@ const AppLauncher = () => {
 
           <AdminLandingThemeCard
             landingTheme={landingTheme}
-            onSelectTheme={handleSelectLandingTheme}
             onToggleTheme={toggleLandingTheme}
           />
 

--- a/src/components/AppLauncher/admin/AdminLandingThemeCard.js
+++ b/src/components/AppLauncher/admin/AdminLandingThemeCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const AdminLandingThemeCard = ({ landingTheme, onSelectTheme, onToggleTheme }) => {
+const AdminLandingThemeCard = ({ landingTheme, onToggleTheme }) => {
   const isDarkTheme = landingTheme === 'dark';
 
   return (
@@ -10,39 +10,29 @@ const AdminLandingThemeCard = ({ landingTheme, onSelectTheme, onToggleTheme }) =
         Control whether the public launcher uses a light or dark mechanical theme.
       </p>
 
-      <fieldset className="landing-theme-selector">
-        <legend className="landing-theme-selector-label">Launcher appearance</legend>
-        <div className="landing-theme-options">
-          <label className={`landing-theme-option ${landingTheme === 'light' ? 'selected' : ''}`}>
-            <input
-              type="radio"
-              name="landing-theme"
-              value="light"
-              checked={landingTheme === 'light'}
-              onChange={() => onSelectTheme('light')}
-            />
-            <span>Light</span>
-          </label>
-          <label className={`landing-theme-option ${landingTheme === 'dark' ? 'selected' : ''}`}>
-            <input
-              type="radio"
-              name="landing-theme"
-              value="dark"
-              checked={landingTheme === 'dark'}
-              onChange={() => onSelectTheme('dark')}
-            />
-            <span>Dark</span>
-          </label>
-        </div>
-      </fieldset>
-
-      <button
-        type="button"
-        className="admin-action-btn landing-theme-toggle-btn"
-        onClick={onToggleTheme}
-      >
-        Toggle to {isDarkTheme ? 'Light' : 'Dark'} Mode
-      </button>
+      <label className={`landing-theme-toggle ${isDarkTheme ? 'active' : ''}`}>
+        <span className="landing-theme-toggle-copy">
+          <span className="landing-theme-toggle-label">Dark mode</span>
+          <span className="landing-theme-toggle-status">
+            {isDarkTheme
+              ? 'Visitors currently see the dark mechanical finish.'
+              : 'Visitors currently see the light mechanical finish.'}
+          </span>
+        </span>
+        <input
+          type="checkbox"
+          checked={isDarkTheme}
+          onChange={onToggleTheme}
+          aria-label={
+            isDarkTheme
+              ? 'Disable dark mode for the public launcher'
+              : 'Enable dark mode for the public launcher'
+          }
+        />
+        <span className="landing-theme-toggle-switch" aria-hidden="true">
+          <span className="landing-theme-toggle-knob" />
+        </span>
+      </label>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the landing theme radio buttons with a single dark mode toggle in the admin console
- adjust launcher logic to rely on the new toggle handler
- refresh the landing theme card styling to present the switch UI

## Testing
- npm test -- --watch=false
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc4677eecc832b836e53d55ee68b8e