### PR TITLE
Add GrokChess static chess app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A modular collection of experimental React experiences bundled behind a shared l
 - **Neon Pong** and **Pong Ring** – duel paddles across neon and circular arenas.
 - **CatNap Leap** – glide between dreamy pillows while keeping a sleepy cat alert.
 - **HTML Chess Lab** – run Stockfish 17 + NNUE entirely in-browser with a live UCI console.
+- **GrokChess** – static GitHub Pages chessboard that pits you against Stockfish with blitz clocks.
 - **Sudoku Roast** – solve handcrafted puzzles in a cozy café setting.
 
 ### Learning tools

--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -84,6 +84,12 @@ HTML Chess Lab runs Stockfish 17 entirely in the browser, streaming stdout and s
 - Layer a lightweight board viewer that mirrors the last `position` command for visual context.
 - Surface depth, nodes, and evaluation charts by parsing `info` lines into structured telemetry panels.
 
+## GrokChess
+GrokChess packages a Stockfish-powered board into a single static HTML page so it can live on GitHub Pages without build tooling. Chessboard.js renders the responsive board, Chess.js validates moves, and a bundled Stockfish WASM worker answers from the black side at depth 10, making it ideal for blitz skirmishes wherever the site is hosted.
+- Add more time controls, including classical presets and custom increments, with persistent preferences stored client-side.
+- Layer PGN export plus a move list that mirrors the live board so players can review games after the final move.
+- Offer difficulty scaling by adjusting Stockfish search depth or skill level for beginners wanting lighter resistance.
+
 ## Sudoku Roast
 Sudoku Roast brings a cozy café vibe to the classic logic puzzle with parchment-inspired styling, smooth note-taking, and an original puzzle generator. Solvers can pencil in candidates, validate progress, and request handcrafted hints without breaking immersion.
 - Track solve statistics, streaks, and difficulty preferences for returning players.

