### PR TITLE
Fix HtmlChess PUBLIC_URL resolution for Stockfish assets

### DIFF
--- a/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
+++ b/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
@@ -1,11 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 
-const resolvePublicUrl = () => {
-  const rawPublicUrl = typeof process !== 'undefined' ? process.env.PUBLIC_URL : '';
-  return (rawPublicUrl ?? '').replace(/\/$/, '');
-};
-
-const PUBLIC_URL = resolvePublicUrl();
+const PUBLIC_URL = (process.env.PUBLIC_URL ?? '').replace(/\/$/, '');
 const STOCKFISH_RELATIVE_PATH = '/apps/htmlChess';
 
 export const STOCKFISH_BASE_PATH = `${PUBLIC_URL}${STOCKFISH_RELATIVE_PATH}`;


### PR DESCRIPTION
## Summary
- rely on the compile-time PUBLIC_URL constant when resolving Stockfish asset paths so subpath deployments load correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dca278ecdc832bb93b4a4b9ea8ed8c