### PR TITLE
Enable cross-origin isolation for Stockfish

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+    <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
     <title>64 Apps</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,5 +128,10 @@ module.exports = {
     compress: true,
     port: 3000,
     open: true,
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+    },
   },
 };


### PR DESCRIPTION
## Summary
- add COOP and COEP meta tags to the HTML shell so Stockfish can use SharedArrayBuffer
- serve the same headers in the webpack dev server to keep the development build cross-origin isolated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcb196a888832bb0b03ca5d795014d