--- a/docs/grokchess/app.js
+++ b/docs/grokchess/app.js
@@ -1,0 +1,373 @@
+(function () {
+  const statusEl = document.getElementById('status');
+  const whiteClockEl = document.getElementById('white-clock');
+  const blackClockEl = document.getElementById('black-clock');
+  const newGameBtn = document.getElementById('new-game');
+  const timeControlSelect = document.getElementById('time-control');
+
+  const timeControls = {
+    '3m': { base: 3 * 60 * 1000, increment: 0 },
+    '5m+2s': { base: 5 * 60 * 1000, increment: 2000 }
+  };
+
+  const game = new Chess();
+  let board = null;
+  let stockfish = null;
+  let stockfishReady = false;
+  let isEngineThinking = false;
+  let pendingFen = null;
+
+  let currentTimeControlKey = timeControlSelect.value;
+  let clocks = {
+    w: timeControls[currentTimeControlKey].base,
+    b: timeControls[currentTimeControlKey].base
+  };
+
+  let activeColor = null;
+  let timerId = null;
+  let lastTick = null;
+  let gameStarted = false;
+  let gameEnded = false;
+  let overrideStatus = null;
+
+  function formatTime(ms) {
+    const safeMs = Math.max(0, Math.floor(ms));
+    const minutes = Math.floor(safeMs / 60000);
+    const seconds = Math.floor((safeMs % 60000) / 1000);
+    const paddedSeconds = seconds.toString().padStart(2, '0');
+    return `${minutes.toString().padStart(2, '0')}:${paddedSeconds}`;
+  }
+
+  function updateClockDisplay() {
+    whiteClockEl.textContent = formatTime(clocks.w);
+    blackClockEl.textContent = formatTime(clocks.b);
+  }
+
+  function pauseClock() {
+    if (timerId) {
+      window.clearInterval(timerId);
+      timerId = null;
+    }
+    activeColor = null;
+    lastTick = null;
+  }
+
+  function advanceClock() {
+    if (!activeColor || lastTick === null || gameEnded) {
+      return;
+    }
+
+    const now = performance.now();
+    const elapsed = now - lastTick;
+    if (elapsed <= 0) {
+      return;
+    }
+
+    lastTick = now;
+    clocks[activeColor] -= elapsed;
+
+    if (clocks[activeColor] <= 0) {
+      clocks[activeColor] = 0;
+      updateClockDisplay();
+      declareTimeout(activeColor);
+    }
+  }
+
+  function tick() {
+    advanceClock();
+    if (!gameEnded) {
+      updateClockDisplay();
+    }
+  }
+
+  function startClockFor(color) {
+    if (gameEnded) {
+      return;
+    }
+
+    activeColor = color;
+    lastTick = performance.now();
+    if (!timerId) {
+      timerId = window.setInterval(tick, 100);
+    }
+  }
+
+  function applyIncrement(color) {
+    const increment = timeControls[currentTimeControlKey].increment;
+    if (increment > 0) {
+      clocks[color] += increment;
+    }
+  }
+
+  function declareTimeout(color) {
+    if (gameEnded) {
+      return;
+    }
+
+    const loser = color === 'w' ? 'White' : 'Black';
+    const winner = color === 'w' ? 'Black' : 'White';
+    overrideStatus = `${loser} flagged. ${winner} wins on time.`;
+    gameEnded = true;
+    isEngineThinking = false;
+    pauseClock();
+    updateStatus();
+  }
+
+  function resetClocks() {
+    clocks = {
+      w: timeControls[currentTimeControlKey].base,
+      b: timeControls[currentTimeControlKey].base
+    };
+    updateClockDisplay();
+  }
+
+  function resetGame() {
+    game.reset();
+    board.start(false);
+    pendingFen = null;
+    pauseClock();
+    resetClocks();
+    activeColor = null;
+    lastTick = null;
+    gameStarted = false;
+    gameEnded = false;
+    overrideStatus = null;
+    isEngineThinking = false;
+    statusEl.textContent = 'White to move.';
+
+    if (stockfishReady && stockfish) {
+      stockfish.postMessage('ucinewgame');
+    }
+  }
+
+  function updateStatus() {
+    if (!overrideStatus) {
+      if (game.in_checkmate()) {
+        const winner = game.turn() === 'w' ? 'Black' : 'White';
+        overrideStatus = `Checkmate! ${winner} wins.`;
+        gameEnded = true;
+        isEngineThinking = false;
+        pauseClock();
+      } else if (game.in_stalemate()) {
+        overrideStatus = 'Draw by stalemate.';
+        gameEnded = true;
+        isEngineThinking = false;
+        pauseClock();
+      } else if (game.insufficient_material()) {
+        overrideStatus = 'Draw by insufficient material.';
+        gameEnded = true;
+        isEngineThinking = false;
+        pauseClock();
+      } else if (game.in_threefold_repetition()) {
+        overrideStatus = 'Draw by threefold repetition.';
+        gameEnded = true;
+        isEngineThinking = false;
+        pauseClock();
+      } else if (game.in_draw()) {
+        overrideStatus = 'Draw by fifty-move rule.';
+        gameEnded = true;
+        isEngineThinking = false;
+        pauseClock();
+      }
+    }
+
+    if (overrideStatus) {
+      statusEl.textContent = overrideStatus;
+      return;
+    }
+
+    let message = `${game.turn() === 'w' ? 'White' : 'Black'} to move.`;
+    if (game.in_check()) {
+      message += ` ${game.turn() === 'w' ? 'White' : 'Black'} is in check.`;
+    }
+    if (isEngineThinking && game.turn() === 'b') {
+      message += ' Stockfish is thinking...';
+    }
+    statusEl.textContent = message;
+  }
+
+  function requestEngineMove() {
+    if (!stockfish || gameEnded) {
+      return;
+    }
+
+    const fen = game.fen();
+    if (!stockfishReady) {
+      pendingFen = fen;
+      return;
+    }
+
+    pendingFen = null;
+    stockfish.postMessage(`position fen ${fen}`);
+    stockfish.postMessage('go depth 10');
+  }
+
+  function handlePlayerMove() {
+    advanceClock();
+    applyIncrement('w');
+    updateClockDisplay();
+
+    if (!gameStarted) {
+      gameStarted = true;
+    }
+
+    if (gameEnded || game.game_over()) {
+      updateStatus();
+      return;
+    }
+
+    isEngineThinking = true;
+    updateStatus();
+    startClockFor('b');
+    requestEngineMove();
+  }
+
+  function handleEngineMove(move) {
+    if (gameEnded) {
+      return;
+    }
+
+    advanceClock();
+    applyIncrement('b');
+    updateClockDisplay();
+    isEngineThinking = false;
+
+    if (gameEnded || game.game_over()) {
+      updateStatus();
+      return;
+    }
+
+    startClockFor('w');
+    updateStatus();
+  }
+
+  function initStockfish() {
+    try {
+      stockfish = new Worker('stockfish.js');
+    } catch (error) {
+      console.error('Stockfish worker failed to load:', error);
+      alert('Failed to load Stockfish engine. Please ensure stockfish.js and stockfish.wasm are available.');
+      overrideStatus = 'Stockfish engine failed to load.';
+      gameEnded = true;
+      isEngineThinking = false;
+      pauseClock();
+      updateStatus();
+      return;
+    }
+
+    stockfish.onmessage = (event) => {
+      const message = event.data;
+      if (typeof message !== 'string') {
+        return;
+      }
+
+      if (message === 'uciok') {
+        stockfish.postMessage('isready');
+        return;
+      }
+
+      if (message === 'readyok') {
+        stockfishReady = true;
+        if (pendingFen && !gameEnded) {
+          requestEngineMove();
+        }
+        return;
+      }
+
+      if (message.startsWith('bestmove')) {
+        const [, bestMove] = message.split(' ');
+        if (!bestMove || bestMove === '(none)') {
+          pendingFen = null;
+          isEngineThinking = false;
+          pauseClock();
+          updateStatus();
+          return;
+        }
+
+        const from = bestMove.slice(0, 2);
+        const to = bestMove.slice(2, 4);
+        const promotion = bestMove.length > 4 ? bestMove.slice(4) : 'q';
+        const move = game.move({ from, to, promotion });
+        if (move) {
+          board.position(game.fen(), true);
+          pendingFen = null;
+          handleEngineMove(move);
+          updateStatus();
+        }
+        return;
+      }
+    };
+
+    stockfish.onerror = (error) => {
+      console.error('Stockfish worker error:', error);
+      alert('Stockfish engine encountered an error. Please refresh the page.');
+      overrideStatus = 'Stockfish engine error.';
+      gameEnded = true;
+      isEngineThinking = false;
+      pauseClock();
+      updateStatus();
+    };
+
+    stockfish.postMessage('uci');
+  }
+
+  function initBoard() {
+    board = Chessboard('board', {
+      draggable: true,
+      position: 'start',
+      orientation: 'white',
+      pieceTheme: 'https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/img/chesspieces/wikipedia/{piece}.png',
+      onDragStart(source, piece) {
+        if (gameEnded || isEngineThinking) {
+          return false;
+        }
+        if (piece.startsWith('b')) {
+          return false;
+        }
+        if (game.turn() !== 'w') {
+          return false;
+        }
+        if (game.in_checkmate() || game.in_draw()) {
+          return false;
+        }
+        return true;
+      },
+      onDrop(source, target) {
+        const move = game.move({ from: source, to: target, promotion: 'q' });
+        if (!move) {
+          return 'snapback';
+        }
+        updateStatus();
+        window.requestAnimationFrame(() => {
+          board.position(game.fen(), true);
+        });
+        handlePlayerMove();
+        return undefined;
+      },
+      onSnapEnd() {
+        board.position(game.fen(), true);
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      board.resize();
+    });
+  }
+
+  newGameBtn.addEventListener('click', () => {
+    resetGame();
+  });
+
+  timeControlSelect.addEventListener('change', (event) => {
+    const value = event.target.value;
+    if (!timeControls[value]) {
+      return;
+    }
+    currentTimeControlKey = value;
+    resetGame();
+  });
+
+  initBoard();
+  initStockfish();
+  resetGame();
+})();

--- a/docs/grokchess/index.html
+++ b/docs/grokchess/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GrokChess</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/chessboard-1.0.0.min.css"
+      integrity="sha512-7mCLQtf8l0oob8cMY3AWEzhFawwzrtcquYpVqnGP0w0jarruMgBHNeyZCP83N14ldW+TmPynsln1zp+q9Z3G1w=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at top, #0f172a, #020617 55%, #000 100%);
+        color: #f8fafc;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+      }
+
+      main {
+        width: min(100%, 640px);
+        background: rgba(15, 23, 42, 0.85);
+        backdrop-filter: blur(10px);
+        border-radius: 18px;
+        padding: 1.5rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+      }
+
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(2rem, 4vw, 2.75rem);
+        letter-spacing: 0.04em;
+      }
+
+      p.description {
+        margin: 0 0 1.5rem;
+        color: rgba(226, 232, 240, 0.8);
+        line-height: 1.5;
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+      }
+
+      .controls label {
+        font-size: 0.9rem;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      select,
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.6rem 1.1rem;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      select {
+        background: rgba(30, 41, 59, 0.85);
+        color: #f8fafc;
+      }
+
+      button#new-game {
+        background: linear-gradient(135deg, #22d3ee, #3b82f6);
+        color: #0f172a;
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+      }
+
+      button#new-game:active {
+        transform: translateY(1px) scale(0.99);
+        box-shadow: none;
+      }
+
+      .board-wrapper {
+        margin: 0 auto 1.5rem;
+        width: min(90vw, 480px);
+      }
+
+      #board {
+        width: 100%;
+      }
+
+      .clocks {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .clock {
+        background: rgba(30, 41, 59, 0.85);
+        border-radius: 14px;
+        padding: 0.85rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .clock h2 {
+        margin: 0;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      .clock span {
+        font-size: clamp(1.6rem, 5vw, 2.4rem);
+        font-variant-numeric: tabular-nums;
+      }
+
+      #status {
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.9);
+        min-height: 1.4em;
+      }
+
+      @media (max-width: 600px) {
+        main {
+          padding: 1.25rem;
+        }
+
+        .controls {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        select,
+        button {
+          width: 100%;
+        }
+
+        button#new-game {
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>GrokChess</h1>
+      <p class="description">
+        Play a fast game against Stockfish right in your browser. Choose a blitz or increment clock, make a move, and GrokChess
+        will let the engine respond instantly.
+      </p>
+      <section class="controls">
+        <label for="time-control">Time control</label>
+        <select id="time-control" aria-label="Select time control">
+          <option value="3m">3m</option>
+          <option value="5m+2s">5m+2s</option>
+        </select>
+        <button id="new-game" type="button">New Game</button>
+      </section>
+      <div class="board-wrapper">
+        <div id="board" role="presentation" aria-label="Chessboard"></div>
+      </div>
+      <section class="clocks" aria-live="polite">
+        <div class="clock white">
+          <h2>White</h2>
+          <span id="white-clock">03:00</span>
+        </div>
+        <div class="clock black">
+          <h2>Black</h2>
+          <span id="black-clock">03:00</span>
+        </div>
+      </section>
+      <div id="status" role="status" aria-live="polite">White to move.</div>
+    </main>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.2/chess.min.js" integrity="sha512-7vhgkE71R+xVQ1BM8DT6vKrrfE0Yv7FpC18JNpDutZCRa14Q6gttxyPjdvVSdGInxjeRGna43EIBgzHuLlHotw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard-js/1.0.0/js/chessboard-1.0.0.min.js" integrity="sha512-MXAJZciV06P88eaJEqn3Ejj6+UeJ8V+RaH//RUW2KIiMzFxLpy0X58F3RrgPf63HgFUsVTNff7kwh28ykV59iA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a docs/grokchess subapp that serves a standalone Stockfish-powered board with time controls for GitHub Pages
- style the GrokChess page with responsive layout, clocks, and Stockfish worker error handling
- document the new GrokChess experience in the main README and apps catalog

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5d7983e6c832ba0607cd24b685138