### PR TITLE
Fix HtmlChess stockfish asset loading in production

### DIFF
--- a/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
+++ b/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
@@ -1,6 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
 
-export const STOCKFISH_BASE_PATH = '/apps/htmlChess';
+const resolvePublicUrl = () => {
+  const rawPublicUrl = typeof process !== 'undefined' ? process.env.PUBLIC_URL : '';
+  return (rawPublicUrl ?? '').replace(/\/$/, '');
+};
+
+const PUBLIC_URL = resolvePublicUrl();
+const STOCKFISH_RELATIVE_PATH = '/apps/htmlChess';
+
+export const STOCKFISH_BASE_PATH = `${PUBLIC_URL}${STOCKFISH_RELATIVE_PATH}`;
 export const STOCKFISH_ENTRYPOINT = `${STOCKFISH_BASE_PATH}/sf171-79.js`;
 
 export const NETWORKS = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,7 @@ module.exports = {
         addCopyPattern(patterns, ['apps/cosmos', 'src/apps/cosmos'], 'apps/cosmos');
         addCopyPattern(patterns, ['src/apps/lang-math'], 'apps/lang-math');
         addCopyPattern(patterns, ['apps/zen-go', 'src/apps/zen-go'], 'apps/zen-go');
+        addCopyPattern(patterns, ['public/apps/htmlChess'], 'apps/htmlChess');
 
         const cacheLabSource = path.resolve(__dirname, 'src/apps/cache-lab/dist');
         if (fs.existsSync(cacheLabSource)) {


### PR DESCRIPTION
## Summary
- prefix the Stockfish asset URLs with the PUBLIC_URL base so the htmlChess engine loads correctly on GitHub Pages
- copy the htmlChess Stockfish binaries into the production bundle so dynamic imports can resolve the files

## Testing
- npm test
- npm run lint
- npm run build *(fails: Module not found: Error: Can't resolve 'zustand'; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9bb5c550832b9647c8b80efff4ce