### PR TITLE
Add COOP/COEP guard for HtmlChess engine

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -79,7 +79,7 @@ Cat Connect Four stages a whimsical match inside a pastel cat café. Players pic
 - Expand cosmetics with unlockable paw trails, animated board frames, and seasonal café decor.
 
 ## HTML Chess Lab
-HTML Chess Lab runs Stockfish 17 entirely in the browser, streaming stdout and stderr in a live console while automatically attaching bundled NNUE networks. A control surface exposes quick UCI macros, manual command entry, and asset diagnostics so analysts can rehearse engine workflows without a desktop binary.
+HTML Chess Lab runs Stockfish 17 entirely in the browser, streaming stdout and stderr in a live console while automatically attaching bundled NNUE networks. A control surface exposes quick UCI macros, manual command entry, and asset diagnostics so analysts can rehearse engine workflows without a desktop binary. Serve the launcher with `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers—`npm start` configures them automatically—so the SharedArrayBuffer-powered engine boots successfully.
 - Allow users to upload custom NNUE networks and keep per-profile presets.
 - Layer a lightweight board viewer that mirrors the last `position` command for visual context.
 - Surface depth, nodes, and evaluation charts by parsing `info` lines into structured telemetry panels.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Gif coming soon
 * **Neon Pong**: duel classic paddles with a neon glow.
 * **Pong Ring**: rally inside a circular quartz arena.
 * **CatNap Leap**: glide between dreamy pillows while keeping a sleepy cat alert.
-* **HTML Chess Lab**: stream Stockfish 17 + NNUE entirely in-browser with a live UCI console.
+* **HTML Chess Lab**: stream Stockfish 17 + NNUE entirely in-browser with a live UCI console. Serve it with `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers (the `npm start` dev server already does) so SharedArrayBuffer-powered analysis boots.
 * **Sudoku Roast**: solve handcrafted puzzles in a cozy café setting.
 
 ### Learning Tools

--- a/public/apps/htmlChess/README.md
+++ b/public/apps/htmlChess/README.md
@@ -7,3 +7,5 @@ Place the Stockfish runtime files in this directory before running the launcher 
 - `nn-37f18f62d772.nnue`
 
 The `HtmlChessApp` dynamically imports `sf171-79.js` from this folder, which in turn expects the `.wasm` and NNUE buffers to live alongside it. Without these binaries, the Stockfish engine will fail to initialise.
+
+Because the engine relies on `SharedArrayBuffer`, serve the launcher with `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. Running `npm start` sets the correct headers automatically; if you use another server make sure it does the same.

--- a/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
+++ b/src/apps/HtmlChessApp/hooks/useStockfishEngine.js
@@ -45,6 +45,12 @@ const useStockfishEngine = ({ onMessage, onError } = {}) => {
     setLoadedNetworks([]);
 
     try {
+      if (!globalThis.crossOriginIsolated || !('SharedArrayBuffer' in globalThis)) {
+        throw new Error(
+          'HtmlChess must be served with Cross-Origin-Opener-Policy: same-origin and Cross-Origin-Embedder-Policy: require-corp headers (for example via npm start).',
+        );
+      }
+
       const module = await import(
         /* webpackIgnore: true */ `${STOCKFISH_ENTRYPOINT}?cache=${Date.now()}`
       );


### PR DESCRIPTION
## Summary
- prevent the Stockfish worker from loading when SharedArrayBuffer prerequisites are missing and surface a clear HtmlChess error message
- document the launcher header requirements across HtmlChess docs and point to `npm start`

## Testing
- npm test -- --watch=false
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e43bf66100832ba06acbb2a7474b29